### PR TITLE
Correctly derive vlans required for vxlan networks

### DIFF
--- a/examples/two_hosts_multiple_tenants_mix_vlan_vxlan.json
+++ b/examples/two_hosts_multiple_tenants_mix_vlan_vxlan.json
@@ -33,7 +33,7 @@
         "DefaultNetType"            : "vxlan",
         "SubnetPool"                : "11.1.0.0/16",
         "AllocSubnetLen"            : 24,
-        "Vxlans"                    : "10001-14000",
+        "Vxlans"                    : "10001-12000",
         "Networks"  : [{
             "Name"                  : "purple",
             "Endpoints" : [{


### PR DESCRIPTION
- take the allocated global vlans and vlans for vxlan networks for all
  tenants into consideration for deriving the vlans required for
  next vxlan network.
- also added a cli to dump the resource config state

Fixes #39 
