### PR TITLE
scripts/dockerhost/start-dockerhosts: Various fixups and catchalls for missing binaries

### DIFF
--- a/scripts/checks
+++ b/scripts/checks
@@ -29,7 +29,13 @@ fi
 echo "+++ golint tree..."
 for i in $(find . -maxdepth 1 -type d -name '*' | grep -vE '/\..*$')
 do
-  golint "${i}"
+  output=$(golint "${i}") # golint has no exit codes
+  if [ -n "${output}" ]
+  then
+    echo -e "!!! golint checking failed: "
+    echo -n "${output}"
+    exit 1
+  fi
 done
 
 echo "+++ go vet tree..."

--- a/scripts/dockerhost/Dockerfile
+++ b/scripts/dockerhost/Dockerfile
@@ -1,16 +1,16 @@
 FROM      ubuntu
 MAINTAINER Sachin Jain <sachja@gmail.com>
 
-RUN apt-get update && apt-get install -y curl build-essential pkg-config python2.7-dev libpython2.7-dev
+RUN apt-get update && apt-get install -y curl build-essential pkg-config python2.7-dev libpython2.7-dev apparmor
 
-RUN curl -sSL https://get.docker.com/ubuntu/ | sh > /dev/null
+RUN curl -sSL https://get.docker.com/ubuntu/ | sh 1>/dev/null 2>&1
 
 RUN cd /tmp && \
 curl -L  https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.tar.gz -o etcd-v2.0.0-linux-amd64.tar.gz && \
 tar -xzf etcd-v2.0.0-linux-amd64.tar.gz && \
 cd /usr/bin && \
-ln -s /tmp/etcd-v2.0.0-linux-amd64/etcd && \
-ln -s /tmp/etcd-v2.0.0-linux-amd64/etcdctl
+mv /tmp/etcd-v2.0.0-linux-amd64/etcd . && \
+mv /tmp/etcd-v2.0.0-linux-amd64/etcdctl .
 
 RUN apt-get install -y openvswitch-switch
 

--- a/scripts/dockerhost/dind
+++ b/scripts/dockerhost/dind
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -e
+
+# DinD: a wrapper script which allows docker to be run inside a docker container.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+# See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+#
+# This script should be executed inside a docker container in privilieged mode
+# ('docker run --privileged', introduced in docker 0.6).
+
+# Usage: dind CMD [ARG...]
+
+# apparmor sucks and Docker needs to know that it's in a container (c) @tianon
+export container=docker
+
+# First, make sure that cgroups are mounted correctly.
+CGROUP=/cgroup
+
+mkdir -p "$CGROUP"
+
+if ! mountpoint -q "$CGROUP"; then
+	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
+		echo >&2 'Could not make a tmpfs mount. Did you use --privileged?'
+		exit 1
+	}
+fi
+
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+	mount -t securityfs none /sys/kernel/security || {
+		echo >&2 'Could not mount /sys/kernel/security.'
+		echo >&2 'AppArmor detection and -privileged mode might break.'
+	}
+fi
+
+# Mount the cgroup hierarchies exactly as they are in the parent system.
+for HIER in $(cut -d: -f2 /proc/1/cgroup); do
+
+	# The following sections address a bug which manifests itself
+	# by a cryptic "lxc-start: no ns_cgroup option specified" when
+	# trying to start containers within a container.
+	# The bug seems to appear when the cgroup hierarchies are not
+	# mounted on the exact same directories in the host, and in the
+	# container.
+
+	SUBSYSTEMS="${HIER%name=*}"
+
+	# If cgroup hierarchy is named(mounted with "-o name=foo") we
+	# need to mount it in $CGROUP/foo to create exect same
+	# directoryes as on host. Else we need to mount it as is e.g.
+	# "subsys1,subsys2" if it has two subsystems
+
+	# Named, control-less cgroups are mounted with "-o name=foo"
+	# (and appear as such under /proc/<pid>/cgroup) but are usually
+	# mounted on a directory named "foo" (without the "name=" prefix).
+	# Systemd and OpenRC (and possibly others) both create such a
+	# cgroup. So just mount them on directory $CGROUP/foo.
+
+	OHIER=$HIER
+	HIER="${HIER#*name=}"
+
+	mkdir -p "$CGROUP/$HIER"
+
+	if ! mountpoint -q "$CGROUP/$HIER"; then
+		mount -n -t cgroup -o "$OHIER" cgroup "$CGROUP/$HIER"
+	fi
+
+	# Likewise, on at least one system, it has been reported that
+	# systemd would mount the CPU and CPU accounting controllers
+	# (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
+	# but on a directory called "cpu,cpuacct" (note the inversion
+	# in the order of the groups). This tries to work around it.
+
+	if [ "$HIER" = 'cpuacct,cpu' ]; then
+		ln -s "$HIER" "$CGROUP/cpu,cpuacct"
+	fi
+
+	# If hierarchy has multiple subsystems, in /proc/<pid>/cgroup
+	# we will see ":subsys1,subsys2,subsys3,name=foo:" substring,
+	# we need to mount it to "$CGROUP/foo" and if there were no
+	# name to "$CGROUP/subsys1,subsys2,subsys3", so we must create
+	# symlinks for docker daemon to find these subsystems:
+	# ln -s $CGROUP/foo $CGROUP/subsys1
+	# ln -s $CGROUP/subsys1,subsys2,subsys3 $CGROUP/subsys1
+
+	if [ "$SUBSYSTEMS" != "${SUBSYSTEMS//,/ }" ]; then
+		SUBSYSTEMS="${SUBSYSTEMS//,/ }"
+		for SUBSYS in $SUBSYSTEMS
+		do
+			ln -s "$CGROUP/$HIER" "$CGROUP/$SUBSYS"
+		done
+	fi
+done
+
+# Note: as I write those lines, the LXC userland tools cannot setup
+# a "sub-container" properly if the "devices" cgroup is not in its
+# own hierarchy. Let's detect this and issue a warning.
+if ! grep -q :devices: /proc/1/cgroup; then
+	echo >&2 'WARNING: the "devices" cgroup should be in its own hierarchy.'
+fi
+if ! grep -qw devices /proc/1/cgroup; then
+	echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
+fi
+
+# Mount /tmp
+mount -t tmpfs none /tmp
+
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi
+
+echo >&2 'ERROR: No command specified.'
+echo >&2 'You probably want to run hack/make.sh, or maybe a shell?'

