### PR TITLE
Pass Id as input to DeleteNetwork and DeleteEndpoint APIs

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -42,7 +42,7 @@ type Network interface {
 	// A network identifies a group of (addressable) endpoints that can
 	// comunicate.
 	CreateNetwork(id string) error
-	DeleteNetwork(value string) error
+	DeleteNetwork(id string) error
 	FetchNetwork(id string) (State, error)
 }
 
@@ -50,7 +50,7 @@ type Endpoint interface {
 	// An endpoint identifies an addressable entity in a network. An endpoint
 	// belongs to a single network.
 	CreateEndpoint(id string) error
-	DeleteEndpoint(value string) error
+	DeleteEndpoint(id string) error
 	FetchEndpoint(id string) (State, error)
 }
 
@@ -74,7 +74,7 @@ type NetworkDriver interface {
 	Init(config *Config, stateDriver StateDriver) error
 	Deinit()
 	CreateNetwork(id string) error
-	DeleteNetwork(value string) error
+	DeleteNetwork(id string) error
 }
 
 type EndpointDriver interface {
@@ -83,7 +83,7 @@ type EndpointDriver interface {
 	Init(config *Config, stateDriver StateDriver) error
 	Deinit()
 	CreateEndpoint(id string) error
-	DeleteEndpoint(value string) error
+	DeleteEndpoint(id string) error
 	MakeEndpointAddress() (*Address, error)
 }
 

--- a/drivers/ovsdriver_test.go
+++ b/drivers/ovsdriver_test.go
@@ -296,16 +296,7 @@ func TestOvsDriverDeleteEndpoint(t *testing.T) {
 		t.Fatalf("endpoint Creation failed. Error: %s", err)
 	}
 
-	cfgEp := &OvsCfgEndpointState{}
-	err = driver.stateDriver.ReadState(id, cfgEp, nil)
-	if err != nil {
-		t.Fatalf("error '%s' reading state for id %s \n", err, id)
-	}
-	value, err := cfgEp.Marshal()
-	if err != nil {
-		t.Fatalf("error marshaling config '%s' \n", err)
-	}
-	err = driver.DeleteEndpoint(value)
+	err = driver.DeleteEndpoint(id)
 	if err != nil {
 		t.Fatalf("endpoint Deletion failed. Error: %s", err)
 	}
@@ -332,16 +323,7 @@ func TestOvsDriverDeleteEndpointiWithIntfName(t *testing.T) {
 		t.Fatalf("endpoint Creation failed. Error: %s", err)
 	}
 
-	cfgEp := &OvsCfgEndpointState{}
-	err = driver.stateDriver.ReadState(id, cfgEp, nil)
-	if err != nil {
-		t.Fatalf("error '%s' reading state for id %s \n", err, id)
-	}
-	value, err := cfgEp.Marshal()
-	if err != nil {
-		t.Fatalf("error marshaling config '%s' \n", err)
-	}
-	err = driver.DeleteEndpoint(value)
+	err = driver.DeleteEndpoint(id)
 	if err != nil {
 		t.Fatalf("endpoint Deletion failed. Error: %s", err)
 	}
@@ -400,17 +382,7 @@ func TestOvsDriverDeleteVxlanPeer(t *testing.T) {
 		t.Fatalf("endpoint Creation failed. Error: %s", err)
 	}
 
-	cfgEp := &OvsCfgEndpointState{}
-	err = driver.stateDriver.ReadState(deleteVxlanEpId, cfgEp, nil)
-	if err != nil {
-		t.Fatalf("error '%s' reading state for id %s \n", err,
-			deleteVxlanEpId)
-	}
-	value, err := cfgEp.Marshal()
-	if err != nil {
-		t.Fatalf("error marshaling config '%s' \n", err)
-	}
-	err = driver.DeleteEndpoint(value)
+	err = driver.DeleteEndpoint(deleteVxlanEpId)
 	if err != nil {
 		t.Fatalf("endpoint Deletion failed. Error: %s", err)
 	}

--- a/drivers/ovsendpointstate.go
+++ b/drivers/ovsendpointstate.go
@@ -127,12 +127,3 @@ func (s *OvsOperEndpointState) Clear() error {
 	key := fmt.Sprintf(EP_OPER_PATH, s.Id)
 	return s.StateDriver.ClearState(key)
 }
-
-func (s *OvsOperEndpointState) Unmarshal(value string) error {
-	return json.Unmarshal([]byte(value), s)
-}
-
-func (s *OvsOperEndpointState) Marshal() (string, error) {
-	bytes, err := json.Marshal(s)
-	return string(bytes[:]), err
-}

--- a/drivers/ovsnetworkstate.go
+++ b/drivers/ovsnetworkstate.go
@@ -67,12 +67,3 @@ func (s *OvsCfgNetworkState) Clear() error {
 	key := fmt.Sprintf(NW_CFG_PATH, s.Id)
 	return s.StateDriver.ClearState(key)
 }
-
-func (s *OvsCfgNetworkState) Unmarshal(value string) error {
-	return json.Unmarshal([]byte(value), s)
-}
-
-func (s *OvsCfgNetworkState) Marshal() (string, error) {
-	bytes, err := json.Marshal(s)
-	return string(bytes[:]), err
-}

--- a/netd.go
+++ b/netd.go
@@ -185,7 +185,7 @@ func processNetEvent(netPlugin *plugin.NetPlugin, key, preValue string,
 
 	operStr := ""
 	if preValue != "" {
-		err = netPlugin.DeleteNetwork(preValue)
+		err = netPlugin.DeleteNetwork(netId)
 		operStr = "delete"
 	} else {
 		err = netPlugin.CreateNetwork(netId)
@@ -307,7 +307,7 @@ func processEpEvent(netPlugin *plugin.NetPlugin, crt *crt.Crt,
 
 	operStr := ""
 	if preValue != "" {
-		err = netPlugin.DeleteEndpoint(preValue)
+		err = netPlugin.DeleteEndpoint(epId)
 		operStr = "delete"
 	} else {
 		err = netPlugin.CreateEndpoint(epId)

--- a/plugin/netplugin.go
+++ b/plugin/netplugin.go
@@ -173,8 +173,8 @@ func (p *NetPlugin) CreateNetwork(id string) error {
 	return p.NetworkDriver.CreateNetwork(id)
 }
 
-func (p *NetPlugin) DeleteNetwork(value string) error {
-	return p.NetworkDriver.DeleteNetwork(value)
+func (p *NetPlugin) DeleteNetwork(id string) error {
+	return p.NetworkDriver.DeleteNetwork(id)
 }
 
 func (p *NetPlugin) FetchNetwork(id string) (core.State, error) {
@@ -185,8 +185,8 @@ func (p *NetPlugin) CreateEndpoint(id string) error {
 	return p.EndpointDriver.CreateEndpoint(id)
 }
 
-func (p *NetPlugin) DeleteEndpoint(value string) error {
-	return p.EndpointDriver.DeleteEndpoint(value)
+func (p *NetPlugin) DeleteEndpoint(id string) error {
+	return p.EndpointDriver.DeleteEndpoint(id)
 }
 
 func (p *NetPlugin) FetchEndpoint(id string) (core.State, error) {


### PR DESCRIPTION
This commit reverts the DeleteNetwork and DeleteEndpoint APIs back to taking network
and endpoint Ids as input instead of an opaque value strings. This follows the netplugin
design to keep driver specific state handling inside the driver than the Netplugin Core.
