### PR TITLE
Read Api cleanup

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -98,7 +98,6 @@ type StateDriver interface {
 	Deinit()
 	Write(key string, value []byte) error
 	Read(key string) ([]byte, error)
-	ReadRecursive(baseKey string) ([]string, error)
 	WriteState(key string, value State,
 		marshal func(interface{}) ([]byte, error)) error
 	ReadState(key string, value State,

--- a/drivers/etcdstatedriver.go
+++ b/drivers/etcdstatedriver.go
@@ -60,21 +60,6 @@ func (d *EtcdStateDriver) Write(key string, value []byte) error {
 	return err
 }
 
-func (d *EtcdStateDriver) ReadRecursive(baseKey string) ([]string, error) {
-	resp, err := d.Client.Get(baseKey, true, false)
-	if err != nil {
-		return []string{}, err
-	}
-
-	keys := make([]string, len(resp.Node.Nodes))
-
-	for idx, respNode := range resp.Node.Nodes {
-		keys[idx] = respNode.Key
-	}
-
-	return keys, err
-}
-
 func (d *EtcdStateDriver) Read(key string) ([]byte, error) {
 	resp, err := d.Client.Get(key, false, false)
 	if err != nil {
@@ -82,6 +67,21 @@ func (d *EtcdStateDriver) Read(key string) ([]byte, error) {
 	}
 
 	return []byte(resp.Node.Value), err
+}
+
+func ReadAll(d core.StateDriver, baseKey string) ([][]byte, error) {
+	etcdDriver := d.(*EtcdStateDriver)
+	resp, err := etcdDriver.Client.Get(baseKey, true, false)
+	if err != nil {
+		return nil, err
+	}
+
+	values := [][]byte{}
+	for _, node := range resp.Node.Nodes {
+		values = append(values, []byte(node.Value))
+	}
+
+	return values, nil
 }
 
 func (d *EtcdStateDriver) ClearState(key string) error {

--- a/drivers/ovsdriver_test.go
+++ b/drivers/ovsdriver_test.go
@@ -66,10 +66,6 @@ func (d *testOvsStateDriver) Read(key string) ([]byte, error) {
 	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
-func (d *testOvsStateDriver) ReadRecursive(baseKey string) ([]string, error) {
-	return []string{}, &core.Error{Desc: "Shouldn't be called!"}
-}
-
 func (d *testOvsStateDriver) ClearState(key string) error {
 	return nil
 }

--- a/drivers/ovsendpointstate_test.go
+++ b/drivers/ovsendpointstate_test.go
@@ -48,10 +48,6 @@ func (d *testEpStateDriver) Read(key string) ([]byte, error) {
 	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
-func (d *testEpStateDriver) ReadRecursive(baseKey string) ([]string, error) {
-	return []string{}, &core.Error{Desc: "Shouldn't be called!"}
-}
-
 func (d *testEpStateDriver) validateKey(key string) error {
 	if key != epCfgKey && key != epOperKey {
 		return &core.Error{Desc: fmt.Sprintf("Unexpected key. recvd: %s expected: %s or %s ",

--- a/drivers/ovsnetworkstate.go
+++ b/drivers/ovsnetworkstate.go
@@ -63,6 +63,23 @@ func (s *OvsCfgNetworkState) Read(id string) error {
 	return s.StateDriver.ReadState(key, s, json.Unmarshal)
 }
 
+func ReadAllOvsCfgNetworks(d core.StateDriver) ([]*OvsCfgNetworkState, error) {
+	values := []*OvsCfgNetworkState{}
+	byteValues, err := ReadAll(d, NW_CFG_PATH_PREFIX)
+	if err != nil {
+		return nil, err
+	}
+	for _, byteValue := range byteValues {
+		value := &OvsCfgNetworkState{StateDriver: d}
+		err = json.Unmarshal(byteValue, value)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
 func (s *OvsCfgNetworkState) Clear() error {
 	key := fmt.Sprintf(NW_CFG_PATH, s.Id)
 	return s.StateDriver.ClearState(key)

--- a/drivers/ovsnetworkstate_test.go
+++ b/drivers/ovsnetworkstate_test.go
@@ -47,10 +47,6 @@ func (d *testNwStateDriver) Read(key string) ([]byte, error) {
 	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
-func (d *testNwStateDriver) ReadRecursive(baseKey string) ([]string, error) {
-	return []string{}, &core.Error{Desc: "Shouldn't be called!"}
-}
-
 func (d *testNwStateDriver) validateKey(key string) error {
 	if key != nwCfgKey {
 		return &core.Error{Desc: fmt.Sprintf("Unexpected key. "+

--- a/netd.go
+++ b/netd.go
@@ -59,8 +59,8 @@ func createDeleteVtep(netPlugin *plugin.NetPlugin, netId, preValue string,
 		return err
 	}
 
-	gOper := &gstate.Oper{}
-	err = gOper.Read(netPlugin.StateDriver, cfgNet.Tenant)
+	gOper := &gstate.Oper{StateDriver: netPlugin.StateDriver}
+	err = gOper.Read(cfgNet.Tenant)
 	if err != nil {
 		return err
 	}
@@ -102,63 +102,64 @@ func skipHost(vtepIp, homingHost, myHostLabel string) bool {
 
 func processCurrentState(netPlugin *plugin.NetPlugin, crt *crt.Crt,
 	opts cliOpts) error {
-	keys, err := netPlugin.StateDriver.ReadRecursive(gstate.CFG_GLOBAL_PREFIX)
+	gCfgs, err := gstate.ReadAllGlobalCfg(netPlugin.StateDriver)
 	if err != nil {
 		return err
 	}
-	for idx, key := range keys {
-		log.Printf("read global key[%d] %s, populating state \n", idx, key)
-		processGlobalEvent(netPlugin, key, "")
+	for idx, gCfg := range gCfgs {
+		log.Printf("read global key[%d] %s, populating state \n", idx, gCfg.Tenant)
+		processGlobalEvent(netPlugin, gCfg.Tenant, "")
 	}
 
-	keys, err = netPlugin.StateDriver.ReadRecursive(drivers.NW_CFG_PATH_PREFIX)
+	var netCfgs []*drivers.OvsCfgNetworkState
+	netCfgs, err = drivers.ReadAllOvsCfgNetworks(netPlugin.StateDriver)
 	if err != nil {
 		return err
 	}
-	for idx, key := range keys {
-		log.Printf("read net key[%d] %s, populating state \n", idx, key)
-		processNetEvent(netPlugin, key, "", opts)
+	for idx, netCfg := range netCfgs {
+		log.Printf("read net key[%d] %s, populating state \n", idx, netCfg.Id)
+		processNetEvent(netPlugin, netCfg.Id, "", opts)
 	}
 
-	keys, err = netPlugin.StateDriver.ReadRecursive(drivers.EP_CFG_PATH_PREFIX)
+	var epCfgs []*drivers.OvsCfgEndpointState
+	epCfgs, err = drivers.ReadAllOvsCfgEndpoints(netPlugin.StateDriver)
 	if err != nil {
 		return err
 	}
-	for idx, key := range keys {
-		log.Printf("read ep key[%d] %s, populating state \n", idx, key)
-		processEpEvent(netPlugin, crt, key, "", opts)
+	for idx, epCfg := range epCfgs {
+		log.Printf("read ep key[%d] %s, populating state \n", idx, epCfg.Id)
+		processEpEvent(netPlugin, crt, epCfg.Id, "", opts)
 	}
 
 	return nil
 }
 
-func processGlobalEvent(netPlugin *plugin.NetPlugin, key, preValue string) (err error) {
+func processGlobalEvent(netPlugin *plugin.NetPlugin, tenant, preValue string) (err error) {
 	var gOper *gstate.Oper
 
-	tenant := strings.TrimPrefix(key, gstate.CFG_GLOBAL_PREFIX)
 	if preValue != "" {
-		gOper := &gstate.Oper{}
-		err = gOper.Read(netPlugin.StateDriver, tenant)
+		gOper := &gstate.Oper{StateDriver: netPlugin.StateDriver}
+		err = gOper.Read(tenant)
 		if err != nil {
 			// already deleted
 			log.Printf("Tenant '%s' already deleted \n", tenant)
 			err = nil
 		} else {
-			err = gOper.Clear(netPlugin.StateDriver)
+			err = gOper.Clear()
 		}
 
 		return
 	}
 
-	gOper = &gstate.Oper{}
-	err = gOper.Read(netPlugin.StateDriver, tenant)
+	gOper = &gstate.Oper{StateDriver: netPlugin.StateDriver}
+	err = gOper.Read(tenant)
 	if err == nil {
 		// already created
 		return
 	}
 
-	gCfg := &gstate.Cfg{}
-	err = gCfg.Read(netPlugin.StateDriver, tenant)
+	gCfg := &gstate.Cfg{StateDriver: netPlugin.StateDriver}
+	err = gCfg.Read(tenant)
 	if err != nil {
 		log.Printf("Error '%s' reading tenant %s \n", err, tenant)
 		return
@@ -170,7 +171,7 @@ func processGlobalEvent(netPlugin *plugin.NetPlugin, key, preValue string) (err 
 		return
 	}
 
-	err = gOper.Update(netPlugin.StateDriver)
+	err = gOper.Write()
 	if err != nil {
 		log.Printf("error '%s' updating goper state %v \n", err, gOper)
 	}
@@ -178,10 +179,8 @@ func processGlobalEvent(netPlugin *plugin.NetPlugin, key, preValue string) (err 
 	return
 }
 
-func processNetEvent(netPlugin *plugin.NetPlugin, key, preValue string,
+func processNetEvent(netPlugin *plugin.NetPlugin, netId, preValue string,
 	opts cliOpts) (err error) {
-
-	netId := strings.TrimPrefix(key, drivers.NW_CFG_PATH_PREFIX)
 
 	operStr := ""
 	if preValue != "" {
@@ -203,19 +202,19 @@ func processNetEvent(netPlugin *plugin.NetPlugin, key, preValue string,
 	return
 }
 
-func getEndpointContainerContext(state *core.StateDriver, epId string) (
+func getEndpointContainerContext(state core.StateDriver, epId string) (
 	*crtclient.ContainerEpContext, error) {
 	var epCtx crtclient.ContainerEpContext
 	var err error
 
-	epCfg := &drivers.OvsCfgEndpointState{StateDriver: *state}
+	epCfg := &drivers.OvsCfgEndpointState{StateDriver: state}
 	err = epCfg.Read(epId)
 	if err != nil {
 		return &epCtx, nil
 	}
 	epCtx.NewContName = epCfg.ContName
 
-	cfgNet := &drivers.OvsCfgNetworkState{StateDriver: *state}
+	cfgNet := &drivers.OvsCfgNetworkState{StateDriver: state}
 	err = cfgNet.Read(epCfg.NetId)
 	if err != nil {
 		return &epCtx, err
@@ -223,7 +222,7 @@ func getEndpointContainerContext(state *core.StateDriver, epId string) (
 	epCtx.DefaultGw = cfgNet.DefaultGw
 	epCtx.SubnetLen = cfgNet.SubnetLen
 
-	operEp := &drivers.OvsOperEndpointState{StateDriver: *state}
+	operEp := &drivers.OvsOperEndpointState{StateDriver: state}
 	err = operEp.Read(epId)
 	if err != nil {
 		return &epCtx, nil
@@ -235,12 +234,12 @@ func getEndpointContainerContext(state *core.StateDriver, epId string) (
 	return &epCtx, err
 }
 
-func getContainerEpContextByContName(state *core.StateDriver, contName string) (
+func getContainerEpContextByContName(state core.StateDriver, contName string) (
 	epCtxs []crtclient.ContainerEpContext, err error) {
 	var epCtx *crtclient.ContainerEpContext
 
 	contName = strings.TrimPrefix(contName, "/")
-	epCfgs, err := drivers.ReadAllEpsCfg(state)
+	epCfgs, err := drivers.ReadAllOvsCfgEndpoints(state)
 	if err != nil {
 		return
 	}
@@ -266,8 +265,7 @@ func getContainerEpContextByContName(state *core.StateDriver, contName string) (
 }
 
 func processEpEvent(netPlugin *plugin.NetPlugin, crt *crt.Crt,
-	key string, preValue string, opts cliOpts) (err error) {
-	epId := strings.TrimPrefix(key, drivers.EP_CFG_PATH_PREFIX)
+	epId string, preValue string, opts cliOpts) (err error) {
 
 	homingHost := ""
 	vtepIp := ""
@@ -298,7 +296,7 @@ func processEpEvent(netPlugin *plugin.NetPlugin, crt *crt.Crt,
 
 	// read the context before to be compared with what changed after
 	contEpContext, err := getEndpointContainerContext(
-		&netPlugin.StateDriver, epId)
+		netPlugin.StateDriver, epId)
 	if err != nil {
 		log.Printf("Failed to obtain the container context for ep '%s' \n",
 			epId)
@@ -336,7 +334,7 @@ func processEpEvent(netPlugin *plugin.NetPlugin, crt *crt.Crt,
 	if preValue == "" && contEpContext.NewContName != "" {
 		// re-read post ep updated state
 		newContEpContext, err1 := getEndpointContainerContext(
-			&netPlugin.StateDriver, epId)
+			netPlugin.StateDriver, epId)
 		if err1 != nil {
 			log.Printf("Failed to obtain the container context for ep '%s' \n", epId)
 			return
@@ -377,13 +375,16 @@ func handleEtcdEvents(netPlugin *plugin.NetPlugin, crt *crt.Crt,
 		log.Printf("Received event for key: %s", node.Key)
 		switch key := node.Key; {
 		case strings.HasPrefix(key, gstate.CFG_GLOBAL_PREFIX):
-			processGlobalEvent(netPlugin, key, preValue)
+			tenant := strings.TrimPrefix(key, gstate.CFG_GLOBAL_PREFIX)
+			processGlobalEvent(netPlugin, tenant, preValue)
 
 		case strings.HasPrefix(key, drivers.NW_CFG_PATH_PREFIX):
-			processNetEvent(netPlugin, key, preValue, opts)
+			netId := strings.TrimPrefix(key, drivers.NW_CFG_PATH_PREFIX)
+			processNetEvent(netPlugin, netId, preValue, opts)
 
 		case strings.HasPrefix(key, drivers.EP_CFG_PATH_PREFIX):
-			processEpEvent(netPlugin, crt, key, preValue, opts)
+			epId := strings.TrimPrefix(key, drivers.EP_CFG_PATH_PREFIX)
+			processEpEvent(netPlugin, crt, epId, preValue, opts)
 		}
 	}
 
@@ -402,7 +403,7 @@ func handleContainerStart(netPlugin *plugin.NetPlugin, crt *crt.Crt,
 		return err
 	}
 
-	epContexts, err = getContainerEpContextByContName(&netPlugin.StateDriver,
+	epContexts, err = getContainerEpContextByContName(netPlugin.StateDriver,
 		contName)
 	if err != nil {
 		log.Printf("Error '%s' getting Ep context for container %s \n",

--- a/netdcli/netdcli.go
+++ b/netdcli/netdcli.go
@@ -400,14 +400,14 @@ func executeOpts(opts *cliOpts) error {
 			state = nwCfg
 		}
 	case CLI_CONSTRUCT_GLOBAL:
-		var gcfg gstate.Cfg
+		gcfg := gstate.Cfg{StateDriver: etcdDriver}
 		if opts.oper.Get() == CLI_OPER_GET {
-			err = gcfg.Read(etcdDriver, opts.tenant)
+			err = gcfg.Read(opts.tenant)
 			log.Printf("State: %v \n", gcfg)
 		} else if opts.oper.Get() == CLI_OPER_DELETE {
 			gcfg.Version = gstate.VersionBeta1
 			gcfg.Tenant = opts.tenant
-			err = gcfg.Clear(etcdDriver)
+			err = gcfg.Clear()
 			if err != nil {
 				log.Fatalf("Failed to delete %s. Error: %s", opts.construct.Get(), err)
 			}
@@ -420,7 +420,7 @@ func executeOpts(opts *cliOpts) error {
 			gcfg.Auto.Vlans = opts.vlans
 			gcfg.Auto.Vxlans = opts.vxlans
 			gcfg.Auto.AllocSubnetLen = opts.allocSubnetLen
-			err = gcfg.Update(etcdDriver)
+			err = gcfg.Write()
 		}
 		if err != nil {
 			log.Fatalf("error '%s' \n", err)

--- a/netmaster/netmaster_test.go
+++ b/netmaster/netmaster_test.go
@@ -62,10 +62,6 @@ func (d *fakeStateDriver) Read(key string) ([]byte, error) {
 	return []byte{}, errors.New("key not found!")
 }
 
-func (d *fakeStateDriver) ReadRecursive(baseKey string) ([]string, error) {
-	return []string{}, errors.New("Shouldn't be called!")
-}
-
 func (d *fakeStateDriver) ClearState(key string) error {
 	if _, ok := testState[key]; ok {
 		delete(testState, key)

--- a/netmaster/networkstate_test.go
+++ b/netmaster/networkstate_test.go
@@ -51,10 +51,6 @@ func (d *testNwStateDriver) Read(key string) ([]byte, error) {
 	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
-func (d *testNwStateDriver) ReadRecursive(baseKey string) ([]string, error) {
-	return []string{}, &core.Error{Desc: "Shouldn't be called!"}
-}
-
 func (d *testNwStateDriver) validateKey(key string) error {
 	if key != nwCfgKey {
 		return &core.Error{Desc: fmt.Sprintf("Unexpected key. recvd: %s "+


### PR DESCRIPTION
This commit brings in following broad changes:
    - Remove ReadRecursive() API in core, since it assumes a structure to the state organization,
      which might not be true for all key-value data stores
    - Added ReadAll() api instead to EtcdStateDriver for now, that returns the values
      (bytes arrays) contained under a base-key
    - Added specific ReadAll<>() functions to the various states that need us to read this today.
      Again, haven't added it to core.State since it might not be supported for all kinds of states.
      But we can revisit this, if more use cases arise.
    - Modified gstate.Cfg and gstate.Oper to adhere to the core.State API
    - With the above changes there are some possible enhancements/optimizations
      that can be made to prevent extra read since we already have read the state.
      But that can be addressed as separate commits.
