### PR TITLE
Introduce Dockerfile for netplugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+##
+#Copyright 2014 Cisco Systems Inc. All rights reserved.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+##
+
+##
+# Container image for netplugin
+#
+# Run netplugin:
+# docker run --net=host <image> -host-label=<label>
+##
+
+FROM golang:1.4
+MAINTAINER Madhav Puri <mapuri@cisco.com> (@mapuri)
+
+ENV GOPATH /go/
+
+COPY ./ /go/src/github.com/contiv/netplugin/
+
+WORKDIR /go/src/github.com/contiv/netplugin/
+
+RUN make build
+
+ENTRYPOINT ["netplugin"]
+CMD ["--help"]


### PR DESCRIPTION
This PR adds a Dockerfile for building a docker image for netplugin. The netplugin can now be started in a container as follows:

```
cd <netplugin-ws>
docker build -t <netplugin-image-tag> .
docker run --net=host <netplugin-image-tag> --host-label=<label> ...
```

addresses issue #52 

Note that this PR doesn't yet adds options for taking config-file etc for netplugin. I am planning to handle that separately as we identify more non-default configuration options.
