### PR TITLE
Initial support for docker based management function using powerstrip and libnetwork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: all build clean default system-test unit-test
 
-TO_BUILD := ./ ./netdcli/ ./mgmtfn/k8contivnet/
+TO_BUILD := ./ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/pslibnet/
 HOST_GOBIN := `which go | xargs dirname`
 HOST_GOROOT := `go env GOROOT`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,7 +64,7 @@ SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "contiv/ubuntu"
+    config.vm.box = "contiv/ubuntu/v2"
     # XXX: need a public url
     config.vm.box_url = "https://cisco.box.com/shared/static/27u8utb1em5730rzprhr5szeuv2p0wir.box"
     num_nodes = 1

--- a/docs/powerstrip.md
+++ b/docs/powerstrip.md
@@ -1,0 +1,61 @@
+#Powerstrip based integration
+
+Netplugin can now be used with docker using powerstrip.
+
+##Trying it out
+- Start the demo vm
+```
+make demo
+ssh netplugin-node1
+sudo -s
+source /etc/profile.d/envvar.sh
+```
+- Start netplugin
+```
+netplugin -host-label=host1 -native-integration &> /tmp/netplugin.log &
+```
+- Start the powerstrip adapter
+```
+cd $GOSRC/github.com/contiv/netplugin
+docker build -t netplugin/pslibnet mgmtfn/pslibnet
+docker run -d --name pslibnet --expose 80 netplugin/pslibnet --host-label=host1 --etcd-url=http://192.168.2.10:2379
+```
+- Start powerstrip
+```
+cd
+mkdir demo
+cat > demo/adapters.yml <<EOF
+version: 1
+endpoints:
+  "POST /*/containers/create":
+    pre: [pslibnet]
+    post: [pslibnet]
+  "POST /*/containers/*/start":
+    pre: [pslibnet]
+    post: [pslibnet]
+  "POST /*/containers/*/stop":
+    pre: [pslibnet]
+  "POST /*/containers/*/delete":
+    pre: [pslibnet]
+adapters:
+  pslibnet: http://pslibnet/adapter/
+EOF
+docker run -d --name powerstrip -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/demo/adapters.yml:/etc/powerstrip/adapters.yml --link pslibnet:pslibnet -p 2375:2375 clusterhq/powerstrip:v0.0.1
+```
+- Create a network
+```
+cd $GOSRC/github.com/contiv/netplugin
+netdcli -cfg examples/late_bindings/powerstrip_demo_vlan_nets.json
+```
+- Run container1
+```
+ssh netplugin-node1
+DOCKER_HOST=localhost:2375 docker run -it --name=myContainer1 --label netid=orange --label tenantid=tenant-one ubuntu bash
+ip addr show
+```
+- Run container2
+```
+ssh netplugin-node1
+DOCKER_HOST=localhost:2375 docker run -it --name=myContainer2 --label netid=orange --label tenantid=tenant-one ubuntu bash
+ping <ip-address of container myContainer1>
+```

--- a/examples/late_bindings/powerstrip_demo_vlan_nets.json
+++ b/examples/late_bindings/powerstrip_demo_vlan_nets.json
@@ -1,0 +1,25 @@
+{
+    "Hosts" : [{
+        "Name"                      : "host1",
+        "Intf"                      : "eth2"
+    },
+    {
+        "Name"                      : "host2",
+        "Intf"                      : "eth2"
+    }],
+    "Tenants" : [ {
+        "Name"                      : "tenant-one",
+        "DefaultNetType"            : "vlan",
+        "SubnetPool"                : "11.1.0.0/16",
+        "AllocSubnetLen"            : 24,
+        "Vlans"                     : "11-28",
+        "Networks"  : [
+        {
+            "Name"                  : "orange"
+        },
+        {
+            "Name"                  : "purple"
+        }
+        ]
+    } ]
+}

