### PR TITLE
Enhance core.Error to store the file and line number info with error

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -15,14 +15,28 @@ limitations under the License.
 
 package core
 
-import "strings"
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
 
 type Error struct {
-	Desc string
+	desc string
+	file string
+	line int
 }
 
 func (e *Error) Error() string {
-	return e.Desc
+	return fmt.Sprintf("%s [%s %d]", e.desc, e.file, e.line)
+}
+
+func Errorf(f string, args ...interface{}) *Error {
+	e := &Error{}
+	e.desc = fmt.Sprintf(f, args...)
+	_, e.file, e.line, _ = runtime.Caller(1)
+	e.file = e.file[strings.LastIndex(e.file, "/")+1:]
+	return e
 }
 
 func ErrIfKeyExists(err error) error {

--- a/core/error_test.go
+++ b/core/error_test.go
@@ -1,0 +1,21 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestErrorStringFormat(t *testing.T) {
+	refStr := "error string"
+	e := Errorf("%s", refStr)
+
+	fileName := "error_test.go"
+	lineNum := 10 // line number where error was formed
+
+	expectedStr := fmt.Sprintf("%s [%s %d]", refStr, fileName, lineNum)
+
+	if e.Error() != expectedStr {
+		t.Fatalf("error string mismatch. Expected: %q, got %q", expectedStr,
+			e.Error())
+	}
+}

--- a/crt/crt.go
+++ b/crt/crt.go
@@ -17,9 +17,9 @@ package crt
 
 import (
 	"encoding/json"
-	"errors"
 	"reflect"
 
+	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/crtclient"
 	"github.com/contiv/netplugin/crtclient/docker"
 )
@@ -76,7 +76,7 @@ func (c *Crt) Init(configStr string) error {
 	}
 
 	if _, ok := ContainerIfRegistry[cfg.Crt.Type]; !ok {
-		return errors.New("unregistered container run time")
+		return core.Errorf("unregistered container run time")
 	}
 
 	crtConfigType := ContainerIfRegistry[cfg.Crt.Type].CrtConfigType

--- a/drivers/etcdstatedriver.go
+++ b/drivers/etcdstatedriver.go
@@ -43,13 +43,13 @@ type EtcdStateDriver struct {
 
 func (d *EtcdStateDriver) Init(config *core.Config) error {
 	if config == nil {
-		return &core.Error{Desc: fmt.Sprintf("Invalid arguments. cfg: %v", config)}
+		return core.Errorf("Invalid arguments. cfg: %v", config)
 	}
 
 	cfg, ok := config.V.(*EtcdStateDriverConfig)
 
 	if !ok {
-		return &core.Error{Desc: "Invalid config type passed!"}
+		return core.Errorf("Invalid config type passed!")
 	}
 
 	d.Client = etcd.NewClient(cfg.Etcd.Machines)
@@ -183,8 +183,8 @@ func ReadAllStateCommon(d core.StateDriver, baseKey string, sType core.State,
 		if !values.Index(i).Elem().FieldByName("CommonState").IsValid() {
 			panic(fmt.Sprintf("The state structure %v is missing core.CommonState",
 				stateType))
-			return nil, &core.Error{Desc: fmt.Sprintf("The state structure %v is missing core.CommonState",
-				stateType)}
+			return nil, core.Errorf("The state structure %v is missing core.CommonState",
+				stateType)
 		}
 		//the following works as every core.State is expected to embed core.CommonState struct
 		values.Index(i).Elem().FieldByName("CommonState").FieldByName("StateDriver").Set(reflect.ValueOf(d))
@@ -221,8 +221,8 @@ func (d *EtcdStateDriver) channelStateEvents(sType core.State,
 			if !value.Elem().Elem().FieldByName("CommonState").IsValid() {
 				panic(fmt.Sprintf("The state structure %v is missing core.CommonState",
 					stateType))
-				retErr <- &core.Error{Desc: fmt.Sprintf("The state structure %v is missing core.CommonState",
-					stateType)}
+				retErr <- core.Errorf("The state structure %v is missing core.CommonState",
+					stateType)
 				return
 			}
 			//the following works as every core.State is expected to embed core.CommonState struct

--- a/drivers/etcdstatedriver_test.go
+++ b/drivers/etcdstatedriver_test.go
@@ -98,19 +98,19 @@ type testState struct {
 }
 
 func (s *testState) Write() error {
-	return &core.Error{Desc: "Should not be called!!"}
+	return core.Errorf("Should not be called!!")
 }
 
 func (s *testState) Read(id string) error {
-	return &core.Error{Desc: "Should not be called!!"}
+	return core.Errorf("Should not be called!!")
 }
 
 func (s *testState) ReadAll() ([]core.State, error) {
-	return nil, &core.Error{Desc: "Should not be called!!"}
+	return nil, core.Errorf("Should not be called!!")
 }
 
 func (s *testState) Clear() error {
-	return &core.Error{Desc: "Should not be called!!"}
+	return core.Errorf("Should not be called!!")
 }
 
 func TestEtcdStateDriverWriteState(t *testing.T) {

--- a/drivers/fakestatedriver.go
+++ b/drivers/fakestatedriver.go
@@ -40,7 +40,7 @@ func (d *FakeStateDriver) Read(key string) ([]byte, error) {
 		return val.value, nil
 	}
 
-	return []byte{}, &core.Error{Desc: "Key not found!"}
+	return []byte{}, core.Errorf("Key not found!")
 }
 
 func (d *FakeStateDriver) ReadAll(baseKey string) ([][]byte, error) {
@@ -55,7 +55,7 @@ func (d *FakeStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 }
 
 func (d *FakeStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *FakeStateDriver) ClearState(key string) error {
@@ -87,7 +87,7 @@ func (d *FakeStateDriver) ReadAllState(baseKey string, sType core.State,
 
 func (d *FakeStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *FakeStateDriver) WriteState(key string, value core.State,

--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -107,8 +107,8 @@ func (d *OvsDriver) performOvsdbOps(ops []libovsdb.Operation) error {
 	reply, _ := d.ovs.Transact(DATABASE, ops...)
 
 	if len(reply) < len(ops) {
-		return &core.Error{Desc: fmt.Sprintf("Unexpected number of replies. Expected: %d, Recvd: %d",
-			len(ops), len(reply))}
+		return core.Errorf("Unexpected number of replies. Expected: %d, Recvd: %d",
+			len(ops), len(reply))
 	}
 	ok := true
 	errors := []string{}
@@ -124,8 +124,7 @@ func (d *OvsDriver) performOvsdbOps(ops []libovsdb.Operation) error {
 	if ok {
 		return nil
 	} else {
-		return &core.Error{Desc: fmt.Sprintf("ovs operation failed. Error(s): %v",
-			errors)}
+		return core.Errorf("ovs operation failed. Error(s): %v", errors)
 	}
 }
 
@@ -206,7 +205,7 @@ func (d *OvsDriver) getPortOrIntfNameFromId(id string, isPort bool) (string, err
 			}
 		}
 	}
-	return "", &core.Error{Desc: fmt.Sprintf("Ovs port/intf not found for id: %s", id)}
+	return "", core.Errorf("Ovs port/intf not found for id: %s", id)
 }
 
 func (d *OvsDriver) createDeletePort(portName, intfName, intfType, id string,
@@ -375,12 +374,13 @@ func (d *OvsDriver) deleteVtep(epOper *OvsOperEndpointState) error {
 func (d *OvsDriver) Init(config *core.Config, stateDriver core.StateDriver) error {
 
 	if config == nil || stateDriver == nil {
-		return &core.Error{Desc: fmt.Sprintf("Invalid arguments. cfg: %v, stateDriver: %v", config, stateDriver)}
+		return core.Errorf("Invalid arguments. cfg: %v, stateDriver: %v",
+			config, stateDriver)
 	}
 
 	cfg, ok := config.V.(*OvsDriverConfig)
 	if !ok {
-		return &core.Error{Desc: "Invalid type passed"}
+		return core.Errorf("Invalid type passed")
 	}
 
 	ovs, err := libovsdb.Connect(cfg.Ovs.DbIp, cfg.Ovs.DbPort)
@@ -564,5 +564,5 @@ func (d *OvsDriver) DeleteEndpoint(id string) (err error) {
 }
 
 func (d *OvsDriver) MakeEndpointAddress() (*core.Address, error) {
-	return nil, &core.Error{Desc: "Not supported"}
+	return nil, core.Errorf("Not supported")
 }

--- a/drivers/ovsdriver_test.go
+++ b/drivers/ovsdriver_test.go
@@ -52,26 +52,26 @@ type testOvsStateDriver struct {
 }
 
 func (d *testOvsStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testOvsStateDriver) Deinit() {
 }
 
 func (d *testOvsStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testOvsStateDriver) Read(key string) ([]byte, error) {
-	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return []byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testOvsStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return [][]byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testOvsStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testOvsStateDriver) ClearState(key string) error {
@@ -145,7 +145,7 @@ func (d *testOvsStateDriver) readStateHelper(isCreateEp bool, oper int,
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown value type"}
+	return core.Errorf("unknown value type")
 }
 
 func (d *testOvsStateDriver) ReadState(key string, value core.State,
@@ -173,17 +173,17 @@ func (d *testOvsStateDriver) ReadState(key string, value core.State,
 		return d.readStateHelper(false, READ_NW, value)
 	}
 
-	return &core.Error{Desc: fmt.Sprintf("unknown key! %s", key)}
+	return core.Errorf("unknown key! %s", key)
 }
 
 func (d *testOvsStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "shouldn't be called!"}
+	return nil, core.Errorf("shouldn't be called!")
 }
 
 func (d *testOvsStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testOvsStateDriver) WriteState(key string, value core.State,

--- a/drivers/ovsendpointstate_test.go
+++ b/drivers/ovsendpointstate_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package drivers
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/contiv/netplugin/core"
@@ -34,32 +33,32 @@ type testEpStateDriver struct {
 }
 
 func (d *testEpStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testEpStateDriver) Deinit() {
 }
 
 func (d *testEpStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testEpStateDriver) Read(key string) ([]byte, error) {
-	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return []byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testEpStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return [][]byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testEpStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testEpStateDriver) validateKey(key string) error {
 	if key != epCfgKey && key != epOperKey {
-		return &core.Error{Desc: fmt.Sprintf("Unexpected key. recvd: %s expected: %s or %s ",
-			key, epCfgKey, epOperKey)}
+		return core.Errorf("Unexpected key. recvd: %s expected: %s or %s ",
+			key, epCfgKey, epOperKey)
 	} else {
 		return nil
 	}
@@ -76,12 +75,12 @@ func (d *testEpStateDriver) ReadState(key string, value core.State,
 
 func (d *testEpStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testEpStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testEpStateDriver) WriteState(key string, value core.State,

--- a/drivers/ovsnetworkstate_test.go
+++ b/drivers/ovsnetworkstate_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package drivers
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/contiv/netplugin/core"
@@ -33,32 +32,32 @@ type testNwStateDriver struct {
 }
 
 func (d *testNwStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) Deinit() {
 }
 
 func (d *testNwStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) Read(key string) ([]byte, error) {
-	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return []byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return [][]byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testNwStateDriver) validateKey(key string) error {
 	if key != nwCfgKey {
-		return &core.Error{Desc: fmt.Sprintf("Unexpected key. "+
-			"recvd: %s expected: %s ", key, nwCfgKey)}
+		return core.Errorf("Unexpected key. recvd: %s expected: %s ",
+			key, nwCfgKey)
 	} else {
 		return nil
 	}
@@ -75,12 +74,12 @@ func (d *testNwStateDriver) ReadState(key string, value core.State,
 
 func (d *testNwStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testNwStateDriver) WriteState(key string, value core.State,

--- a/mgmtfn/k8contivnet/contivnet.go
+++ b/mgmtfn/k8contivnet/contivnet.go
@@ -21,13 +21,13 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/netmaster"
 )
 
@@ -51,7 +51,7 @@ func getHostLabel() (string, error) {
 		}
 	}
 
-	return "", errors.New("couldn't find host label")
+	return "", core.Errorf("couldn't find host label")
 }
 
 func printUsage(arg0 string) {

--- a/mgmtfn/pslibnet/libnetdriver.go
+++ b/mgmtfn/pslibnet/libnetdriver.go
@@ -3,9 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os/exec"
 
+	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/netmaster"
 	"github.com/mapuri/libnetwork/driverapi"
 )
@@ -30,11 +30,11 @@ func (d *LibNetDriver) Config(config interface{}) error {
 }
 
 func (d *LibNetDriver) CreateNetwork(nid driverapi.UUID, config interface{}) error {
-	return fmt.Errorf("Not implemented")
+	return core.Errorf("Not implemented")
 }
 
 func (d *LibNetDriver) DeleteNetwork(nid driverapi.UUID) error {
-	return fmt.Errorf("Not implemented")
+	return core.Errorf("Not implemented")
 }
 
 func invokeNetdcli(dc DriverConfig, isAdd bool) error {
@@ -68,7 +68,7 @@ func invokeNetdcli(dc DriverConfig, isAdd bool) error {
 	cmd.Stdin = bytes.NewReader(config)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("command failed. Error: %s, Output: %s", err, out)
+		return core.Errorf("command failed. Error: %s, Output: %s", err, out)
 	}
 	return nil
 }
@@ -77,7 +77,7 @@ func (d *LibNetDriver) CreateEndpoint(nid, eid driverapi.UUID, key string,
 	config interface{}) (*driverapi.SandboxInfo, error) {
 	dc, ok := config.(DriverConfig)
 	if !ok {
-		return nil, fmt.Errorf("Invalid config passed")
+		return nil, core.Errorf("Invalid config passed")
 	}
 
 	err := invokeNetdcli(dc, true)
@@ -96,7 +96,7 @@ func (d *LibNetDriver) CreateEndpoint(nid, eid driverapi.UUID, key string,
 func (d *LibNetDriver) DeleteEndpoint(nid, eid driverapi.UUID) error {
 	dc, ok := d.endpoints[eid]
 	if !ok {
-		return fmt.Errorf("endpoint info not found for epid: %q, netid: %q",
+		return core.Errorf("endpoint info not found for epid: %q, netid: %q",
 			eid, nid)
 	}
 	err := invokeNetdcli(dc, false)

--- a/mgmtfn/pslibnet/powerstriphooks.go
+++ b/mgmtfn/pslibnet/powerstriphooks.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/contiv/netplugin/core"
 	"github.com/mapuri/libnetwork/driverapi"
 )
 
@@ -167,10 +168,10 @@ func (adptr *PwrStrpAdptr) handlePreCreate(req *PowerStripRequest) (*PowerStripR
 	}
 
 	if netId, ok := dockerReq.Labels["netid"]; !ok || netId == "" {
-		return nil, fmt.Errorf("Container doesn't contain a valid 'netid' label. Labels: %+v Body: %q",
+		return nil, core.Errorf("Container doesn't contain a valid 'netid' label. Labels: %+v Body: %q",
 			dockerReq, req.ClientRequest.Body)
 	} else if tenantId, ok := dockerReq.Labels["tenantid"]; !ok || tenantId == "" {
-		return nil, fmt.Errorf("Container doesn't contain a valid 'tenantid' label. Labels: %+v Body: %q",
+		return nil, core.Errorf("Container doesn't contain a valid 'tenantid' label. Labels: %+v Body: %q",
 			dockerReq, req.ClientRequest.Body)
 	} else {
 		// XXX: record the outstanding network for which we are yet to receive a
@@ -194,7 +195,7 @@ func (adptr *PwrStrpAdptr) handlePostCreate(req *PowerStripRequest) (*PowerStrip
 
 	// should not happen
 	if adptr.outstandingNet.netId == "" {
-		return nil, fmt.Errorf("received a container create response, without corresponding create!")
+		return nil, core.Errorf("received a container create response, without corresponding create!")
 	}
 
 	//structure of interesting fields in the create response
@@ -266,7 +267,7 @@ func (adptr *PwrStrpAdptr) getFullContainerId(contIdOrName string) string {
 func (adptr *PwrStrpAdptr) handlePreStart(req *PowerStripRequest) (*PowerStripResponse, error) {
 	contIdOrName := extractContIdOrName(req.ClientRequest)
 	if _, ok := adptr.containerNets[adptr.getFullContainerId(contIdOrName)]; !ok {
-		return nil, fmt.Errorf("got a start request for non existent container. contIdOrName: %s Request: %+v",
+		return nil, core.Errorf("got a start request for non existent container. contIdOrName: %s Request: %+v",
 			contIdOrName, req)
 	} else {
 		adptr.outstandingContId = adptr.getFullContainerId(contIdOrName)
@@ -287,12 +288,12 @@ func (adptr *PwrStrpAdptr) handlePostStart(req *PowerStripRequest) (*PowerStripR
 
 	// should not happen
 	if adptr.outstandingContId == "" {
-		return nil, fmt.Errorf("received a container start response, without corresponding start request!")
+		return nil, core.Errorf("received a container start response, without corresponding start request!")
 	}
 
 	// should not happen
 	if _, ok := adptr.containerNets[adptr.outstandingContId]; !ok {
-		return nil, fmt.Errorf("received a container start response for unknown container %s",
+		return nil, core.Errorf("received a container start response for unknown container %s",
 			adptr.outstandingContId)
 	}
 
@@ -311,7 +312,7 @@ func (adptr *PwrStrpAdptr) handlePostStart(req *PowerStripRequest) (*PowerStripR
 			}
 		}(netUuid, epUuid)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to create endpoint for net: %+v container: %q with net(s): %+v. Error: %s",
+			return nil, core.Errorf("Failed to create endpoint for net: %+v container: %q with net(s): %+v. Error: %s",
 				net, contId, adptr.containerNets[contId], err)
 		}
 	}

--- a/mgmtfn/pslibnet/powerstriphooks_test.go
+++ b/mgmtfn/pslibnet/powerstriphooks_test.go
@@ -13,11 +13,11 @@ func (d *LibNetDriver) Config(config interface{}) error {
 }
 
 func (d *LibNetDriver) CreateNetwork(nid driverapi.UUID, config interface{}) error {
-	return fmt.Errorf("Not implemented")
+	return core.Errorf("Not implemented")
 }
 
 func (d *LibNetDriver) DeleteNetwork(nid driverapi.UUID) error {
-	return fmt.Errorf("Not implemented")
+	return core.Errorf("Not implemented")
 }
 
 func (d *LibNetDriver) CreateEndpoint(nid, eid driverapi.UUID, key string,

--- a/netdcli/netdcli.go
+++ b/netdcli/netdcli.go
@@ -481,7 +481,7 @@ func executeOpts(opts *cliOpts) error {
 				state = rsrc
 			}
 		} else {
-			return fmt.Errorf("Only get operation is supported for resources")
+			return core.Errorf("Only get operation is supported for resources")
 		}
 	}
 

--- a/netmaster/hoststate_test.go
+++ b/netmaster/hoststate_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 package netmaster
 
 import (
-	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/contiv/netplugin/core"
@@ -34,32 +32,32 @@ type testHostStateDriver struct {
 }
 
 func (d *testHostStateDriver) Init(config *core.Config) error {
-	return errors.New("Shouldn't be called!")
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testHostStateDriver) Deinit() {
 }
 
 func (d *testHostStateDriver) Write(key string, value []byte) error {
-	return errors.New("Shouldn't be called!")
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testHostStateDriver) Read(key string) ([]byte, error) {
-	return []byte{}, errors.New("Shouldn't be called!")
+	return []byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testHostStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return [][]byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testHostStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testHostStateDriver) validateKey(key string) error {
 	if key != hostCfgKey {
-		return errors.New(fmt.Sprintf("Unexpected key. recvd: %s "+
-			"expected: %s", key, hostCfgKey))
+		return core.Errorf("Unexpected key. recvd: %s expected: %s",
+			key, hostCfgKey)
 	} else {
 		return nil
 	}
@@ -76,12 +74,12 @@ func (d *testHostStateDriver) ReadState(key string, value core.State,
 
 func (d *testHostStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testHostStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testHostStateDriver) WriteState(key string, value core.State,

--- a/netmaster/netmaster.go
+++ b/netmaster/netmaster.go
@@ -16,7 +16,6 @@ limitations under the License.
 package netmaster
 
 import (
-	"errors"
 	"log"
 	"net"
 	"strconv"
@@ -53,7 +52,7 @@ func Init(stateDriver *core.StateDriver, cfg *Config) error {
 
 func checkPktTagType(pktTagType string) error {
 	if pktTagType != "" && pktTagType != "vlan" && pktTagType != "vxlan" {
-		return errors.New("invalid pktTagType")
+		return core.Errorf("invalid pktTagType")
 	}
 
 	return nil
@@ -61,7 +60,7 @@ func checkPktTagType(pktTagType string) error {
 
 func validateTenantConfig(tenant *ConfigTenant) error {
 	if tenant.Name == "" {
-		return errors.New("invalid tenant name")
+		return core.Errorf("invalid tenant name")
 	}
 
 	err := checkPktTagType(tenant.DefaultNetType)
@@ -184,10 +183,10 @@ func DeleteTenant(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 
 func validateHostConfig(host *ConfigHost) error {
 	if host.Name == "" {
-		return errors.New("null host name")
+		return core.Errorf("null host name")
 	}
 	if host.VtepIp == "" && host.Intf == "" {
-		return errors.New("either vtep or intf needed for the host")
+		return core.Errorf("either vtep or intf needed for the host")
 	}
 
 	return nil
@@ -407,12 +406,12 @@ func validateNetworkConfig(tenant *ConfigTenant) error {
 	var err error
 
 	if tenant.Name == "" {
-		return errors.New("null tenant name")
+		return core.Errorf("null tenant name")
 	}
 
 	for _, network := range tenant.Networks {
 		if network.Name == "" {
-			errors.New("null network name")
+			core.Errorf("null network name")
 		}
 
 		err = checkPktTagType(network.PktTagType)
@@ -436,7 +435,7 @@ func validateNetworkConfig(tenant *ConfigTenant) error {
 
 		if network.DefaultGw != "" {
 			if net.ParseIP(network.DefaultGw) == nil {
-				return errors.New("invalid IP")
+				return core.Errorf("invalid IP")
 			}
 		}
 	}
@@ -516,7 +515,7 @@ func CreateNetworks(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 		} else if nwMasterCfg.PktTagType == "vxlan" {
 			// XXX: take local vlan as config, instead of allocating it
 			// independently. Return erro for now, if user tries this config
-			return &core.Error{Desc: "Not handled. Need to introduce local-vlan config"}
+			return core.Errorf("Not handled. Need to introduce local-vlan config")
 			nwCfg.PktTag = int(pktTag)
 			nwCfg.ExtPktTag, _ = strconv.Atoi(nwMasterCfg.PktTag)
 		} else if nwMasterCfg.PktTagType == "vlan" {
@@ -705,17 +704,17 @@ func validateEndpointConfig(stateDriver core.StateDriver, tenant *ConfigTenant) 
 	var err error
 
 	if tenant.Name == "" {
-		return errors.New("null tenant name")
+		return core.Errorf("null tenant name")
 	}
 
 	for _, network := range tenant.Networks {
 		if network.Name == "" {
-			errors.New("null network name")
+			core.Errorf("null network name")
 		}
 
 		for _, ep := range network.Endpoints {
 			if ep.Container == "" {
-				return errors.New("invalid container name for the endpoint")
+				return core.Errorf("invalid container name for the endpoint")
 			}
 			if ep.IpAddress != "" {
 				nwMasterCfg := &MasterNwConfig{}
@@ -729,10 +728,10 @@ func validateEndpointConfig(stateDriver core.StateDriver, tenant *ConfigTenant) 
 				if nwMasterCfg.SubnetIp != "" {
 					log.Printf("validate: found endpoint with ip for " +
 						"auto-allocated net \n")
-					return errors.New("found ep with ip for auto-allocated net")
+					return core.Errorf("found ep with ip for auto-allocated net")
 				}
 				if net.ParseIP(ep.IpAddress) == nil {
-					return errors.New("invalid ep IP")
+					return core.Errorf("invalid ep IP")
 				}
 			}
 		}
@@ -961,10 +960,10 @@ func DeleteEndpoints(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 func validateEpBindings(epBindings *[]ConfigEp) error {
 	for _, ep := range *epBindings {
 		if ep.Host == "" {
-			return errors.New("invalid host name for the endpoint")
+			return core.Errorf("invalid host name for the endpoint")
 		}
 		if ep.Container == "" {
-			return errors.New("invalid container name for the endpoint")
+			return core.Errorf("invalid container name for the endpoint")
 		}
 	}
 

--- a/netmaster/networkstate_test.go
+++ b/netmaster/networkstate_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package netmaster
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/contiv/netplugin/core"
@@ -33,32 +32,32 @@ type testNwStateDriver struct {
 }
 
 func (d *testNwStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) Deinit() {
 }
 
 func (d *testNwStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) Read(key string) ([]byte, error) {
-	return []byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return []byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return [][]byte{}, &core.Error{Desc: "Shouldn't be called!"}
+	return [][]byte{}, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testNwStateDriver) validateKey(key string) error {
 	if key != nwCfgKey {
-		return &core.Error{Desc: fmt.Sprintf("Unexpected key. recvd: %s "+
-			"expected: %s or %s ", key, nwCfgKey)}
+		return core.Errorf("Unexpected key. recvd: %s expected: %s or %s ",
+			key, nwCfgKey)
 	} else {
 		return nil
 	}
@@ -75,12 +74,12 @@ func (d *testNwStateDriver) ReadState(key string, value core.State,
 
 func (d *testNwStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testNwStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testNwStateDriver) WriteState(key string, value core.State,

--- a/plugin/netplugin.go
+++ b/plugin/netplugin.go
@@ -17,7 +17,6 @@ package plugin
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"sync"
 
@@ -86,15 +85,14 @@ func (p *NetPlugin) InitHelper(driverRegistry map[string]DriverConfigTypes,
 		return driver, config, nil
 	} else {
 		return nil, nil,
-			&core.Error{Desc: fmt.Sprintf("Failed to find a registered driver for: %s",
-				driverName)}
+			core.Errorf("Failed to find a registered driver for: %s", driverName)
 	}
 
 }
 
 func (p *NetPlugin) Init(configStr string) error {
 	if configStr == "" {
-		return &core.Error{Desc: "empty config passed"}
+		return core.Errorf("empty config passed")
 	}
 
 	var driver core.Driver = nil
@@ -180,7 +178,7 @@ func (p *NetPlugin) DeleteNetwork(id string) error {
 }
 
 func (p *NetPlugin) FetchNetwork(id string) (core.State, error) {
-	return nil, &core.Error{Desc: "Not implemented"}
+	return nil, core.Errorf("Not implemented")
 }
 
 func (p *NetPlugin) CreateEndpoint(id string) error {
@@ -192,5 +190,5 @@ func (p *NetPlugin) DeleteEndpoint(id string) error {
 }
 
 func (p *NetPlugin) FetchEndpoint(id string) (core.State, error) {
-	return nil, &core.Error{Desc: "Not implemented"}
+	return nil, core.Errorf("Not implemented")
 }

--- a/resources/etcdresourceallocator.go
+++ b/resources/etcdresourceallocator.go
@@ -52,15 +52,14 @@ func (ra *EtcdResourceManager) findResource(id, desc string) (core.Resource, boo
 	rsrcType, ok := ResourceRegistry[desc]
 	if !ok {
 		return nil, alreadyExists,
-			&core.Error{Desc: fmt.Sprintf("No resource found for description: %q",
-				desc)}
+			core.Errorf("No resource found for description: %q", desc)
 	}
 
 	val := reflect.New(rsrcType)
 	// sanity checks
 	if !val.Elem().FieldByName("CommonState").IsValid() {
 		panic(fmt.Sprintf("The state structure %v is missing core.CommonState", rsrcType))
-		return nil, false, &core.Error{Desc: fmt.Sprintf("The state structure %v is missing core.CommonState", rsrcType)}
+		return nil, false, core.Errorf("The state structure %v is missing core.CommonState", rsrcType)
 	}
 	//the following works as every core.State is expected to embed core.CommonState struct
 	val.Elem().FieldByName("CommonState").FieldByName("StateDriver").Set(reflect.ValueOf(ra.Etcd))
@@ -95,8 +94,7 @@ func (ra *EtcdResourceManager) DefineResource(id, desc string,
 	}
 
 	if alreadyExists {
-		return &core.Error{Desc: fmt.Sprintf("Resource with id: %q already exists",
-			id)}
+		return core.Errorf("Resource with id: %q already exists", id)
 	}
 
 	err = rsrc.Init(rsrcCfg)
@@ -115,8 +113,8 @@ func (ra *EtcdResourceManager) UndefineResource(id, desc string) error {
 	}
 
 	if !alreadyExists {
-		return &core.Error{Desc: fmt.Sprintf("No resource found for description: %q and id: %q",
-			desc, id)}
+		return core.Errorf("No resource found for description: %q and id: %q",
+			desc, id)
 	}
 
 	rsrc.Deinit()
@@ -133,8 +131,8 @@ func (ra *EtcdResourceManager) AllocateResourceVal(id, desc string) (interface{}
 	}
 
 	if !alreadyExists {
-		return nil, &core.Error{Desc: fmt.Sprintf("No resource found for description: %q and id: %q",
-			desc, id)}
+		return nil, core.Errorf("No resource found for description: %q and id: %q",
+			desc, id)
 	}
 
 	return rsrc.Allocate()
@@ -149,8 +147,8 @@ func (ra *EtcdResourceManager) DeallocateResourceVal(id, desc string,
 	}
 
 	if !alreadyExists {
-		return &core.Error{Desc: fmt.Sprintf("No resource found for description: %q and id: %q",
-			desc, id)}
+		return core.Errorf("No resource found for description: %q and id: %q",
+			desc, id)
 	}
 
 	return rsrc.Deallocate(value)

--- a/resources/etcdresourceallocator_test.go
+++ b/resources/etcdresourceallocator_test.go
@@ -18,6 +18,7 @@ package resources
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/contiv/netplugin/core"
@@ -39,15 +40,15 @@ type TestResource struct {
 }
 
 func (r *TestResource) Write() error {
-	return &core.Error{Desc: "Shouldn't be called"}
+	return core.Errorf("Shouldn't be called")
 }
 
 func (r *TestResource) Read(id string) error {
-	return &core.Error{Desc: "Shouldn't be called"}
+	return core.Errorf("Shouldn't be called")
 }
 
 func (r *TestResource) Clear() error {
-	return &core.Error{Desc: "Shouldn't be called"}
+	return core.Errorf("Shouldn't be called")
 }
 
 func (r *TestResource) ReadAll() ([]core.State, error) {
@@ -100,8 +101,8 @@ func TestEtcdResourceManagerDefineInvalidResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource definition succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q",
-		testResourceDesc) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q", testResourceDesc)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }
@@ -131,8 +132,8 @@ func TestEtcdResourceManagerUndefineInvalidResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource un-definition succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q",
-		testResourceDesc) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q", testResourceDesc)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }
@@ -147,8 +148,9 @@ func TestEtcdResourceManagerUndefineNonexistentResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource un-definition succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q and id: %q",
-		testResourceDesc, testResourceId) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q and id: %q",
+			testResourceDesc, testResourceId)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }
@@ -178,8 +180,8 @@ func TestEtcdResourceManagerAllocateInvalidResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q",
-		testResourceDesc) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q", testResourceDesc)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }
@@ -194,8 +196,9 @@ func TestEtcdResourceManagerAllocateiNonexistentResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q and id: %q",
-		testResourceDesc, testResourceId) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q and id: %q",
+			testResourceDesc, testResourceId)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }
@@ -230,8 +233,8 @@ func TestEtcdResourceManagerDeallocateInvalidResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource deallocation succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q",
-		testResourceDesc) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q", testResourceDesc)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }
@@ -246,8 +249,9 @@ func TestEtcdResourceManagerDeallocateiNonexistentResource(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != fmt.Sprintf("No resource found for description: %q and id: %q",
-		testResourceDesc, testResourceId) {
+	if !strings.Contains(err.Error(),
+		fmt.Sprintf("No resource found for description: %q and id: %q",
+			testResourceDesc, testResourceId)) {
 		t.Fatalf("Unexpected error. Error: %s", err)
 	}
 }

--- a/resources/subnetresource.go
+++ b/resources/subnetresource.go
@@ -76,14 +76,14 @@ func (r *AutoSubnetCfgResource) ReadAll() ([]core.State, error) {
 func (r *AutoSubnetCfgResource) Init(rsrcCfg interface{}) error {
 	cfg, ok := rsrcCfg.(*AutoSubnetCfgResource)
 	if !ok {
-		return &core.Error{Desc: "Invalid type for subnet resource config"}
+		return core.Errorf("Invalid type for subnet resource config")
 	}
 	r.SubnetPool = cfg.SubnetPool
 	r.SubnetPoolLen = cfg.SubnetPoolLen
 	r.AllocSubnetLen = cfg.AllocSubnetLen
 
 	if cfg.AllocSubnetLen < cfg.SubnetPoolLen {
-		return &core.Error{Desc: "AllocSubnetLen should be greater than or equal to SubnetPoolLen"}
+		return core.Errorf("AllocSubnetLen should be greater than or equal to SubnetPoolLen")
 	}
 
 	err := r.Write()
@@ -138,7 +138,7 @@ func (r *AutoSubnetCfgResource) Allocate() (interface{}, error) {
 
 	subnet, ok := oper.FreeSubnets.NextSet(0)
 	if !ok {
-		return nil, &core.Error{Desc: "no subnets available."}
+		return nil, core.Errorf("no subnets available.")
 	}
 
 	oper.FreeSubnets.Clear(subnet)
@@ -168,12 +168,12 @@ func (r *AutoSubnetCfgResource) Deallocate(value interface{}) error {
 
 	pair, ok := value.(SubnetIpLenPair)
 	if !ok {
-		return &core.Error{Desc: "Invalid type for subnet value"}
+		return core.Errorf("Invalid type for subnet value")
 	}
 
 	if pair.Len != r.AllocSubnetLen {
-		return &core.Error{Desc: fmt.Sprintf("Invalid subnet length. Exp: %d Rcvd: %d",
-			r.AllocSubnetLen, pair.Len)}
+		return core.Errorf("Invalid subnet length. Exp: %d Rcvd: %d",
+			r.AllocSubnetLen, pair.Len)
 	}
 
 	var subnet uint

--- a/resources/subnetresource_test.go
+++ b/resources/subnetresource_test.go
@@ -85,7 +85,7 @@ func (vt *subnetRsrcValidator) ValidateState(state core.State) error {
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown state object type!"}
+	return core.Errorf("unknown state object type!")
 }
 
 func (vt *subnetRsrcValidator) CopyState(state core.State) error {
@@ -107,7 +107,7 @@ func (vt *subnetRsrcValidator) CopyState(state core.State) error {
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown state object type!"}
+	return core.Errorf("unknown state object type!")
 }
 
 type subnetRsrcValidateOp int
@@ -251,26 +251,26 @@ type testSubnetRsrcStateDriver struct {
 }
 
 func (d *testSubnetRsrcStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testSubnetRsrcStateDriver) Deinit() {
 }
 
 func (d *testSubnetRsrcStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testSubnetRsrcStateDriver) Read(key string) ([]byte, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testSubnetRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testSubnetRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testSubnetRsrcStateDriver) validate(key string, state core.State,
@@ -281,7 +281,7 @@ func (d *testSubnetRsrcStateDriver) validate(key string, state core.State,
 	if !ok {
 		errStr := fmt.Sprintf("No matching validation entry for id: %s", id)
 		log.Printf("%s\n", errStr)
-		return &core.Error{Desc: errStr}
+		return core.Errorf(errStr)
 	}
 
 	switch op {
@@ -311,12 +311,12 @@ func (d *testSubnetRsrcStateDriver) ReadState(key string, value core.State,
 
 func (d *testSubnetRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testSubnetRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testSubnetRsrcStateDriver) WriteState(key string, value core.State,
@@ -383,7 +383,8 @@ func TestAutoSubnetCfgResourceAllocateExhaustion(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Subnet resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != "no subnets available." {
+	if !strings.Contains(err.Error(),
+		"no subnets available.") {
 		t.Fatalf("Subnet resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
 			"no subnets available.", err)
 	}

--- a/resources/vlanresource.go
+++ b/resources/vlanresource.go
@@ -68,7 +68,7 @@ func (r *AutoVlanCfgResource) Init(rsrcCfg interface{}) error {
 	var ok bool
 	r.Vlans, ok = rsrcCfg.(*bitset.BitSet)
 	if !ok {
-		return &core.Error{Desc: "Invalid type for vlan resource config"}
+		return core.Errorf("Invalid type for vlan resource config")
 	}
 	err := r.Write()
 	if err != nil {
@@ -121,7 +121,7 @@ func (r *AutoVlanCfgResource) Allocate() (interface{}, error) {
 
 	vlan, ok := oper.FreeVlans.NextSet(0)
 	if !ok {
-		return nil, &core.Error{Desc: "no vlans available."}
+		return nil, core.Errorf("no vlans available.")
 	}
 
 	oper.FreeVlans.Clear(vlan)
@@ -143,7 +143,7 @@ func (r *AutoVlanCfgResource) Deallocate(value interface{}) error {
 
 	vlan, ok := value.(uint)
 	if !ok {
-		return &core.Error{Desc: "Invalid type for vlan value"}
+		return core.Errorf("Invalid type for vlan value")
 	}
 	if oper.FreeVlans.Test(vlan) {
 		return nil

--- a/resources/vlanresource_test.go
+++ b/resources/vlanresource_test.go
@@ -82,7 +82,7 @@ func (vt *vlanRsrcValidator) ValidateState(state core.State) error {
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown state object type!"}
+	return core.Errorf("unknown state object type!")
 }
 
 func (vt *vlanRsrcValidator) CopyState(state core.State) error {
@@ -102,7 +102,7 @@ func (vt *vlanRsrcValidator) CopyState(state core.State) error {
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown state object type!"}
+	return core.Errorf("unknown state object type!")
 }
 
 type vlanRsrcValidateOp int
@@ -228,26 +228,26 @@ type testVlanRsrcStateDriver struct {
 }
 
 func (d *testVlanRsrcStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVlanRsrcStateDriver) Deinit() {
 }
 
 func (d *testVlanRsrcStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVlanRsrcStateDriver) Read(key string) ([]byte, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVlanRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVlanRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testVlanRsrcStateDriver) validate(key string, state core.State,
@@ -258,7 +258,7 @@ func (d *testVlanRsrcStateDriver) validate(key string, state core.State,
 	if !ok {
 		errStr := fmt.Sprintf("No matching validation entry for id: %s", id)
 		log.Printf("%s\n", errStr)
-		return &core.Error{Desc: errStr}
+		return core.Errorf(errStr)
 	}
 
 	switch op {
@@ -288,12 +288,12 @@ func (d *testVlanRsrcStateDriver) ReadState(key string, value core.State,
 
 func (d *testVlanRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVlanRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testVlanRsrcStateDriver) WriteState(key string, value core.State,
@@ -358,7 +358,7 @@ func TestAutoVlanCfgResourceAllocateExhaustion(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Vlan resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != "no vlans available." {
+	if !strings.Contains(err.Error(), "no vlans available.") {
 		t.Fatalf("Vlan resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
 			"no vlans available.", err)
 	}

--- a/resources/vxlanresource.go
+++ b/resources/vxlanresource.go
@@ -73,7 +73,7 @@ func (r *AutoVxlanCfgResource) ReadAll() ([]core.State, error) {
 func (r *AutoVxlanCfgResource) Init(rsrcCfg interface{}) error {
 	cfg, ok := rsrcCfg.(*AutoVxlanCfgResource)
 	if !ok {
-		return &core.Error{Desc: "Invalid vxlan resource config."}
+		return core.Errorf("Invalid vxlan resource config.")
 	}
 	r.Vxlans = cfg.Vxlans
 	r.LocalVlans = cfg.LocalVlans
@@ -128,12 +128,12 @@ func (r *AutoVxlanCfgResource) Allocate() (interface{}, error) {
 
 	vxlan, ok := oper.FreeVxlans.NextSet(0)
 	if !ok {
-		return nil, &core.Error{Desc: "no vxlans available."}
+		return nil, core.Errorf("no vxlans available.")
 	}
 
 	vlan, ok := oper.FreeLocalVlans.NextSet(0)
 	if !ok {
-		return nil, &core.Error{Desc: "no local vlans available."}
+		return nil, core.Errorf("no local vlans available.")
 	}
 
 	oper.FreeVxlans.Clear(vxlan)
@@ -156,7 +156,7 @@ func (r *AutoVxlanCfgResource) Deallocate(value interface{}) error {
 
 	pair, ok := value.(VxlanVlanPair)
 	if !ok {
-		return &core.Error{Desc: "Invalid type for vxlan-vlan pair"}
+		return core.Errorf("Invalid type for vxlan-vlan pair")
 	}
 	vxlan := pair.Vxlan
 	oper.FreeVxlans.Set(vxlan)

--- a/resources/vxlanresource_test.go
+++ b/resources/vxlanresource_test.go
@@ -84,7 +84,7 @@ func (vt *vxlanRsrcValidator) ValidateState(state core.State) error {
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown state object type!"}
+	return core.Errorf("unknown state object type!")
 }
 
 func (vt *vxlanRsrcValidator) CopyState(state core.State) error {
@@ -106,7 +106,7 @@ func (vt *vxlanRsrcValidator) CopyState(state core.State) error {
 		return nil
 	}
 
-	return &core.Error{Desc: "unknown state object type!"}
+	return core.Errorf("unknown state object type!")
 }
 
 type vxlanRsrcValidateOp int
@@ -272,26 +272,26 @@ type testVxlanRsrcStateDriver struct {
 }
 
 func (d *testVxlanRsrcStateDriver) Init(config *core.Config) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVxlanRsrcStateDriver) Deinit() {
 }
 
 func (d *testVxlanRsrcStateDriver) Write(key string, value []byte) error {
-	return &core.Error{Desc: "Shouldn't be called!"}
+	return core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVxlanRsrcStateDriver) Read(key string) ([]byte, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVxlanRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVxlanRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testVxlanRsrcStateDriver) validate(key string, state core.State,
@@ -302,7 +302,7 @@ func (d *testVxlanRsrcStateDriver) validate(key string, state core.State,
 	if !ok {
 		errStr := fmt.Sprintf("No matching validation entry for id: %s", id)
 		log.Printf("%s\n", errStr)
-		return &core.Error{Desc: errStr}
+		return core.Errorf(errStr)
 	}
 
 	switch op {
@@ -332,12 +332,12 @@ func (d *testVxlanRsrcStateDriver) ReadState(key string, value core.State,
 
 func (d *testVxlanRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
-	return nil, &core.Error{Desc: "Shouldn't be called!"}
+	return nil, core.Errorf("Shouldn't be called!")
 }
 
 func (d *testVxlanRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
-	return &core.Error{Desc: "not supported"}
+	return core.Errorf("not supported")
 }
 
 func (d *testVxlanRsrcStateDriver) WriteState(key string, value core.State,
@@ -399,7 +399,7 @@ func TestAutoVxlanCfgResourceAllocateVxlanExhaustion(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Vxlan resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != "no vxlans available." {
+	if !strings.Contains(err.Error(), "no vxlans available.") {
 		t.Fatalf("Vxlan resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
 			"no vxlans available.", err)
 	}
@@ -418,7 +418,7 @@ func TestAutoVxlanCfgResourceAllocateVlanExhaustion(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Vxlan resource allocation succeeded, expected to fail!")
 	}
-	if err.Error() != "no local vlans available." {
+	if !strings.Contains(err.Error(), "no local vlans available.") {
 		t.Fatalf("Vxlan resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
 			"no local vlans available.", err)
 	}

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -15,6 +15,7 @@ test_packages="github.com/contiv/netplugin/drivers \
     github.com/contiv/netplugin/gstate \
     github.com/contiv/netplugin/netmaster \
     github.com/contiv/netplugin/resources \
+    github.com/contiv/netplugin/core \
     "
 
 while [ "${#}" -gt 0 ]

--- a/systemtests/utils/tempfile.go
+++ b/systemtests/utils/tempfile.go
@@ -29,7 +29,7 @@ type TempFileCtx struct {
 
 func (ctx *TempFileCtx) Create(fileContents string) (*os.File, error) {
 	if ctx.dir != "" && len(ctx.files) != 0 {
-		return nil, &core.Error{Desc: "Create context called for an already created context!"}
+		return nil, core.Errorf("Create context called for an already created context!")
 	}
 
 	dir, err := ioutil.TempDir("", "netp_tests")

--- a/systemtests/utils/utils.go
+++ b/systemtests/utils/utils.go
@@ -17,7 +17,6 @@ package utils
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -25,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/netmaster"
 )
 
@@ -313,7 +313,7 @@ func NetworkStateExists(node TestbedNode, network string) error {
 		return err
 	}
 	if string(output) == "" {
-		return errors.New("got null output")
+		return core.Errorf("got null output")
 	}
 	return nil
 }

--- a/systemtests/utils/vagrant.go
+++ b/systemtests/utils/vagrant.go
@@ -16,7 +16,6 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -58,7 +57,8 @@ func (v *Vagrant) Setup(env string, numNodes int) error {
 	}
 	nodeNamesBytes := re.FindAll(output, -1)
 	if nodeNamesBytes == nil {
-		err = &core.Error{Desc: fmt.Sprintf("No running nodes found in vagrant status output: \n%s\n", output)}
+		err = core.Errorf("No running nodes found in vagrant status output: \n%s\n",
+			output)
 		return err
 	}
 	nodeNames := []string{}
@@ -67,8 +67,8 @@ func (v *Vagrant) Setup(env string, numNodes int) error {
 		nodeNames = append(nodeNames, nodeName)
 	}
 	if len(nodeNames) != numNodes {
-		err = &core.Error{Desc: fmt.Sprintf("Number of running node(s) (%d) is not equal to number of expected node(s) (%d) in vagrant status output: \n%s\n",
-			len(nodeNames), numNodes, output)}
+		err = core.Errorf("Number of running node(s) (%d) is not equal to number of expected node(s) (%d) in vagrant status output: \n%s\n",
+			len(nodeNames), numNodes, output)
 		return err
 	}
 


### PR DESCRIPTION
Use core.Error interface throughout the code for consistency and to allow making use of the features provided by this interface now and in future.

Signed-off-by: Madhav Puri <madhav.puri@gmail.com>