### PR TITLE
Add system tests, that allow to ensure basic sanity of netplugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
+.PHONY: all build clean default system-test unit-test
+
+TO_BUILD := ./ ./netdcli/ 
+
 all: build unit-test system-test
 
+default: build
+
 build:
-	go get ./...
-	go install -v -installsuffix=netplugin ./...
+	./scripts/checks
+	go get -d $(TO_BUILD)
+	go install -v $(TO_BUILD)
 
 clean:
-	go clean -i -r -v ./...
+	go clean -i -v ./...
+
+demo: build
+	CONTIV_ENV=$(CONTIV_ENV) CONTIV_NODES=$(CONTIV_NODES) vagrant up
+
+clean-demo:
+	CONTIV_NODES=$(CONTIV_NODES) vagrant destroy -f
 
 unit-test: build
 	go test -v github.com/contiv/netplugin/drivers  \
@@ -14,4 +27,5 @@ unit-test: build
 		github.com/contiv/netplugin/gstate          \
 
 
-system-test:
+system-test: build
+	go test -v github.com/contiv/netplugin/systemtests

--- a/README.md
+++ b/README.md
@@ -16,40 +16,43 @@ The ability to specify the intent succinctly is the primary goal of the design a
 
 ###Building and Testing
 
-`vagrant up`
+- Build:
 
-Note:
-- Make sure VirtualBox is installed
-- The guest VM provisioning requires downloading packages from the Internet, so a http-proxy needs to be set in the VM. If you are behind one else the VM setup will fail. It can be specified by setting the VAGRANT_ENV variable to a string of a space separated `<env-var>=<value>` pairs.
-`CONTIV_ENV="http_proxy=http://my.proxy.url https_proxy=http://my.proxy.url" vagrant up`
+  `make build`
 
-`vagrant up`
+   Note:
+   - building the project requires Go1.4. Instructions to install Go can be found at: https://golang.org/doc/install
 
-`vagrant ssh netplugin-node1`
+- Run unit-tests:
 
-`sudo -s`
+  `make unit-test`
 
-`source /etc/profile.d/envvar.sh`
+- Run system-tests:
 
-`cd $GOSRC/github.com/contiv/netplugin`
-
-`make unit-test`
+  `make system-test`
 
 ###Trying it out 
 
-The netplugin produces two binaries, a netplugin daemon and a netdcli tool to interact with it.
+The netplugin produces two binaries, a netplugin daemon and a netdcli tool to interact with it. The binaries can tried out in a vagrant environment, which can be setup as follows.
+
+`make demo`
+
+Note:
+- Make sure VirtualBox is installed
+
+`vagrant ssh netplugin-node1`
 
 ####A quick example
 
 1. Start netplugin
 
-    `netplugin`
+    `sudo netplugin`
 
 2. Create two containers `myContainer1` and `myContainer2`
 
-    `docker run -it --name=myContainer1 --hostname=myContainer1 ubuntu /bin/bash`
+    `sudo docker run -it --name=myContainer1 --hostname=myContainer1 ubuntu /bin/bash`
 
-    `docker run -it --name=myContainer2 --hostname=myContainer2 ubuntu /bin/bash`
+    `sudo docker run -it --name=myContainer2 --hostname=myContainer2 ubuntu /bin/bash`
 
 3. Launch a desired configuration for the two containers
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+netplugin_synced_bindir="/netplugin-bin"
+
 provision_common = <<SCRIPT
 ## setup the environment file. Export the env-vars passed as args to 'vagrant up'
 echo Args passed: [[ $@ ]]
