### PR TITLE
Remove hardcoded http-proxy from Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ The ability to specify the intent succintly is the primary goal of the design an
 
 `vagrant up`
 
-Note: make sure virtualbox is installed
+Note:
+- make sure virtualbox is installed
+- The guest vm provisioning requires downloading packages from the Internet, so a http-proxy needs to be set in the vm if you are behind one else the vm setup will fail. It can be specified by setting the VAGRANT_ENV variable to a string of a space separated `<env-var>=<value>` pairs.
+`VAGRANT_ENV="http_proxy=http://my.proxy.url https_proxy=http://my.proxy.url" vagrant up`
 
 `vagrant ssh default`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,23 +1,23 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$vagrant_env = ENV['VAGRANT_ENV']
 $provision = <<SCRIPT
-## install packages
-(apt-get update -qq && apt-get install -y vim curl python-software-properties git openvswitch-switch) || exit 1
+## setup the environment file. Export the env-vars passed as args to 'vagrant up'
+echo Args passed: [[ $@ ]]
+echo 'export GOPATH=/opt/golang' > /etc/profile.d/envvar.sh
+echo 'export GOBIN=$GOPATH/bin' >> /etc/profile.d/envvar.sh
+echo 'export GOSRC=$GOPATH/src' >> /etc/profile.d/envvar.sh
+echo 'export PATH=$PATH:/usr/local/go/bin:$GOBIN' >> /etc/profile.d/envvar.sh
+if [ $# -gt 0 ]; then
+    echo "export $@" >> /etc/profile.d/envvar.sh
+fi
 
-## setup enviorment. XXX: remove http-proxy stuff
-cat > /etc/profile.d/envvar.sh <<'EOF'
-export GOPATH=/opt/golang
-export GOBIN=$GOPATH/bin
-export GOSRC=$GOPATH/src
-export PATH=$PATH:/usr/local/go/bin:$GOBIN
-export http_proxy=proxy.esl.cisco.com:8080
-export https_proxy=$http_proxy
-export HTTP_PROXY=$http_proxy
-export HTTPS_PROXY=$http_proxy
-EOF
-
+## source the environment
 . /etc/profile.d/envvar.sh || exit 1
+
+## install basic packages
+(apt-get update -qq > /dev/null && apt-get install -y vim curl python-software-properties git > /dev/null) || exit 1
 
 ## install Go 1.4
 (cd /usr/local/ && \
@@ -31,20 +31,22 @@ tar -xzf etcd-v0.4.6-linux-amd64.tar.gz && \
 cd /usr/bin && \
 ln -s /tmp/etcd-v0.4.6-linux-amd64/etcd && \
 ln -s /tmp/etcd-v0.4.6-linux-amd64/etcdctl && \
-etcd &) || exit 1
+etcd > /dev/null &) || exit 1
 
 ## install and start docker
-curl -sSL https://get.docker.com/ubuntu/ | sh
+(curl -sSL https://get.docker.com/ubuntu/ | sh > /dev/null) || exit 1
 
-## link the netplugin repo, for quick test-fix-test turnaround
+## link the netplugin repo, for a quick test-fix-test turn-around
 (mkdir -p $GOSRC/github.com/contiv && \
-sudo ln -s /vagrant $GOSRC/github.com/contiv/netplugin) || exit 1
+ln -s /vagrant $GOSRC/github.com/contiv/netplugin) || exit 1
 
-##enable ovsdb-server to listen for incoming requests
-(ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
+## install openvswitch and enable ovsdb-server to listen for incoming requests
+(apt-get install -y openvswitch-switch > /dev/null && \
+ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
 ovs-vsctl set-manager ptcp:6640) || exit 1
 
 SCRIPT
+
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 config.vm.box = "ubuntu/trusty64"
@@ -53,5 +55,8 @@ config.vm.network :private_network, ip: "10.0.2.88"
 config.vm.provider "virtualbox" do |v|
 v.customize ['modifyvm', :id, '--nicpromisc1', 'allow-all']
 end
-config.vm.provision "shell", inline: $provision
+config.vm.provision "shell" do |s|
+    s.inline = $provision
+    s.args = $vagrant_env
+end
 end


### PR DESCRIPTION
- Added a variable VAGRANT_ENV that can be set at commandline to pass
  http-proxy and other environment variables to the guest vm
- Updated the README

Fixes issue #2 
