### PR TITLE
scripts/unittests: Quicker feedback for failed test builds.

### DIFF
--- a/scripts/unittests
+++ b/scripts/unittests
@@ -54,8 +54,12 @@ if ${run_in_vagrant}; then
     exit 0
 fi
 
-# running in the sand box
-(cd $GOSRC/github.com/contiv/netplugin && \
- godep go test -v $test_packages) || exit 1
+for pkg in ${test_packages}
+do
+  # running in the sand box
+  (cd $GOSRC/github.com/contiv/netplugin && \
+  godep go test -v ${pkg}) || exit 1
+done
+
 echo "Sandbox: Tests succeeded!"
 exit 0


### PR DESCRIPTION
Somewhat Opinionated but... 

Noticed this while moving `drivers`. Now, any test failure, including build errors, will stop the VM immediately. I found that it was hard to quickly judge if the test had succeeded or not.

No need to merge it if it's not popular, I just thought this was a good idea.