### PR TITLE
Handle stateful restart of ovs network driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ unit-test: build
 system-test: build
 	CONTIV_HOST_GOPATH=$(GOPATH) godep go test -v -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/singlehost 
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 20m -v -run "sanity" \
+	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -v -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
 # setting CONTIV_SOE=1 while calling 'make regress-test' will stop the test

--- a/core/core.go
+++ b/core/core.go
@@ -58,6 +58,11 @@ type Plugin interface {
 	Endpoint
 }
 
+type InstanceInfo struct {
+	StateDriver StateDriver `json:"-"`
+	HostLabel   string      `json:"host-label"`
+}
+
 type Driver interface {
 	// A driver implements the programming logic
 }
@@ -65,7 +70,7 @@ type Driver interface {
 type NetworkDriver interface {
 	// A network driver implements the programming logic for network
 	Driver
-	Init(config *Config, stateDriver StateDriver) error
+	Init(config *Config, info *InstanceInfo) error
 	Deinit()
 	CreateNetwork(id string) error
 	DeleteNetwork(id string) error
@@ -74,7 +79,7 @@ type NetworkDriver interface {
 type EndpointDriver interface {
 	// An endpoint driver implements the programming logic for endpoints
 	Driver
-	Init(config *Config, stateDriver StateDriver) error
+	Init(config *Config, info *InstanceInfo) error
 	Deinit()
 	CreateEndpoint(id string) error
 	DeleteEndpoint(id string) error

--- a/drivers/ovsendpointstate.go
+++ b/drivers/ovsendpointstate.go
@@ -72,6 +72,17 @@ type OvsOperEndpointState struct {
 	VtepIp     string `json:'vtepIP"`
 }
 
+func (s *OvsOperEndpointState) Matches(c *OvsCfgEndpointState) bool {
+	// match the fields updated from configuration state
+	return s.NetId == c.NetId &&
+		s.ContName == c.ContName &&
+		s.AttachUUID == c.AttachUUID &&
+		s.IpAddress == c.IpAddress &&
+		s.HomingHost == c.HomingHost &&
+		s.IntfName == c.IntfName &&
+		s.VtepIp == c.VtepIp
+}
+
 func (s *OvsOperEndpointState) Write() error {
 	key := fmt.Sprintf(EP_OPER_PATH, s.Id)
 	return s.StateDriver.WriteState(key, s, json.Marshal)

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bufio"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -502,27 +503,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	defConfigStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
-                       "state": "etcd"
-                    },
-                    "ovs" : {
-                       "dbip": "127.0.0.1",
-                       "dbport": 6640
-                    },
-                    "etcd" : {
-                        "machines": ["http://127.0.0.1:4001"]
-                    },
-                    "crt" : {
-                       "type": "docker"
-                    },
-                    "docker" : {
-                        "socket" : "unix:///var/run/docker.sock"
-                    }
-                  }`
-
 	flagSet = flag.NewFlagSet("netd", flag.ExitOnError)
 	flagSet.StringVar(&opts.hostLabel,
 		"host-label",
@@ -545,6 +525,30 @@ func main() {
 	if flagSet.NFlag() < 1 {
 		log.Printf("host-label not specified, using default (%s)", opts.hostLabel)
 	}
+
+	defConfigStr := fmt.Sprintf(`{
+                    "drivers" : {
+                       "network": "ovs",
+                       "endpoint": "ovs",
+                       "state": "etcd"
+                    },
+                    "plugin-instance": {
+                       "host-label": "%s"
+                    },
+                    "ovs" : {
+                       "dbip": "127.0.0.1",
+                       "dbport": 6640
+                    },
+                    "etcd" : {
+                        "machines": ["http://127.0.0.1:4001"]
+                    },
+                    "crt" : {
+                       "type": "docker"
+                    },
+                    "docker" : {
+                        "socket" : "unix:///var/run/docker.sock"
+                    }
+                  }`, opts.hostLabel)
 
 	netPlugin := &plugin.NetPlugin{}
 

--- a/state/fakestatedriver.go
+++ b/state/fakestatedriver.go
@@ -14,6 +14,9 @@ type ValueData struct {
 	value []byte
 }
 
+type FakeStateDriverConfig struct {
+}
+
 type FakeStateDriver struct {
 	TestState map[string]ValueData
 }

--- a/systemtests/utils/utils.go
+++ b/systemtests/utils/utils.go
@@ -59,8 +59,14 @@ func ConfigCleanupCommon(t *testing.T, nodes []TestbedNode) {
 			t.Errorf("Failed to cleanup the left over test case state. Error: %s\nCmd: %q\nOutput:\n%s\n",
 				err, cmdStr, output)
 		}
-		//XXX: remove this once netplugin is capable of handling cleanup
-		cmdStr = "sudo pkill netplugin"
+	}
+	//XXX: remove this once netplugin is capable of handling cleanup
+	StopNetPlugin(t, nodes)
+}
+
+func StopNetPlugin(t *testing.T, nodes []TestbedNode) {
+	for _, node := range nodes {
+		cmdStr := "sudo pkill netplugin"
 		node.RunCommand(cmdStr)
 	}
 }


### PR DESCRIPTION
- restore ovs driver's oper state on a stateful restart to preserve port-number information
- On getting endpoint create check if an oper state for the endpoint already exists. If it exists and doesn't match the received config then unprogram the stale info before proceeding with handling the create. The CreateEndpoint call becomes a noop if the configuration matches the oper state.
- This enables the stateful restart of the driver but following condition is not yet handled:
  - changing the host binding of the endpoint while the driver was down, which may leave stale state on the previous host.
- Added tests for this change.

Fixes #47 

Signed-off-by: Madhav Puri <madhav.puri@gmail.com>