### PR TITLE
Reorganize drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 #ide files
 *.swp
+
+# vagrant
+.vagrant

--- a/gstate/gstate_test.go
+++ b/gstate/gstate_test.go
@@ -18,13 +18,13 @@ package gstate
 import (
 	"testing"
 
-	"github.com/contiv/netplugin/drivers"
 	"github.com/contiv/netplugin/resources"
+	"github.com/contiv/netplugin/state"
 )
 
 var (
 	gstateTestRA = &resources.EtcdResourceManager{Etcd: gstateSD}
-	gstateSD     = &drivers.FakeStateDriver{}
+	gstateSD     = &state.FakeStateDriver{}
 )
 
 func TestGlobalConfigAutoVlans(t *testing.T) {

--- a/netdcli/cfg.go
+++ b/netdcli/cfg.go
@@ -27,6 +27,7 @@ import (
 	"github.com/contiv/netplugin/drivers"
 	"github.com/contiv/netplugin/gstate"
 	"github.com/contiv/netplugin/netmaster"
+	"github.com/contiv/netplugin/state"
 )
 
 func getEpName(net *netmaster.ConfigNetwork, ep *netmaster.ConfigEp) string {
@@ -250,11 +251,11 @@ func processDeletions(stateDriver core.StateDriver, allCfg *netmaster.Config) (e
 }
 
 func initEtcd(defOpts *cliOpts) (core.StateDriver, error) {
-	driverConfig := &drivers.EtcdStateDriverConfig{}
+	driverConfig := &state.EtcdStateDriverConfig{}
 	driverConfig.Etcd.Machines = []string{defOpts.etcdUrl}
 	config := &core.Config{V: driverConfig}
 
-	etcdDriver := &drivers.EtcdStateDriver{}
+	etcdDriver := &state.EtcdStateDriver{}
 	err := etcdDriver.Init(config)
 	if err != nil {
 		log.Printf("error '%s' initializing etcd \n", err)

--- a/netmaster/netmaster_test.go
+++ b/netmaster/netmaster_test.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/contiv/netplugin/drivers"
+	"github.com/contiv/netplugin/state"
 )
 
-var fakeDriver = &drivers.FakeStateDriver{}
+var fakeDriver = &state.FakeStateDriver{}
 
 func applyConfig(t *testing.T, cfgBytes []byte) {
 	cfg := &Config{}

--- a/plugin/netplugin.go
+++ b/plugin/netplugin.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/drivers"
+	"github.com/contiv/netplugin/state"
 )
 
 // implements the generic Plugin interface
@@ -47,8 +48,8 @@ var EndpointDriverRegistry = map[string]DriverConfigTypes{
 
 var StateDriverRegistry = map[string]DriverConfigTypes{
 	"etcd": DriverConfigTypes{
-		DriverType: reflect.TypeOf(drivers.EtcdStateDriver{}),
-		ConfigType: reflect.TypeOf(drivers.EtcdStateDriverConfig{}),
+		DriverType: reflect.TypeOf(state.EtcdStateDriver{}),
+		ConfigType: reflect.TypeOf(state.EtcdStateDriverConfig{}),
 	},
 }
 

--- a/resources/etcdresourceallocator_test.go
+++ b/resources/etcdresourceallocator_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/contiv/netplugin/core"
-	"github.com/contiv/netplugin/drivers"
+	"github.com/contiv/netplugin/state"
 )
 
 const (
@@ -79,7 +79,7 @@ func (r *TestResource) Deallocate(value interface{}) error {
 	return nil
 }
 
-var fakeDriver = &drivers.FakeStateDriver{}
+var fakeDriver = &state.FakeStateDriver{}
 
 func TestEtcdResourceManagerDefineResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}

--- a/state/etcdstatedriver.go
+++ b/state/etcdstatedriver.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package state
 
 import (
 	"fmt"

--- a/state/etcdstatedriver_test.go
+++ b/state/etcdstatedriver_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package state
 
 import (
 	"bytes"

--- a/state/fakestatedriver.go
+++ b/state/fakestatedriver.go
@@ -1,4 +1,4 @@
-package drivers
+package state
 
 import (
 	"log"


### PR DESCRIPTION
This pushes most of the state drivers into `drivers/state`. There is also a small patch to ignore `.vagrant` directories that might live inside the repository. PTAL