--- a/mgmtfn/pslibnet/Dockerfile
+++ b/mgmtfn/pslibnet/Dockerfile
@@ -1,0 +1,42 @@
+##
+#Copyright 2014 Cisco Systems Inc. All rights reserved.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+##
+
+##
+# Container image for the powerstrip adapter of netplugin
+#
+# Run pslibnet:
+# docker run <image> -host-label=<label> --etcd-url=<etcd-client-url, eg. http://1.2.3.4:2379>
+##
+
+FROM golang:1.4
+MAINTAINER Madhav Puri <mapuri@cisco.com> (@mapuri)
+
+ENV GOPATH /go/
+
+COPY ./ /go/src/github.com/contiv/pslibnet
+
+WORKDIR /go/src/github.com/contiv/pslibnet
+
+RUN go get -d .
+RUN go install -v .
+
+# build and install netdcli as pslibnet needs it.
+# Note: the following build requires the netdcli code downloaded
+# by above build
+WORKDIR /go/src/github.com/contiv/netplugin
+RUN go install ./netdcli/
+
+ENTRYPOINT ["pslibnet"]
+CMD ["--help"]

--- a/mgmtfn/pslibnet/libnetdriver.go
+++ b/mgmtfn/pslibnet/libnetdriver.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/contiv/netplugin/netmaster"
+	"github.com/mapuri/libnetwork/driverapi"
+)
+
+// XXX: Replace with the actual structure once it is defined by libnetwork
+type DriverConfig struct {
+	tenantId string
+	netId    string
+	contId   string
+}
+
+// implement the driverapi
+// XXX: extract this into separate package so that it can be used once
+// libnetwork is integrated with docker and powerstrip is not needed
+type LibNetDriver struct {
+	endpoints map[driverapi.UUID]DriverConfig
+}
+
+func (d *LibNetDriver) Config(config interface{}) error {
+	d.endpoints = make(map[driverapi.UUID]DriverConfig)
+	return nil
+}
+
+func (d *LibNetDriver) CreateNetwork(nid driverapi.UUID, config interface{}) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func (d *LibNetDriver) DeleteNetwork(nid driverapi.UUID) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func invokeNetdcli(dc DriverConfig, isAdd bool) error {
+	EpCfg := &netmaster.Config{
+		Tenants: []netmaster.ConfigTenant{
+			netmaster.ConfigTenant{
+				Name: dc.tenantId,
+				Networks: []netmaster.ConfigNetwork{
+					netmaster.ConfigNetwork{
+						Name: dc.netId,
+						Endpoints: []netmaster.ConfigEp{
+							netmaster.ConfigEp{
+								AttachUUID: dc.contId,
+								Container:  dc.contId,
+								// XXX: host-label needs to come from config
+								Host: gcliOpts.hostLabel,
+							},
+						},
+					},
+				},
+			}}}
+	cfgArg := "-add-cfg"
+	if !isAdd {
+		cfgArg = "-del-cfg"
+	}
+	cmd := exec.Command("netdcli", "-etcd-url", gcliOpts.etcdUrl, cfgArg, "-")
+	config, err := json.Marshal(EpCfg)
+	if err != nil {
+		return err
+	}
+	cmd.Stdin = bytes.NewReader(config)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("command failed. Error: %s, Output: %s", err, out)
+	}
+	return nil
+}
+
+func (d *LibNetDriver) CreateEndpoint(nid, eid driverapi.UUID, key string,
+	config interface{}) (*driverapi.SandboxInfo, error) {
+	dc, ok := config.(DriverConfig)
+	if !ok {
+		return nil, fmt.Errorf("Invalid config passed")
+	}
+
+	err := invokeNetdcli(dc, true)
+	if err != nil {
+		return nil, err
+	}
+
+	//update driver state
+	d.endpoints[eid] = dc
+	// XXX: todo start populating sandbox info. Right now Netplugin takes care
+	// of managing interfaces in network namespace. And it's not yet clear how
+	// much control libnetwork gives to the driver by passing the sboxkey.
+	return nil, nil
+}
+
+func (d *LibNetDriver) DeleteEndpoint(nid, eid driverapi.UUID) error {
+	dc, ok := d.endpoints[eid]
+	if !ok {
+		return fmt.Errorf("endpoint info not found for epid: %q, netid: %q",
+			eid, nid)
+	}
+	err := invokeNetdcli(dc, false)
+	if err != nil {
+		return err
+	}
+
+	//update driver state
+	delete(d.endpoints, eid)
+	return nil
+}

