### PR TITLE
add support for container-host late bindings for scheduler integration

### DIFF
--- a/examples/late_bindings/multiple_vxlan_nets.json
+++ b/examples/late_bindings/multiple_vxlan_nets.json
@@ -1,0 +1,36 @@
+
+{
+    "Hosts" : [{
+        "Name"                  : "host1",
+        "VtepIp"                : "192.168.2.10"
+    },
+    {
+        "Name"                  : "host2",
+        "VtepIp"                : "192.168.2.11"
+    }],
+    "Tenants" : [ {
+        "Name"                      : "tenant-one",
+        "DefaultNetType"            : "vxlan",
+        "SubnetPool"                : "11.1.0.0/16",
+        "AllocSubnetLen"            : 24,
+        "Vxlans"                    : "10001-20000",
+        "Networks"  : [ {
+            "Name"                  : "orange",
+            "Endpoints" : [ {
+                "Container"         : "myContainer1"
+            },
+            {
+                "Container"         : "myContainer3"
+            } ]
+        },
+        {
+            "Name"                  : "purple",
+            "Endpoints" : [ {
+                "Container"         : "myContainer2"
+            },
+            {
+                "Container"         : "myContainer4"
+            } ]
+        } ]
+    } ]
+}

--- a/examples/late_bindings/multiple_vxlan_nets_host_bindings.json
+++ b/examples/late_bindings/multiple_vxlan_nets_host_bindings.json
@@ -1,0 +1,17 @@
+
+[{
+    "Container"         : "myContainer1",
+    "Host"              : "host1"
+},
+{
+    "Container"         : "myContainer2",
+    "Host"              : "host1"
+},
+{
+    "Container"         : "myContainer3",
+    "Host"              : "host2"
+},
+{
+    "Container"         : "myContainer4",
+    "Host"              : "host2"
+}]

--- a/netdcli/netdcli.go
+++ b/netdcli/netdcli.go
@@ -104,30 +104,31 @@ func (c *Construct) Get() interface{} {
 }
 
 type cliOpts struct {
-	help           bool
-	cfgDesired     bool
-	cfgAdditions   bool
-	cfgDeletions   bool
-	oper           Operation
-	construct      Construct
-	etcdUrl        string
-	tenant         string
-	netId          string
-	pktTag         string
-	pktTagType     string
-	subnetCidr     string
-	ipAddr         string
-	contName       string
-	subnetIp       string
-	subnetLen      uint
-	allocSubnetLen uint
-	defaultGw      string
-	idStr          string
-	vlans          string
-	vxlans         string
-	homingHost     string
-	vtepIp         string
-	intfName       string
+	help            bool
+	cfgDesired      bool
+	cfgAdditions    bool
+	cfgDeletions    bool
+	cfgHostBindings bool
+	oper            Operation
+	construct       Construct
+	etcdUrl         string
+	tenant          string
+	netId           string
+	pktTag          string
+	pktTagType      string
+	subnetCidr      string
+	ipAddr          string
+	contName        string
+	subnetIp        string
+	subnetLen       uint
+	allocSubnetLen  uint
+	defaultGw       string
+	idStr           string
+	vlans           string
+	vxlans          string
+	homingHost      string
+	vtepIp          string
+	intfName        string
 }
 
 var opts cliOpts
@@ -141,6 +142,10 @@ func init() {
 	flagSet.Var(&opts.construct,
 		"construct",
 		"Construct to operate on i.e network or endpoint")
+	flagSet.BoolVar(&opts.cfgHostBindings,
+		"host-bindings-cfg",
+		false,
+		"Json file describing container to host bindings")
 	flagSet.BoolVar(&opts.cfgAdditions,
 		"add-cfg",
 		false,
@@ -461,7 +466,7 @@ func main() {
 	}
 	opts.idStr = flagSet.Arg(0)
 
-	if opts.cfgDesired || opts.cfgDeletions || opts.cfgAdditions {
+	if opts.cfgDesired || opts.cfgDeletions || opts.cfgAdditions || opts.cfgHostBindings {
 		err = executeJsonCfg(&opts)
 	} else {
 		err = executeOpts(&opts)

--- a/systemtests/utils/utils.go
+++ b/systemtests/utils/utils.go
@@ -89,6 +89,10 @@ func ApplyDesiredConfig(t *testing.T, jsonCfg string, node VagrantNode) {
 	applyConfig(t, "cfg", jsonCfg, node)
 }
 
+func ApplyHostBindingsConfig(t *testing.T, jsonCfg string, node VagrantNode) {
+	applyConfig(t, "host-bindings-cfg", jsonCfg, node)
+}
+
 func ConfigSetupCommon(t *testing.T, jsonCfg string, nodes []VagrantNode) {
 	startNetPlugin(t, nodes)
 


### PR DESCRIPTION
This allows for a provision where schedulers can chose to bind a container/pod to a host independently and specify the host bindings after the network intent is consumed by the netmaster. i.e. the current json is broken into two parts:
- specification of the network intent (which containers belong to who)
- bindings between hosts and containers (this is typically a scheduling decision, as workloads are assigned hosts and moved around)

Comments welcome!