--- a/scripts/dockerhost/start-dockerhosts
+++ b/scripts/dockerhost/start-dockerhosts
@@ -51,12 +51,28 @@ if [ -n "${errors}" ]; then
     exit 1
 fi
 
+set -e
+
 scriptdir=`dirname "$BASH_SOURCE"`
 echo $scriptdir
 
+if ! sudo ip link | grep -q docker0
+then
+  echo "Docker bridge is dead; restart docker"
+  if [ "x$CONTIV_NOWARN" == "x" ]
+  then
+    echo "Please press enter to allow this. Set \$CONTIV_NOWARN to disable this warning."
+    read
+    echo "Restarting docker."
+  fi
+  sudo service docker restart 2>/dev/null || :
+fi
+
 # Create a linux bridge between containers
-sudo brctl addbr br-em1
-sudo ip link set br-em1 up
+if sudo brctl addbr br-em1 2>/dev/null
+then
+  sudo ip link set br-em1 up
+fi
 
 num_nodes=1
 if [ -n "$CONTIV_NODES" ];
@@ -66,21 +82,24 @@ fi
 echo "Num nodes = "$num_nodes
 
 # Create the docker image for hosts
-# sudo docker build -t ubuntu_netplugin $scriptdir
+sudo docker build -t ubuntu_netplugin $scriptdir
 
 # Pull ubuntu image for use within the docker hosts
-sudo docker pull ubuntu
+sudo docker pull ubuntu:latest
 
-mkdir /tmp/ubuntu_image
+mkdir -p /tmp/ubuntu_image
 
-sudo docker save -o /tmp/ubuntu_image/ubuntu-image.tar ubuntu
+if [ ! -f /tmp/ubuntu_image/ubuntu-image.tar ]
+then
+  sudo docker save -o /tmp/ubuntu_image/ubuntu-image.tar ubuntu:latest
+fi
 
 cluster=""
 first="true"
 for i in `seq 1 $num_nodes`; 
 do
     host="netplugin-node$i"
-    echo "Starting $host"
+    echo "Starting $host, removing any old ones if necessary"
     # godep modifies the host's GOPATH env variable, CONTIV_HOST_GOPATH
     # contains the unmodified path passed from the Makefile, use that
     # when it is defined.
@@ -89,16 +108,30 @@ do
     else
         gopath=$GOPATH
     fi
