### PR TITLE
Introduce WatchAll() as a StateDriver method

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -81,6 +81,11 @@ type EndpointDriver interface {
 	MakeEndpointAddress() (*Address, error)
 }
 
+type WatchState struct {
+	Curr State
+	Prev State
+}
+
 type StateDriver interface {
 	// A state driver provides mechanism for reading/writing state for networks,
 	// endpoints and meta-data managed by the core. The state is assumed to be
@@ -90,15 +95,22 @@ type StateDriver interface {
 	Driver
 	Init(config *Config) error
 	Deinit()
+
+	// XXX: the following raw versions of Read, Write, ReadAll and WatchAll
+	// can perhaps be removed from core API, as no one uses them directly.
 	Write(key string, value []byte) error
 	Read(key string) ([]byte, error)
 	ReadAll(baseKey string) ([][]byte, error)
+	WatchAll(baseKey string, rsps chan [2][]byte) error
+
 	WriteState(key string, value State,
 		marshal func(interface{}) ([]byte, error)) error
 	ReadState(key string, value State,
 		unmarshal func([]byte, interface{}) error) error
 	ReadAllState(baseKey string, stateType State,
 		unmarshal func([]byte, interface{}) error) ([]State, error)
+	WatchAllState(baseKey string, stateType State,
+		unmarshal func([]byte, interface{}) error, rsps chan WatchState) error
 	ClearState(key string) error
 }
 

--- a/core/state.go
+++ b/core/state.go
@@ -7,6 +7,11 @@ type State interface {
 	Clear() error
 }
 
+type WatchableState interface {
+	State
+	WatchAll(rsps chan WatchState) error
+}
+
 // CommonState defines the fields common to all core.State implementations.
 // This struct shall be embedded as anonymous field in all structs that
 // implement core.State

--- a/drivers/etcdstatedriver.go
+++ b/drivers/etcdstatedriver.go
@@ -17,6 +17,7 @@ package drivers
 
 import (
 	"fmt"
+	"log"
 	"reflect"
 
 	"github.com/contiv/go-etcd/etcd"
@@ -25,6 +26,10 @@ import (
 
 // implements the StateDriver interface for an etcd based distributed
 // key-value store used to store config and runtime state for the netplugin.
+
+const (
+	RECURSIVE = true
+)
 
 type EtcdStateDriverConfig struct {
 	Etcd struct {
@@ -82,6 +87,54 @@ func (d *EtcdStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	}
 
 	return values, nil
+}
+
+func (d *EtcdStateDriver) channelEtcdEvents(etcdRsps chan *etcd.Response,
+	rsps chan [2][]byte, retErr chan error) {
+	for {
+		// block on change notifications
+		etcdRsp := <-etcdRsps
+
+		node := etcdRsp.Node
+		log.Printf("Received event for key: %s", node.Key)
+
+		// XXX: The logic below assumes that the node returned is always a node
+		// of interest. Eg: If we set a watch on /a/b/c, then we are mostly
+		// interested in changes in that directory i.e. changes to /a/b/c/d1..d2
+		// This works for now as the constructs like network and endpoints that
+		// need to be watched are organized as above. Need to revisit when
+		// this assumption changes.
+		rsp := [2][]byte{nil, nil}
+		if etcdRsp.Node.Value != "" {
+			rsp[0] = []byte(etcdRsp.Node.Value)
+		}
+		if etcdRsp.PrevNode != nil && etcdRsp.PrevNode.Value != "" {
+			rsp[1] = []byte(etcdRsp.PrevNode.Value)
+		}
+
+		//channel the translated response
+		rsps <- rsp
+	}
+
+	// shall never come here
+	retErr <- nil
+}
+
+func (d *EtcdStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	etcdRsps := make(chan *etcd.Response)
+	stop := make(chan bool, 1)
+	recvErr := make(chan error, 1)
+
+	go d.channelEtcdEvents(etcdRsps, rsps, recvErr)
+
+	_, err := d.Client.Watch(baseKey, 0, RECURSIVE, etcdRsps, stop)
+	if err != nil && err != etcd.ErrWatchStoppedByUser {
+		log.Printf("etcd watch failed. Error: %s", err)
+		return err
+	}
+
+	err = <-recvErr
+	return err
 }
 
 func (d *EtcdStateDriver) ClearState(key string) error {
@@ -144,6 +197,67 @@ func ReadAllStateCommon(d core.StateDriver, baseKey string, sType core.State,
 func (d *EtcdStateDriver) ReadAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return ReadAllStateCommon(d, baseKey, sType, unmarshal)
+}
+
+func (d *EtcdStateDriver) channelStateEvents(sType core.State,
+	unmarshal func([]byte, interface{}) error,
+	byteRsps chan [2][]byte, rsps chan core.WatchState, retErr chan error) {
+	for {
+		// block on change notifications
+		byteRsp := <-byteRsps
+
+		rsp := core.WatchState{nil, nil}
+		for i := 0; i < 2; i++ {
+			if byteRsp[i] == nil {
+				continue
+			}
+			stateType := reflect.TypeOf(sType)
+			value := reflect.New(stateType)
+			err := unmarshal(byteRsp[i], value.Interface())
+			if err != nil {
+				retErr <- err
+				return
+			}
+			if !value.Elem().Elem().FieldByName("CommonState").IsValid() {
+				panic(fmt.Sprintf("The state structure %v is missing core.CommonState",
+					stateType))
+				retErr <- &core.Error{Desc: fmt.Sprintf("The state structure %v is missing core.CommonState",
+					stateType)}
+				return
+			}
+			//the following works as every core.State is expected to embed core.CommonState struct
+			value.Elem().Elem().FieldByName("CommonState").FieldByName("StateDriver").Set(reflect.ValueOf(d))
+			switch i {
+			case 0:
+				rsp.Curr = value.Elem().Interface().(core.State)
+			case 1:
+				rsp.Prev = value.Elem().Interface().(core.State)
+			}
+		}
+
+		//channel the translated response
+		rsps <- rsp
+	}
+
+	// shall never come here
+	retErr <- nil
+}
+
+func (d *EtcdStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	byteRsps := make(chan [2][]byte, 1)
+	recvErr := make(chan error, 1)
+
+	go d.channelStateEvents(sType, unmarshal, byteRsps, rsps, recvErr)
+
+	err := d.WatchAll(baseKey, byteRsps)
+	if err != nil {
+		return err
+	}
+
+	err = <-recvErr
+	return err
+
 }
 
 func (d *EtcdStateDriver) WriteState(key string, value core.State,

--- a/drivers/fakestatedriver.go
+++ b/drivers/fakestatedriver.go
@@ -54,6 +54,10 @@ func (d *FakeStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return values, nil
 }
 
+func (d *FakeStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *FakeStateDriver) ClearState(key string) error {
 	if _, ok := d.TestState[key]; ok {
 		delete(d.TestState, key)
@@ -79,6 +83,11 @@ func (d *FakeStateDriver) ReadState(key string, value core.State,
 func (d *FakeStateDriver) ReadAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return ReadAllStateCommon(d, baseKey, sType, unmarshal)
+}
+
+func (d *FakeStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *FakeStateDriver) WriteState(key string, value core.State,

--- a/drivers/ovsdriver_test.go
+++ b/drivers/ovsdriver_test.go
@@ -70,6 +70,10 @@ func (d *testOvsStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testOvsStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testOvsStateDriver) ClearState(key string) error {
 	return nil
 }
@@ -175,6 +179,11 @@ func (d *testOvsStateDriver) ReadState(key string, value core.State,
 func (d *testOvsStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "shouldn't be called!"}
+}
+
+func (d *testOvsStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testOvsStateDriver) WriteState(key string, value core.State,

--- a/drivers/ovsendpointstate.go
+++ b/drivers/ovsendpointstate.go
@@ -50,6 +50,11 @@ func (s *OvsCfgEndpointState) ReadAll() ([]core.State, error) {
 	return s.StateDriver.ReadAllState(EP_CFG_PATH_PREFIX, s, json.Unmarshal)
 }
 
+func (s *OvsCfgEndpointState) WatchAll(rsps chan core.WatchState) error {
+	return s.StateDriver.WatchAllState(EP_CFG_PATH_PREFIX, s, json.Unmarshal,
+		rsps)
+}
+
 func (s *OvsCfgEndpointState) Clear() error {
 	key := fmt.Sprintf(EP_CFG_PATH, s.Id)
 	return s.StateDriver.ClearState(key)

--- a/drivers/ovsendpointstate_test.go
+++ b/drivers/ovsendpointstate_test.go
@@ -52,6 +52,10 @@ func (d *testEpStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testEpStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testEpStateDriver) validateKey(key string) error {
 	if key != epCfgKey && key != epOperKey {
 		return &core.Error{Desc: fmt.Sprintf("Unexpected key. recvd: %s expected: %s or %s ",
@@ -73,6 +77,11 @@ func (d *testEpStateDriver) ReadState(key string, value core.State,
 func (d *testEpStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testEpStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testEpStateDriver) WriteState(key string, value core.State,

--- a/drivers/ovsnetworkstate.go
+++ b/drivers/ovsnetworkstate.go
@@ -66,6 +66,11 @@ func (s *OvsCfgNetworkState) ReadAll() ([]core.State, error) {
 	return s.StateDriver.ReadAllState(NW_CFG_PATH_PREFIX, s, json.Unmarshal)
 }
 
+func (s *OvsCfgNetworkState) WatchAll(rsps chan core.WatchState) error {
+	return s.StateDriver.WatchAllState(NW_CFG_PATH_PREFIX, s, json.Unmarshal,
+		rsps)
+}
+
 func (s *OvsCfgNetworkState) Clear() error {
 	key := fmt.Sprintf(NW_CFG_PATH, s.Id)
 	return s.StateDriver.ClearState(key)

--- a/drivers/ovsnetworkstate_test.go
+++ b/drivers/ovsnetworkstate_test.go
@@ -51,6 +51,10 @@ func (d *testNwStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testNwStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testNwStateDriver) validateKey(key string) error {
 	if key != nwCfgKey {
 		return &core.Error{Desc: fmt.Sprintf("Unexpected key. "+
@@ -72,6 +76,11 @@ func (d *testNwStateDriver) ReadState(key string, value core.State,
 func (d *testNwStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testNwStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testNwStateDriver) WriteState(key string, value core.State,

--- a/netmaster/hoststate_test.go
+++ b/netmaster/hoststate_test.go
@@ -52,6 +52,10 @@ func (d *testHostStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testHostStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testHostStateDriver) validateKey(key string) error {
 	if key != hostCfgKey {
 		return errors.New(fmt.Sprintf("Unexpected key. recvd: %s "+
@@ -73,6 +77,11 @@ func (d *testHostStateDriver) ReadState(key string, value core.State,
 func (d *testHostStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testHostStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testHostStateDriver) WriteState(key string, value core.State,

--- a/netmaster/networkstate_test.go
+++ b/netmaster/networkstate_test.go
@@ -51,6 +51,10 @@ func (d *testNwStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testNwStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testNwStateDriver) validateKey(key string) error {
 	if key != nwCfgKey {
 		return &core.Error{Desc: fmt.Sprintf("Unexpected key. recvd: %s "+
@@ -72,6 +76,11 @@ func (d *testNwStateDriver) ReadState(key string, value core.State,
 func (d *testNwStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testNwStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testNwStateDriver) WriteState(key string, value core.State,

--- a/plugin/netplugin.go
+++ b/plugin/netplugin.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/drivers"
@@ -61,6 +62,7 @@ type PluginConfig struct {
 }
 
 type NetPlugin struct {
+	sync.Mutex
 	ConfigFile     string
 	NetworkDriver  core.NetworkDriver
 	EndpointDriver core.EndpointDriver

--- a/resources/subnetresource_test.go
+++ b/resources/subnetresource_test.go
@@ -269,6 +269,10 @@ func (d *testSubnetRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testSubnetRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testSubnetRsrcStateDriver) validate(key string, state core.State,
 	op subnetRsrcValidateOp) error {
 	strs := strings.Split(key, "/")
@@ -308,6 +312,11 @@ func (d *testSubnetRsrcStateDriver) ReadState(key string, value core.State,
 func (d *testSubnetRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testSubnetRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testSubnetRsrcStateDriver) WriteState(key string, value core.State,

--- a/resources/vlanresource_test.go
+++ b/resources/vlanresource_test.go
@@ -246,6 +246,10 @@ func (d *testVlanRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testVlanRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testVlanRsrcStateDriver) validate(key string, state core.State,
 	op vlanRsrcValidateOp) error {
 	strs := strings.Split(key, "/")
@@ -285,6 +289,11 @@ func (d *testVlanRsrcStateDriver) ReadState(key string, value core.State,
 func (d *testVlanRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testVlanRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testVlanRsrcStateDriver) WriteState(key string, value core.State,

--- a/resources/vxlanresource_test.go
+++ b/resources/vxlanresource_test.go
@@ -290,6 +290,10 @@ func (d *testVxlanRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
 }
 
+func (d *testVxlanRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+	return &core.Error{Desc: "not supported"}
+}
+
 func (d *testVxlanRsrcStateDriver) validate(key string, state core.State,
 	op vxlanRsrcValidateOp) error {
 	strs := strings.Split(key, "/")
@@ -329,6 +333,11 @@ func (d *testVxlanRsrcStateDriver) ReadState(key string, value core.State,
 func (d *testVxlanRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, &core.Error{Desc: "Shouldn't be called!"}
+}
+
+func (d *testVxlanRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
+	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
+	return &core.Error{Desc: "not supported"}
 }
 
 func (d *testVxlanRsrcStateDriver) WriteState(key string, value core.State,


### PR DESCRIPTION
- WatchAll() allows monitoring changes to a state pointed by the key.
  It returns a channel of a current and previous state pair, with previous
  state being nil in case of create and current state being nil in case of
  delete. If both are not nil then it indicates a modify.
- Implemented WatchAll() for EtcdStateDriver
- Integrated the watch in netd.go to monitor changes on network and endpoint
  configurations and generate respective create/delete events. This let's us
  formalize state based communication between netmaster and netplugin as now
  the different StateDriver just need to implement WatchAll on underlying data
  store to be able to provide state change events.
- Right now we just support create and delete events, but the ability to get
  both current and previous state as part of Watch allows us to generate
  modify events, if needed in future.

fixes #51 