--- a/mgmtfn/pslibnet/main.go
+++ b/mgmtfn/pslibnet/main.go
@@ -1,0 +1,118 @@
+package main
+
+// the powerstrip libnetwork daemon handles powerstrip events and invokes
+// netmaster (netdcli) to program the network.
+
+// libnetwork is still under development but it defines a driverapi and
+// provides some utilities that can be used to start integrating NetPlugin.
+//
+// This implementation is capable of doing the following:
+// - It registers for powerstrip's post-hook for container-start to trigger
+//   CreateEndpoint() API. This is required right now to guarantee that container
+//   namespace is created and can be used. In real world, this will be mimicked
+//   by libnetwork before container is actually started but just after it's
+//   network namespace is ready. We register for pre-create request and
+//   response as well to find out the netid (passed as container label) and map
+//   it to it's id
+// - It registers for powerstrip's pre-hook for container-stop to trigger
+//   DeleEndpoint() API. This is close to how it shall happen in real-world as
+//   well.
+// - Right now there is no trigger in powerstrip to for invoking the
+//   CreateNetwork() and DeleteNetwork() APIs, so they are triggered explicitly
+//   outside this daemon.
+//
+// Following is the interpretation/mapping of driverapi arguments to underlying
+// netplugin API:
+// Config(config interface{})
+// - This API initializes driver's internal state.
+//   + config - right now we don't interpret this arg.
+// CreateNetwork(nid UUID, config interface{}) error
+// - This API is not implemented and not invoked from this daemon.
+//   + nid - libnetwork's derived uuid for a network.
+// DeleteNetwork(nid UUID) error
+// - This API is not implemented and not invoked from this daemon.
+//   + nid - libnetwork's derived uuid for a network.
+// CreateEndpoint(nid, eid UUID, key string, config interface{}) (*SandboxInfo, error)
+// - This API shall be invoked on the post-start hook.
+//   + nid - libnetwork's derived uuid for a network.
+//   + eid - libnetwork's derived uuid for a endpoint
+//   + key - this is ths path of the file in container's network namespace. For
+//   now we don't need this as we are hooking ourselves in post start, so
+//   CreateEndpoint() in Netplugin shall take care of AttachEndpoint(). In real
+//   world, we 'may' want to use this to identify container's network namespace
+//   and program it.
+//   + config - this is expected to contain info like net-id, tenant-id,
+//   container-id that are need to invoke netmaster.
+//   + SandboxInfo - This is network namespace state, that driver shall
+//   mainatin per container.
+// DeleteEndpoint(nid, eid UUID) error
+// - This API shall be invoked on the post-stop hook.
+//   + nid - libnetwork's derived uuid for a network.
+//   + eid - libnetwork's derived uuid for a endpoint
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+)
+
+type cliOpts struct {
+	hostLabel string
+	etcdUrl   string
+}
+
+var gcliOpts cliOpts
+
+func main() {
+	var flagSet *flag.FlagSet
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	gHostLabel, err := os.Hostname()
+	if err != nil {
+		log.Printf("Failed to fetch hostname. Error: %s", err)
+		os.Exit(1)
+	}
+
+	flagSet = flag.NewFlagSet("pslibnet", flag.ExitOnError)
+	flagSet.StringVar(&gcliOpts.hostLabel,
+		"host-label",
+		gHostLabel,
+		"label used to identify endpoints homed for this host, default is host name")
+	flagSet.StringVar(&gcliOpts.etcdUrl,
+		"etcd-url",
+		"http://127.0.0.1:4001",
+		"Etcd cluster url")
+
+	err = flagSet.Parse(os.Args[1:])
+	if err != nil {
+		log.Fatalf("Failed to parse command. Error: %s", err)
+	}
+
+	if flagSet.NFlag() < 1 {
+		log.Printf("host-label not specified, using default (%s)", gcliOpts.hostLabel)
+	}
+
+	driver := &LibNetDriver{}
+	err = driver.Config(nil)
+	if err != nil {
+		log.Printf("libnet driver init failed. Error: %s", err)
+		os.Exit(1)
+	}
+	adapter := &PwrStrpAdptr{}
+	err = adapter.Init(driver)
+	if err != nil {
+		log.Printf("powerstrip adaper init failed. Error: %s", err)
+		os.Exit(1)
+	}
+
+	// start serving the API requests
+	http.HandleFunc("/adapter/", adapter.CallHook)
+	err = http.ListenAndServe(":80", nil)
+	if err != nil {
+		log.Printf("Error listening for http requests. Error: %s", err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}

--- a/mgmtfn/pslibnet/powerstriphooks.go
+++ b/mgmtfn/pslibnet/powerstriphooks.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/mapuri/libnetwork/driverapi"
+)
+
+type ClientRequest struct {
+	Method  string `json:"Method"`
+	Request string `json:"Request"`
+	Body    string `json:"Body"`
+}
+
+type ServerResponse struct {
+	ContentType string `json:"ContentType"`
+	Body        string `json:"Body"`
+	Code        int    `json:"Code"`
+}
+
+type PowerStripRequest struct {
+	PowerstripProtocolVersion int            `json:"PowerstripProtocolVersion"`
+	Type                      string         `json:"Type"`
+	ClientRequest             ClientRequest  `json:"ClientRequest"`
+	ServerResponse            ServerResponse `json:"ServerResponse"`
+}
+
+type PowerStripResponse struct {
+	PowerstripProtocolVersion int            `json:"PowerstripProtocolVersion"`
+	ModifiedClientRequest     ClientRequest  `json:"ModifiedClientRequest"`
+	ModifiedServerResponse    ServerResponse `json:"ModifiedServerResponse"`
+}
+
+type ContainerNet struct {
+	tenantId string
+	netId    string
+}
+
+type handlerFunc func(*PowerStripRequest) (*PowerStripResponse, error)
+
+//structure to keep state based on requests and responses as seen by the adapter
+type PwrStrpAdptr struct {
+	driver driverapi.Driver
+	//track the network that a container belongs to
+	containerNets map[string][]ContainerNet
+	// tracks the network received in last container create. Set on
+	// getting contianer pre-create and cleared on getting post-create.
+	outstandingNet ContainerNet
+	// tracks the container-id/name received in last container start. Set on
+	// getting contianer pre-start and cleared on getting post-start.
+	outstandingContId string
+	// track name to Id mapping when a conatiner name was specified
+	nameIdMap map[string]string
+	// hooks implememted by this adapter
+	powerstripHooks map[string]handlerFunc
+}
+
+func makeClientRequest(req *PowerStripRequest) *PowerStripResponse {
+	return &PowerStripResponse{
+		PowerstripProtocolVersion: req.PowerstripProtocolVersion,
+		ModifiedClientRequest: ClientRequest{
+			Method:  req.ClientRequest.Method,
+			Request: req.ClientRequest.Request,
+			Body:    req.ClientRequest.Body,
+		},
+	}
+}
+
+func makeServerResponse(req *PowerStripRequest) *PowerStripResponse {
+	return &PowerStripResponse{
+		PowerstripProtocolVersion: req.PowerstripProtocolVersion,
+		ModifiedServerResponse: ServerResponse{
+			ContentType: req.ServerResponse.ContentType,
+			Body:        req.ServerResponse.Body,
+			Code:        req.ServerResponse.Code,
+		},
+	}
+}
+
+func (adptr *PwrStrpAdptr) Init(d driverapi.Driver) error {
+	adptr.driver = d
+	adptr.containerNets = make(map[string][]ContainerNet)
+	adptr.outstandingNet = ContainerNet{"", ""}
+	adptr.outstandingContId = ""
+	adptr.nameIdMap = make(map[string]string)
+	adptr.powerstripHooks = map[string]handlerFunc{
+		"pre-hook:create":  adptr.handlePreCreate,
+		"post-hook:create": adptr.handlePostCreate,
+		"pre-hook:start":   adptr.handlePreStart,
+		"post-hook:start":  adptr.handlePostStart,
+		"pre-hook:stop":    adptr.handlePreStop,
+		"pre-hook:delete":  adptr.handlePreDelete,
+	}
+
+	return nil
+}
+
+func extractHookStr(req *PowerStripRequest) string {
+
+	str := ""
+	if req.ClientRequest.Method == "DELETE" {
+		str = fmt.Sprintf("%s:delete", req.Type)
+	} else {
+		str = fmt.Sprintf("%s:%s", req.Type,
+			req.ClientRequest.Request[strings.LastIndex(req.ClientRequest.Request, "/")+1:])
+	}
+	//remove any query parameters
+	if strings.Index(str, "?") != -1 {
+		str = string(str[:strings.Index(str, "?")])
+	}
+
+	return str
+}
+
+// handle the calls from powerstrip adapter. In absence of formal plugin hooks,
+// the netplugin hooks into post-create and pre-delete requests from power strip.
+func (adptr *PwrStrpAdptr) CallHook(w http.ResponseWriter, r *http.Request) {
+	log.Printf("handling new request")
+	req := &PowerStripRequest{}
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(req)
+	if err != nil {
+		log.Printf("failed to parse powerstrip request. Error: %s", err)
+		return
+	}
+	log.Printf("powerstrip request: %+v", req)
+
+	fn, ok := adptr.powerstripHooks[extractHookStr(req)]
+	if !ok {
+		log.Printf("No handler for hook %q, request: %+v", extractHookStr(req), req)
+		http.Error(w, "Unhandled request", http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := fn(req)
+	if err != nil {
+		log.Printf("failed to handle request. Error: %s", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	encoder := json.NewEncoder(w)
+	err = encoder.Encode(resp)
+	if err != nil {
+		log.Printf("failed to write response. Error: %s", err)
+	}
+	return
+}
+
+// Check that container is created with a 'netid' label. This helps us map the
+// container to a network. This label could be put by one of docker clients (cli,
+// compose etc)
+func (adptr *PwrStrpAdptr) handlePreCreate(req *PowerStripRequest) (*PowerStripResponse, error) {
+	//structure of interesting fields in the create request
+	type DockerCreateRequest struct {
+		Labels map[string]string `json:"Labels"`
+	}
+
+	dockerReq := &DockerCreateRequest{}
+	err := json.Unmarshal([]byte(req.ClientRequest.Body), dockerReq)
+	if err != nil {
+		return nil, err
+	}
+
+	if netId, ok := dockerReq.Labels["netid"]; !ok || netId == "" {
+		return nil, fmt.Errorf("Container doesn't contain a valid 'netid' label. Labels: %+v Body: %q",
+			dockerReq, req.ClientRequest.Body)
+	} else if tenantId, ok := dockerReq.Labels["tenantid"]; !ok || tenantId == "" {
+		return nil, fmt.Errorf("Container doesn't contain a valid 'tenantid' label. Labels: %+v Body: %q",
+			dockerReq, req.ClientRequest.Body)
+	} else {
+		// XXX: record the outstanding network for which we are yet to receive a
+		// corresponding container-id (in server response). This simplifies things
+		// by assuming that there can't be two outstanding request. Need to revisit
+		// and handle this correctly.
+		adptr.outstandingNet = ContainerNet{tenantId: tenantId, netId: netId}
+	}
+
+	return makeClientRequest(req), nil
+}
+
+// Map the 'netid' received in create request to the container-id
+func (adptr *PwrStrpAdptr) handlePostCreate(req *PowerStripRequest) (*PowerStripResponse, error) {
+	defer func() { adptr.outstandingNet = ContainerNet{"", ""} }()
+
+	// ignore the response if container create failed
+	if req.ServerResponse.Code != 201 {
+		return makeServerResponse(req), nil
+	}
+
+	// should not happen
+	if adptr.outstandingNet.netId == "" {
+		return nil, fmt.Errorf("received a container create response, without corresponding create!")
+	}
+
+	//structure of interesting fields in the create response
+	type DockerCreateResponse struct {
+		ContId string `json:"Id"`
+	}
+	dockerResp := &DockerCreateResponse{}
+	err := json.Unmarshal([]byte(req.ServerResponse.Body), dockerResp)
+	if err != nil {
+		return nil, err
+	}
+
+	//update the adptr to remember the netid to container-id mapping
+	if _, ok := adptr.containerNets[dockerResp.ContId]; !ok {
+		adptr.containerNets[dockerResp.ContId] = make([]ContainerNet, 0)
+	}
+	adptr.containerNets[dockerResp.ContId] = append(adptr.containerNets[dockerResp.ContId],
+		adptr.outstandingNet)
+	// if a container name was specified update that mapping as well
+	if strings.Index(req.ClientRequest.Request, "?") != -1 {
+		queryParam := string(req.ClientRequest.Request[strings.Index(req.ClientRequest.Request, "?")+1:])
+		// right now create API just takes name as query parameter
+		name := strings.Split(queryParam, "=")[1]
+		adptr.nameIdMap[name] = dockerResp.ContId
+	}
+
+	return makeServerResponse(req), nil
+}
+
+func extractContIdOrName(req ClientRequest) string {
+	reqParts := strings.Split(req.Request, "/")
+	if req.Method == "POST" {
+		// container-id is at last but one position in the request string for
+		// POST requests (i.e. start and stop)
+		return reqParts[len(reqParts)-2]
+	} else {
+		// container-id is at last position in the request string for DELETE
+		// requests
+		return reqParts[len(reqParts)-1]
+	}
+}
+
+// take conatiner Id (complete or short hash) or name and return full container
+// Id if container exists, else return empty string
+func (adptr *PwrStrpAdptr) getFullContainerId(contIdOrName string) string {
+	// see if caller passed a full Id
+	if _, ok := adptr.containerNets[contIdOrName]; ok {
+		return contIdOrName
+	}
+	// see if caller passed a name
+	if id, ok := adptr.nameIdMap[contIdOrName]; ok {
+		return id
+	}
+	//see if caller passed a short conatiner Id
+	retId := ""
+	for id, _ := range adptr.containerNets {
+		if strings.HasPrefix(id, contIdOrName) && retId == "" {
+			retId = id
+		} else if retId != "" {
+			// found overlapping containers with the passed prefix
+			return ""
+		}
+	}
+	return retId
+}
+
+// Record the container-id, so that we can create endpoints for the container
+// once it is started (and we get post-start) trigger
+func (adptr *PwrStrpAdptr) handlePreStart(req *PowerStripRequest) (*PowerStripResponse, error) {
+	contIdOrName := extractContIdOrName(req.ClientRequest)
+	if _, ok := adptr.containerNets[adptr.getFullContainerId(contIdOrName)]; !ok {
+		return nil, fmt.Errorf("got a start request for non existent container. contIdOrName: %s Request: %+v",
+			contIdOrName, req)
+	} else {
+		adptr.outstandingContId = adptr.getFullContainerId(contIdOrName)
+	}
+
+	return makeClientRequest(req), nil
+}
+
+// Call the network driver's CreateEndpoint API for all networks that the
+// container belongs to.
+func (adptr *PwrStrpAdptr) handlePostStart(req *PowerStripRequest) (*PowerStripResponse, error) {
+	defer func() { adptr.outstandingContId = "" }()
+
+	// ignore the response if container start failed
+	if req.ServerResponse.Code != 204 {
+		return makeServerResponse(req), nil
+	}
+
+	// should not happen
+	if adptr.outstandingContId == "" {
+		return nil, fmt.Errorf("received a container start response, without corresponding start request!")
+	}
+
+	// should not happen
+	if _, ok := adptr.containerNets[adptr.outstandingContId]; !ok {
+		return nil, fmt.Errorf("received a container start response for unknown container %s",
+			adptr.outstandingContId)
+	}
+
+	// Now create an endpoint for every network this container is part of
+	contId := adptr.outstandingContId
+	for _, net := range adptr.containerNets[contId] {
+		// in libnetwork netUUID and epUUID are derived by the libnetwork,
+		// just deriving a unique string for now.
+		netUuid := driverapi.UUID(fmt.Sprintf("%s-%s", net.tenantId, net.netId))
+		epUuid := driverapi.UUID(fmt.Sprintf("%s-%s-%s", net.tenantId, net.netId, contId))
+		_, err := adptr.driver.CreateEndpoint(netUuid, epUuid, "",
+			DriverConfig{net.tenantId, net.netId, contId})
+		defer func(netUuid, epUuid driverapi.UUID) {
+			if err != nil {
+				adptr.driver.DeleteEndpoint(netUuid, epUuid)
+			}
+		}(netUuid, epUuid)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create endpoint for net: %+v container: %q with net(s): %+v. Error: %s",
+				net, contId, adptr.containerNets[contId], err)
+		}
+	}
+
+	return makeServerResponse(req), nil
+}
+
+// Call the network driver's DeleteEndpoint API for all the networks that the
+// container belongs to.
+func (adptr *PwrStrpAdptr) handlePreStop(req *PowerStripRequest) (*PowerStripResponse, error) {
+	contIdOrName := extractContIdOrName(req.ClientRequest)
+	fullContId := adptr.getFullContainerId(contIdOrName)
+	if _, ok := adptr.containerNets[fullContId]; !ok {
+		log.Printf("got a stop request for non existent container. contIdOrName: %s Request: %+v",
+			contIdOrName, req)
+		// let the request be forwarded to docker
+	} else {
+		// delete the endpoint for every network this container is part of
+		for _, net := range adptr.containerNets[fullContId] {
+			// in libnetwork netUUID and epUUID are derived by the libnetwork,
+			// just deriving a unique string for now.
+			netUuid := driverapi.UUID(fmt.Sprintf("%s-%s", net.tenantId, net.netId))
+			epUuid := driverapi.UUID(fmt.Sprintf("%s-%s-%s", net.tenantId, net.netId, fullContId))
+			err := adptr.driver.DeleteEndpoint(netUuid, epUuid)
+			if err != nil {
+				log.Printf("Failed to delete endpoint for net: %+v container: %q with net(s): %+v. Error: %s",
+					net, contIdOrName, adptr.containerNets[fullContId], err)
+				continue
+			}
+		}
+	}
+
+	return makeClientRequest(req), nil
+}
+
+// Clear the mapping of container's uuid to all networks
+func (adptr *PwrStrpAdptr) handlePreDelete(req *PowerStripRequest) (*PowerStripResponse, error) {
+	contIdOrName := extractContIdOrName(req.ClientRequest)
+	fullContId := adptr.getFullContainerId(contIdOrName)
+	if _, ok := adptr.containerNets[fullContId]; !ok {
+		log.Printf("got a delete request for non existent container. contIdOrName: %s Request: %+v",
+			contIdOrName, req)
+		// let the request be forwarded to docker
+	} else {
+		// XXX: with powerstrip there is no way to stimulate a stop request
+		// if a container exits, so perform the stop related cleanup on delete as well
+		adptr.handlePreStop(req)
+		delete(adptr.containerNets, fullContId)
+		delete(adptr.nameIdMap, contIdOrName)
+	}
+
+	return makeClientRequest(req), nil
+}

--- a/mgmtfn/pslibnet/powerstriphooks_test.go
+++ b/mgmtfn/pslibnet/powerstriphooks_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mapuri/libnetwork/driverapi"
+)
+
+type TestDriver struct {
+}
+
+func (d *LibNetDriver) Config(config interface{}) error {
+}
+
+func (d *LibNetDriver) CreateNetwork(nid driverapi.UUID, config interface{}) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func (d *LibNetDriver) DeleteNetwork(nid driverapi.UUID) error {
+	return fmt.Errorf("Not implemented")
+}
+
+func (d *LibNetDriver) CreateEndpoint(nid, eid driverapi.UUID, key string,
+	config interface{}) (*driverapi.SandboxInfo, error) {
+}
+
+func (d *LibNetDriver) DeleteEndpoint(nid, eid driverapi.UUID) error {
+}
+
+func TestPwrStrpAdptrHandlePreCreateNoNetId(t *testing.T) {
+	adptr := &PwrStrpAdptr{}
+	adptr.Init()
+}
+
+func TestPwrStrpAdptrHandlePreCreateNoTenantId(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePreCreateSuccess(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePostCreateFailureCode(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePostCreateSuccess(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePreStartSuccess(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePostStartFailureCode(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePostStartCreateEndpointFailure(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePostStartSuccess(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePreStopSuccess(t *testing.T) {
+}
+
+func TestPwrStrpAdptrHandlePreDeleteSuccess(t *testing.T) {
+}

--- a/netdcli/netdcli.go
+++ b/netdcli/netdcli.go
@@ -161,19 +161,19 @@ func init() {
 	flagSet.BoolVar(&opts.cfgHostBindings,
 		"host-bindings-cfg",
 		false,
-		"Json file describing container to host bindings")
+		"Json file describing container to host bindings. Use '-' to read configuration from stdin")
 	flagSet.BoolVar(&opts.cfgAdditions,
 		"add-cfg",
 		false,
-		"Json file describing addition to global and network intent")
+		"Json file describing addition to global and network intent. Use '-' to read configuration from stdin")
 	flagSet.BoolVar(&opts.cfgDeletions,
 		"del-cfg",
 		false,
-		"Json file describing deletion from global and network intent")
+		"Json file describing deletion from global and network intent. Use '-' to read configuration from stdin")
 	flagSet.BoolVar(&opts.cfgDesired,
 		"cfg",
 		false,
-		"Json file describing the global and network intent")
+		"Json file describing the global and network intent. Use '-' to read configuration from stdin")
 	flagSet.StringVar(&opts.etcdUrl,
 		"etcd-url",
 		"http://127.0.0.1:4001",
@@ -237,7 +237,7 @@ func init() {
 	flagSet.StringVar(&opts.intfName,
 		"intf-name",
 		"",
-		"Name of an exisitng linux device to use as endpoint's interface. This can be used for adding the host interface to the bridge for vlan based networks.")
+		"Name of an existing linux device to use as endpoint's interface. This can be used for adding the host interface to the bridge for vlan based networks.")
 
 	flagSet.BoolVar(&opts.help, "help", false, "prints this message")
 }
@@ -512,6 +512,8 @@ func executeOpts(opts *cliOpts) error {
 }
 
 func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
 	err := flagSet.Parse(os.Args[1:])
 	if err != nil {
 		log.Fatalf("Failed to parse command. Error: %s", err)

--- a/systemtests/singlehost/regression_test.go
+++ b/systemtests/singlehost/regression_test.go
@@ -84,3 +84,49 @@ func TestOneHostVlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 }
+
+// XXX: don't run this until we upgrade docker to a recent version that supports
+// labels and build-time env
+func TestOneHostVlanPowerstripDocker(t *testing.T) {
+	defer func() {
+		utils.ConfigCleanupCommon(t, testbed.GetNodes())
+		utils.StopOnError(t.Failed())
+	}()
+
+	cfgFile := utils.GetCfgFile("late_bindings/powerstrip_demo_vlan_nets")
+	jsonCfg, err := ioutil.ReadFile(cfgFile)
+	if err != nil {
+		t.Fatalf("failed to read config file %s \n", err)
+	}
+
+	node1 := testbed.GetNodes()[0]
+
+	utils.StartNetPlugin(t, testbed.GetNodes(), true)
+
+	utils.StartPowerStripAdapter(t, testbed.GetNodes())
+
+	utils.ApplyDesiredConfig(t, string(jsonCfg), node1)
+
+	env := []string{"DOCKER_HOST=localhost:2375"}
+	utils.StartServerWithEnvAndArgs(t, node1, "server1", env,
+		[]string{"--label", "netid=orange", "--label", "tenantid=tenant-one"})
+	defer func() {
+		utils.DockerCleanupWithEnv(t, node1, "server1", env)
+	}()
+	ipAddress := utils.GetIpAddressFromNetworkAndContainerName(t, node1,
+		"orange", "server1")
+
+	// test ping success between containers in same network
+	utils.StartClientWithEnvAndArgs(t, node1, "client1", ipAddress, env,
+		[]string{"--label", "netid=orange", "--label", "tenantid=tenant-one"})
+	defer func() {
+		utils.DockerCleanupWithEnv(t, node1, "client1", env)
+	}()
+
+	// test ping failure between containers in different networks
+	utils.StartClientFailureWithEnvAndArgs(t, node1, "client2", ipAddress, env,
+		[]string{"--label", "netid=purple", "--label", "tenantid=tenant-one"})
+	defer func() {
+		utils.DockerCleanupWithEnv(t, node1, "client2", env)
+	}()
+}

--- a/systemtests/utils/vagrantcommand.go
+++ b/systemtests/utils/vagrantcommand.go
@@ -45,5 +45,5 @@ func (c *VagrantCommand) Run(cmd string, args ...string) error {
 }
 
 func (c *VagrantCommand) RunWithOutput(cmd string, args ...string) ([]byte, error) {
-	return c.getCmd(cmd, args...).Output()
+	return c.getCmd(cmd, args...).CombinedOutput()
 }


### PR DESCRIPTION
This PR brings in a very basic/crude libnetwork integration with Netplugin. It:
    - Uses powerstrip to stimulate plugin calls from docker.
    - Uses label support recently added to docker to pass network and tenant information for
      the container.
    - Implements libnetwork driverapi to add a bare minimal driver support.
      libnetwork is still changing so this part will continue evolve.
    - Adds a regression test but not enabled as this feature requires label support and
      build-time env support (for building behind proxy) in docker daemon
    - Adda a demo doc with instructions on using netplugin with powerstrip.

address #56 