@@ -12,42 +14,65 @@ if [ $# -gt 0 ]; then
     echo "export $@" >> /etc/profile.d/envvar.sh
 fi
 
+## set the mounted host filesystems to be read-only
+(mount -o remount,ro,exec /vagrant) || exit 1
+if [ -e #{netplugin_synced_bindir} ]; then
+    (mount -o remount,ro,exec #{netplugin_synced_bindir}) || exit 1
+fi
+
 ## source the environment
 . /etc/profile.d/envvar.sh || exit 1
 
-## install basic packages
-(apt-get update -qq > /dev/null && apt-get install -y vim curl python-software-properties git > /dev/null) || exit 1
+### install basic packages
+#(apt-get update -qq > /dev/null && apt-get install -y vim curl python-software-properties git > /dev/null) || exit 1
+#
+### install Go 1.4
+#(cd /usr/local/ && \
+#curl -L https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz -o go1.4.linux-amd64.tar.gz && \
+#tar -xzf go1.4.linux-amd64.tar.gz) || exit 1
+#
+### install etcd
+#(cd /tmp && \
+#curl -L  https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.tar.gz -o etcd-v2.0.0-linux-amd64.tar.gz && \
+#tar -xzf etcd-v2.0.0-linux-amd64.tar.gz && \
+#cd /usr/bin && \
+#ln -s /tmp/etcd-v2.0.0-linux-amd64/etcd && \
+#ln -s /tmp/etcd-v2.0.0-linux-amd64/etcdctl) || exit 1
+#
+### install and start docker
+#(curl -sSL https://get.docker.com/ubuntu/ | sh > /dev/null) || exit 1
+#
+## pass the env-var args to docker and restart the service. This helps passing
+## stuff like http-proxy etc
+if [ $# -gt 0 ]; then
+    (echo "export $@" >> /etc/default/docker && \
+     service docker restart) || exit 1
+fi
 
-## install Go 1.4
-(cd /usr/local/ && \
-curl -L https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz -o go1.4.linux-amd64.tar.gz && \
-tar -xzf go1.4.linux-amd64.tar.gz) || exit 1
-
-## install etcd
-(cd /tmp && \
-curl -L  https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.tar.gz -o etcd-v2.0.0-linux-amd64.tar.gz && \
-tar -xzf etcd-v2.0.0-linux-amd64.tar.gz && \
-cd /usr/bin && \
-ln -s /tmp/etcd-v2.0.0-linux-amd64/etcd && \
-ln -s /tmp/etcd-v2.0.0-linux-amd64/etcdctl) || exit 1
-
-## install and start docker
-(curl -sSL https://get.docker.com/ubuntu/ | sh > /dev/null) || exit 1
-
-## link the netplugin repo, for a quick test-fix-test turn-around
+## link the netplugin repo, for read access to examples and scripts
 (mkdir -p $GOSRC/github.com/contiv && \
 ln -s /vagrant $GOSRC/github.com/contiv/netplugin) || exit 1
 
+## link the netplugin binary, so that they are in $PATH
+(cd /usr/local/bin/ && \
+ ln -s #{netplugin_synced_bindir}/netplugin && \
+ ln -s #{netplugin_synced_bindir}/netdcli) || exit 1
+
 ## install openvswitch and enable ovsdb-server to listen for incoming requests
-(apt-get install -y openvswitch-switch > /dev/null && \
-ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
+#(apt-get install -y openvswitch-switch > /dev/null) || exit 1
+(ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
 ovs-vsctl set-manager ptcp:6640) || exit 1
 SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "ubuntu/trusty64"
-    num_nodes = ( ENV['CONTIV_NODES'] || 1).to_i
+    config.vm.box = "contiv/ubuntu"
+    # XXX: need a public url
+    config.vm.box_url = "https://cisco.box.com/shared/static/27u8utb1em5730rzprhr5szeuv2p0wir.box"
+    num_nodes = 1
+    if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then
+        num_nodes = ENV['CONTIV_NODES'].to_i
+    end
     base_ip = "192.168.2."
     node_ips = num_nodes.times.collect { |n| base_ip + "#{n+10}" }
     node_names = num_nodes.times.collect { |n| "netplugin-node#{n+1}" } 
@@ -72,6 +97,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 v.customize ['modifyvm', :id, '--nictype3', 'virtio']
                 v.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
                 v.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
+            end
+            # mount host filesystems as read only since these files potentially
+            # get shared between multiple vms. Just a safety check to prevent
+            # inadvertent modifications. XXX: This doesn't seem to be working,
+            # so will remount the parition as part of provisioning later and
+            # change options
+            #node.vm.synced_folder ".", "/vagrant", mount_options: ["ro", "exec"]
+            node.vm.synced_folder ".", "/vagrant"
+            if ENV['GOBIN'] then
+                #node.vm.synced_folder ENV['GOBIN'],
+                #    netplugin_synced_bindir,
+                #    mount_options: ["ro", "exec"]
+                node.vm.synced_folder ENV['GOBIN'],
+                    netplugin_synced_bindir
             end
             node.vm.provision "shell" do |s|
                 s.inline = provision_common

--- a/scripts/checks
+++ b/scripts/checks
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+#performs basic dev and build environment checks
+
+echo "Checking GOBIN is set..."
+if [ $GOBIN == "" ]; then
+    echo "GOBIN needs to be set to proceed. Usually it's GOPATH/bin"
+    exit 1
+fi
+
+echo "Checking Go version..."
+ver=$(go version | awk '{print $3}')
+if [[ $ver < "go1.4" ]]; then
+    echo "Go version check failed. Expected 1.4 but found $ver"
+    exit 1
+fi
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -l ./)
+if [ -n "${fmtRes}" ]; then
+    echo -e "gofmt checking failed:\n${fmtRes}"
+    exit 1
+fi
+
+echo "All checks passed!!"

--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -6,6 +6,14 @@
 # allow easy experimentation on failure runs or crashes that leaves
 # system in invalid state 
 
+# Note: issuing ovs-vsctl needs 'root' permission otherwise
+# cleanup will silently fail. Make sure the caller invokes this script
+# as 'root' or 'sudo'.
+if [ "$(id -u)" != "0" ]; then
+    echo "Please run as root:$(id -u):"
+    exit 1
+fi
+
 if ! $(which etcdctl > /dev/null 2>&1)
 then
     echo "etcdctl not found !\n"
@@ -21,4 +29,5 @@ fi
 etcdctl rm -recursive /contiv > /dev/null 2>&1
 ovs-vsctl del-br contivBridge > /dev/null 2>&1
 
-# ip link delete portx
+echo "cleanup complete!"
+exit 0

--- a/systemtests/singlehost_test.go
+++ b/systemtests/singlehost_test.go
@@ -1,0 +1,126 @@
+package systemtests
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/contiv/netplugin/systemtests/utils"
+)
+
+var vagrant *utils.Vagrant
+
+func TestMain(m *testing.M) {
+	// setup a single node vagrant testbed
+	vagrant = &utils.Vagrant{}
+	log.Printf("Starting vagrant up...")
+	err := vagrant.Setup(os.Getenv("CONTIV_ENV"), 1)
+	log.Printf("Done with vagrant up...")
+	if err != nil {
+		log.Printf("Vagrant setup failed. Error: %s", err)
+		vagrant.Teardown()
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+
+	vagrant.Teardown()
+
+	os.Exit(exitCode)
+}
+
+func TestSingleHostSingleVlanFromFile(t *testing.T) {
+	node := vagrant.GetNodes()[0]
+	defer func() {
+		output, err := node.RunCommandWithOutput("sudo $GOSRC/github.com/contiv/netplugin/scripts/cleanup")
+		if err != nil {
+			t.Errorf("Failed to cleanup the left over test case state. Error: %s, Output: \n%s\n",
+				err, output)
+		}
+	}()
+
+	//start the netplugin
+	output, err := node.RunCommandWithOutput("sudo nohup netplugin -host-label host1 0<&- &>/tmp/netplugin.log &")
+	if err != nil {
+		t.Fatalf("Failed to launch netplugin. Error: %s, Output: \n%s\n",
+			err, output)
+	}
+	defer func() {
+		//XXX: remove this once netplugin is capable of handling cleanup
+		node.RunCommand("sudo pkill netplugin")
+	}()
+
+	//create a single vlan network, with two endpoints and static IPs
+	jsonCfg :=
+		`{
+        "DefaultNetType"            : "vlan",
+        "SubnetPool"                : "11.1.0.0/16",
+        "AllocSubnetLen"            : 24,
+        "Vlans"                     : "11-48",
+        "Networks"  : [ {
+            "Name"                  : "orange",
+            "Endpoints" : [
+            {
+                "Container"         : "myContainer1",
+                "Host"              : "host1"
+            },
+            {
+                "Container"         : "myContainer2",
+                "Host"              : "host1"
+            }
+            ]
+        } ]
+        }`
+
+	// replace newlines with space and " with \" for echo to consume and
+	// produce desired json config
+	jsonCfg = strings.Replace(
+		strings.Replace(jsonCfg, "\n", " ", -1),
+		"\"", "\\\"", -1)
+	output, err = node.RunCommandWithOutput(fmt.Sprintf("echo %s > /tmp/netdcli.cfg",
+		jsonCfg))
+	if err != nil {
+		t.Fatalf("Failed to create netdcli.cfg file. Error: %s, Output: \n%s\n",
+			err, output)
+	}
+
+	output, err = node.RunCommandWithOutput("netdcli -cfg /tmp/netdcli.cfg")
+	if err != nil {
+		t.Fatalf("Failed to issue netdcli. Error: %s, Output: \n%s\n",
+			err, output)
+	}
+
+	//start container 1, running a simple wait loop
+	output, err = node.RunCommandWithOutput("sudo docker run -d --name=myContainer1 ubuntu /bin/bash -c 'mkfifo foo && < foo'")
+	if err != nil {
+		t.Fatalf("Failed to launch the container. Error: %s, Output: \n%s\n",
+			err, output)
+	}
+	defer func() {
+		node.RunCommand("sudo docker kill myContainer1")
+		node.RunCommand("sudo docker rm myContainer1")
+	}()
+
+	//start container 2 with ping for container 1
+	//XXX: for now hardcode the IP. Need a better way of figuring out the allocated IP.
+	output, err = node.RunCommandWithOutput("sudo docker run --name=myContainer2 ubuntu /bin/bash -c 'ping -c5 11.1.0.1'")
+	if err != nil {
+		t.Fatalf("Failed to launch the container. Error: %s, Output: \n%s\n",
+			err, output)
+	}
+	defer func() {
+		node.RunCommand("sudo docker kill myContainer2")
+		node.RunCommand("sudo docker rm myContainer2")
+	}()
+
+	//verify that the output indicates <100% loss (some loss is expected due to
+	// timing of interface creation and starting ping)
+	if strings.Contains(string(output), ", 100% packet loss,") {
+		t.Fatalf("Ping test failed. Output: \n%s\n", output)
+	}
+}
+
+func TestSingleHostMultiVlanFrom(t *testing.T) {
+}

--- a/systemtests/utils/tempfile.go
+++ b/systemtests/utils/tempfile.go
@@ -1,0 +1,79 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/contiv/netplugin/core"
+)
+
+type TempFileCtx struct {
+	dir   string
+	files []*os.File
+}
+
+func (ctx *TempFileCtx) Create(fileContents string) (*os.File, error) {
+	if ctx.dir != "" && len(ctx.files) != 0 {
+		return nil, &core.Error{Desc: "Create context called for an already created context!"}
+	}
+
+	dir, err := ioutil.TempDir("", "netp_tests")
+	if err != nil {
+		return nil, err
+	}
+	ctx.dir = dir
+	defer func() {
+		if err != nil {
+			ctx.Destroy()
+		}
+	}()
+
+	var file *os.File = nil
+	file, err = ioutil.TempFile(dir, "netp_tests")
+	if err != nil {
+		return nil, err
+	}
+	ctx.files = append(ctx.files, file)
+
+	_, err = file.Write([]byte(fileContents))
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (ctx *TempFileCtx) AddFile(fileContents string) (*os.File, error) {
+	file, err := ioutil.TempFile(ctx.dir, "netp_tests")
+	if err != nil {
+		return nil, err
+	}
+	ctx.files = append(ctx.files, file)
+	defer func() {
+		if err != nil {
+			ctx.files = ctx.files[:len(ctx.files)-1]
+			file.Close()
+			os.Remove(file.Name())
+		}
+	}()
+
+	_, err = file.Write([]byte(fileContents))
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (ctx *TempFileCtx) Destroy() {
+	if ctx.dir == "" {
+		return
+	}
+
+	for _, file := range ctx.files {
+		file.Close()
+	}
+	os.RemoveAll(ctx.dir)
+	ctx.files = []*os.File{}
+	ctx.dir = ""
+}

--- a/systemtests/utils/vagrant.go
+++ b/systemtests/utils/vagrant.go
@@ -1,0 +1,90 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/contiv/netplugin/core"
+)
+
+type Testbed interface {
+	Setup(env string, numNodes int) error
+	Teardown()
+	GetNodes() []TestbedNode
+}
+
+type Vagrant struct {
+	expectedNodes int
+	nodes         []VagrantNode
+}
+
+func (v *Vagrant) Setup(env string, numNodes int) error {
+	vCmd := &VagrantCommand{ContivNodes: numNodes, ContivEnv: env}
+	output, err := vCmd.RunWithOutput("up")
+	if err != nil {
+		log.Printf("Vagrant up failed. Error: %s Output: \n%s\n",
+			err, output)
+		return err
+	}
+	v.expectedNodes = numNodes
+	defer func() {
+		if err != nil {
+			v.Teardown()
+		}
+	}()
+
+	output, err = vCmd.RunWithOutput("status")
+	if err != nil {
+		log.Printf("Vagrant status failed. Error: %s Output: \n%s\n",
+			err, output)
+		return err
+	}
+
+	// now some hardwork of finding the names of the running nodes from status output
+	re, err := regexp.Compile("[a-zA-Z0-9_\\- ]*running \\(virtualbox\\)")
+	if err != nil {
+		return err
+	}
+	nodeNamesBytes := re.FindAll(output, -1)
+	if nodeNamesBytes == nil {
+		err = &core.Error{Desc: fmt.Sprintf("No running nodes found in vagrant status output: \n%s\n", output)}
+		return err
+	}
+	nodeNames := []string{}
+	for _, nodeNameByte := range nodeNamesBytes {
+		nodeName := strings.Fields(string(nodeNameByte))[0]
+		nodeNames = append(nodeNames, nodeName)
+	}
+	if len(nodeNames) != numNodes {
+		err = &core.Error{Desc: fmt.Sprintf("Number of running node(s) (%d) is not equal to number of expected node(s) (%d) in vagrant status output: \n%s\n",
+			len(nodeNames), numNodes, output)}
+		return err
+	}
+
+	// got the names, now fill up the vagrant-nodes structure
+	for i, nodeName := range nodeNames {
+		log.Printf("Adding node: %q", nodeName)
+		node := VagrantNode{Name: nodeName, NodeNum: i + 1}
+		v.nodes = append(v.nodes, node)
+	}
+
+	return nil
+}
+
+func (v *Vagrant) Teardown() {
+	vCmd := &VagrantCommand{ContivNodes: v.expectedNodes}
+	output, err := vCmd.RunWithOutput("destroy", "-f")
+	if err != nil {
+		log.Printf("Vagrant destroy failed. Error: %s Output: \n%s\n",
+			err, output)
+	}
+
+	v.nodes = []VagrantNode{}
+	v.expectedNodes = 0
+}
+
+func (v *Vagrant) GetNodes() []VagrantNode {
+	return v.nodes
+}

--- a/systemtests/utils/vagrantcommand.go
+++ b/systemtests/utils/vagrantcommand.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type TestCommand interface {
+	Run(cmd string, args ...string) error
+	RunWithOutput(cmd string, args ...string) ([]byte, error)
+}
+
+type VagrantCommand struct {
+	ContivNodes int
+	ContivEnv   string
+}
+
+func (c *VagrantCommand) getCmd(cmd string, args ...string) *exec.Cmd {
+	newArgs := append([]string{cmd}, args...)
+	osCmd := exec.Command("vagrant", newArgs...)
+	osCmd.Env = os.Environ()
+	if c.ContivNodes != 0 {
+		osCmd.Env = append(osCmd.Env, fmt.Sprintf("CONTIV_NODES=%d", c.ContivNodes))
+	}
+	if c.ContivEnv != "" {
+		osCmd.Env = append(osCmd.Env, fmt.Sprintf("CONTIV_ENV=%s", c.ContivEnv))
+	}
+
+	return osCmd
+}
+
+func (c *VagrantCommand) Run(cmd string, args ...string) error {
+	return c.getCmd(cmd, args...).Run()
+}
+
+func (c *VagrantCommand) RunWithOutput(cmd string, args ...string) ([]byte, error) {
+	return c.getCmd(cmd, args...).Output()
+}

--- a/systemtests/utils/vagrantnode.go
+++ b/systemtests/utils/vagrantnode.go
@@ -1,0 +1,22 @@
+package utils
+
+type TestbedNode interface {
+	RunCommand(cmd string) (err error)
+	RunCommandWithOutput(cmd string) (output string, err error)
+}
+
+type VagrantNode struct {
+	Name    string
+	NodeNum int
+}
+
+func (n *VagrantNode) RunCommand(cmd string) error {
+	vCmd := &VagrantCommand{ContivNodes: n.NodeNum}
+	return vCmd.Run("ssh", n.Name, "-c", cmd)
+}
+
+func (n *VagrantNode) RunCommandWithOutput(cmd string) (string, error) {
+	vCmd := &VagrantCommand{ContivNodes: n.NodeNum}
+	output, err := vCmd.RunWithOutput("ssh", n.Name, "-c", cmd)
+	return string(output), err
+}


### PR DESCRIPTION
- system-tests are:
  - regular 'go test'
  - built and run in a sandboxed (vagrant) environment using 'make system-test'
- Added the first system-test to verify ping between containers in a single host,
  single vlan environment
- Integrated demo environment with Makefile. A demo environment can
  be launched using 'make demo' (instead of vagrant up)
- Changed Vagrantfile a bit to mount the host's GOBIN directory to access the built
  binaries. The Vagrant vms still have readonly access to the project directory but
  can no longer build their own binary. This streamlines the build process a bit
  and keeps all VMs in cluster synced to common set of binaries.
- Fix the Makefile to allow non-root user to do a build
- Added build time checks for go-version, go-fmt etc
- Updated VagrantFile to use a custom vagrant-box with pre-installed binaries. The box is
  right now hosted in cisco.com domain which limits it public access (need to change)
- Update Readme.md with build, test and demo instructions
