### PR TITLE
Mount and use host's go binary in the vagrant vm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all build clean default system-test unit-test
 
 TO_BUILD := ./ ./netdcli/ 
+HOST_GOBIN := `which go | xargs dirname`
+HOST_GOROOT := `go env GOROOT`
 
 all: build unit-test system-test
 
@@ -14,14 +16,16 @@ build:
 clean:
 	go clean -i -v ./...
 
+# setting CONTIV_NODES=<number> while calling 'make demo' can be used to bring
+# up a cluster of <number> nodes. By default <number> = 1
 demo: build
-	CONTIV_ENV="$(CONTIV_ENV)" CONTIV_NODES=$(CONTIV_NODES) vagrant up
+	CONTIV_HOST_GOBIN=$(HOST_GOBIN) CONTIV_HOST_GOROOT=$(HOST_GOROOT) vagrant up
 
 clean-demo:
-	CONTIV_NODES=$(CONTIV_NODES) vagrant destroy -f
+	vagrant destroy -f
 
 unit-test: build
-	./scripts/unittests -vagrant
+	CONTIV_HOST_GOBIN=$(HOST_GOBIN) CONTIV_HOST_GOROOT=$(HOST_GOROOT) ./scripts/unittests -vagrant
 
 system-test: build
 	go test -v -run "sanity" github.com/contiv/netplugin/systemtests/singlehost 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@
 # vi: set ft=ruby :
 
 netplugin_synced_gopath="/opt/golang"
+host_gobin_path="/opt/go/bin"
+host_goroot_path="/opt/go/root"
 
 provision_common = <<SCRIPT
 ## setup the environment file. Export the env-vars passed as args to 'vagrant up'
@@ -9,13 +11,21 @@ echo Args passed: [[ $@ ]]
 echo 'export GOPATH=#{netplugin_synced_gopath}' > /etc/profile.d/envvar.sh
 echo 'export GOBIN=$GOPATH/bin' >> /etc/profile.d/envvar.sh
 echo 'export GOSRC=$GOPATH/src' >> /etc/profile.d/envvar.sh
-echo 'export PATH=$PATH:/usr/local/go/bin:$GOBIN' >> /etc/profile.d/envvar.sh
+echo 'export GOROOT=#{host_goroot_path}' >> /etc/profile.d/envvar.sh
+echo 'export PATH=$PATH:#{host_gobin_path}:$GOBIN' >> /etc/profile.d/envvar.sh
 if [ $# -gt 0 ]; then
     echo "export $@" >> /etc/profile.d/envvar.sh
 fi
 
-## set the mounted host filesystems to be read-only
+## set the mounted host filesystems to be read-only.Just a safety check
+## to prevent inadvertent modifications from vm.
 (mount -o remount,ro,exec /vagrant) || exit 1
+if [ -e #{host_gobin_path} ]; then
+    (mount -o remount,ro,exec #{host_gobin_path}) || exit 1
+fi
+if [ -e #{host_goroot_path} ]; then
+    (mount -o remount,ro,exec #{host_goroot_path}) || exit 1
+fi
 if [ -e #{netplugin_synced_gopath} ]; then
     (mount -o remount,ro,exec #{netplugin_synced_gopath}) || exit 1
 fi
@@ -86,15 +96,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 v.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
                 v.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
             end
-            # mount host filesystems as read only since these files potentially
-            # get shared between multiple vms. Just a safety check to prevent
-            # inadvertent modifications. XXX: This doesn't seem to be working,
-            # so will remount the parition as part of provisioning later and
-            # change options
-            #node.vm.synced_folder ".", "/vagrant", mount_options: ["ro", "exec"]
-            #node.vm.synced_folder ENV['GOPATH'], netplugin_synced_gopath, mount_options: ["ro", "exec"]
+            # mount the host directories
             node.vm.synced_folder ".", "/vagrant"
             node.vm.synced_folder ENV['GOPATH'], netplugin_synced_gopath
+            if ENV['CONTIV_HOST_GOBIN'] != nil
+                node.vm.synced_folder ENV['CONTIV_HOST_GOBIN'], host_gobin_path
+            end
+            if ENV['CONTIV_HOST_GOROOT'] != nil
+                node.vm.synced_folder ENV['CONTIV_HOST_GOROOT'], host_goroot_path
+            end
             node.vm.provision "shell" do |s|
                 s.inline = provision_common
                 s.args = ENV['CONTIV_ENV']

--- a/scripts/checks
+++ b/scripts/checks
@@ -4,9 +4,9 @@
 
 echo "Checking Go version..."
 ver=$(go version | awk '{print $3}')
-expVer="go1.4"
-if [[ ${ver} != ${expVer} ]]; then
-    echo "Go version check failed. Expected ${expVer} but found ${ver}"
+minVer="go1.4"
+if [[ ${ver} < ${minVer} ]]; then
+    echo "Go version check failed. Expected >=${minVer} but found ${ver}"
     exit 1
 fi
 

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -31,7 +31,7 @@ done
 
 # running on host
 if ${run_in_vagrant}; then
-    (CONTIV_NODES=1 CONTIV_ENV=$CONTIV_ENV vagrant up)
+    (CONTIV_NODES=1 vagrant up)
     ret=$?
     if [ ${ret} -ne 0 ]; then
         (CONTIV_NODES=1 vagrant destroy -f)


### PR DESCRIPTION
This allows to relax the strict version check for host go version.

Fixes issue #30 