-    sudo docker run -d -i -t --name $host --privileged -e CONTIV_DIND_HOST_GOPATH=$gopath \
-        -e GOSRC=/gopath/src/ -v /var/lib/docker -v $gopath:/gopath -v /proc:/host/proc \
-        -v /tmp/ubuntu_image:/ubuntu_image sachja/ubuntu_netplugin bash \
-        -c "/gopath/src/github.com/contiv/netplugin/scripts/dockerhost/start-service.sh & bash"
+
+    sudo docker rm -f $host 2>/dev/null || :
+    sudo docker run -d -i -t --name $host \
+      --privileged \
+      -e CONTIV_DIND_HOST_GOPATH=$gopath \
+      -e GOSRC=/gopath/src/ -v /var/lib/docker \
+      -v ${gopath}:/gopath \
+      -v /proc:/host/proc \
+      -v /tmp/ubuntu_image:/ubuntu_image \
+      ubuntu_netplugin \
+      bash -c "/gopath/src/github.com/contiv/netplugin/scripts/dockerhost/start-service.sh && bash"
     sudo docker exec $host hostname $host
     sudo docker exec $host sh -c 'echo $(hostname -I | cut -d\  -f1) $(hostname) | tee -a /etc/hosts'
+
+    if sudo ip link | grep -q $i-int
+    then
+      sudo ip link delete $i-int
+    fi
+
     sudo ip link add $i-int type veth peer name $i-ext
     sudo brctl addif br-em1 $i-ext
     sudo ip link set $i-ext up
     sudo ip link set netns $($scriptdir/docker-pid $host) dev $i-int
+
     sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set dev $i-int name eth2
     sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set eth2 up
     addr=$((10+$i-1))
@@ -107,23 +140,40 @@ do
     sudo nsenter -t $($scriptdir/docker-pid $host) -n ip addr add $ip_addr dev eth2
     sudo nsenter -t $($scriptdir/docker-pid $host) -n ip route add "192.168.2.0/24" dev eth2
     if [ $i -gt "1" ]; then
-	cluster=$cluster",";
+      cluster=$cluster",";
     fi
-    sudo docker exec $host service docker start
+
+    echo "Starting docker in $host"
+    sudo docker exec -d $host /bin/bash -c '/bin/bash /gopath/src/github.com/contiv/netplugin/scripts/dockerhost/dind docker -d -D &>/tmp/docker.log'
+
+    echo "Waiting for docker to start"
+    times=0
+    if ! sudo docker exec $host test -f /var/run/docker.sock >/dev/null
+    then
+      sudo docker exec $host ps aux
+      sleep 1
+      times=$((1 + $times))
+      if [ $times -gt 10 ]
+      then
+        echo "!!! could not boot dind"
+        exit 1
+      fi
+    fi
+
     sudo docker exec $host docker load -i /ubuntu_image/ubuntu-image.tar
+
     addr=$($scriptdir/docker-ip $host)
     cluster=$cluster$host"=http://"$addr":2380"
     first="false"
 done
-
-sudo rm -rf /tmp/ubuntu_image
 
 for i in `seq 1 $num_nodes`; 
 do
     host="netplugin-node$i"
     echo "Starting etcd on $host"
     addr=$($scriptdir/docker-ip $host)
-    sudo docker exec -d $host etcd -name $host -data-dir /opt/etcd -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls http://$addr:2379,http://$addr:4001 -initial-advertise-peer-urls http://$addr:2380 -listen-peer-urls http://$addr:2380 -initial-cluster $cluster -initial-cluster-state new 
+    # FIXME we should probably add this to the docker image
+    sudo docker exec -d $host etcd -name $host -data-dir /opt/etcd -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls http://$addr:2379,http://$addr:4001 -initial-advertise-peer-urls http://$addr:2380 -listen-peer-urls http://$addr:2380 -initial-cluster $cluster -initial-cluster-state new
 done
 
 sleep 5s

--- a/systemtests/utils/dind.go
+++ b/systemtests/utils/dind.go
@@ -36,6 +36,7 @@ func (v *Dind) Setup(env string, numNodes int) error {
 	}
 	cmd := &TestCommand{ContivNodes: numNodes, ContivEnv: env}
 	output, err := cmd.RunWithOutput("scripts/dockerhost/start-dockerhosts")
+	fmt.Println(string(output))
 	if err != nil {
 		log.Printf("start-dockerhosts failed. Error: %s Output: \n%s\n",
 			err, output)


### PR DESCRIPTION
This adds several changes which make the script idempotent and communicates needs to the user more effectively.

The script in its current state does not validate many errors that could be caused by an improperly configured machine. Now, we tell the user what we need.

Additionally, the script would not stop in the face of errors, and would continue forward doing many things that will not work because of prior expectations. This has been (hopefully) corrected.

I did not verify that the tool indeed still works. I will be reviewing the code later today and can validate that then.