### PR TITLE
Second pass of fixing linting errors

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -13,45 +13,44 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package core
-
 // The package 'core' provides definition for a generic interface that helps
 // provision networking for an endpoint (like a container,
 // a vm or a bare-metal host). The interface is invoked (north-bound) by the
 // 'daemon' or the extension-plugin (TBD) part of docker. The interface in
 // turn invokes (south-bound) a driver-interface that provides
 // hardware/kernel/device specific programming implementation, if any.
+package core
 
+// Address is a string represenation of a network address (mac, ip, dns-name, url etc)
 type Address struct {
-	// A string represenation of a network address (mac, ip, dns-name, url etc)
 	addr string
 }
 
+// Config object parsed from a json styled config
 type Config struct {
-	// Config object parsed from a json styled config
 	V interface{}
 }
 
+// Network identifies a group of (addressable) endpoints that can
+// comunicate.
 type Network interface {
-	// A network identifies a group of (addressable) endpoints that can
-	// comunicate.
 	CreateNetwork(id string) error
 	DeleteNetwork(id string) error
 	FetchNetwork(id string) (State, error)
 }
 
+// Endpoint identifies an addressable entity in a network. An endpoint
+// belongs to a single network.
 type Endpoint interface {
-	// An endpoint identifies an addressable entity in a network. An endpoint
-	// belongs to a single network.
 	CreateEndpoint(id string) error
 	DeleteEndpoint(id string) error
 	FetchEndpoint(id string) (State, error)
 }
 
+// Plugin brings together an implementation of a network, endpoint and
+// state drivers. Along with implementing north-bound interfaces for
+// network and endpoint operations
 type Plugin interface {
-	// A plugin brings together an implementation of a network, endpoint and
-	// state drivers. Along with implementing north-bound interfaces for
-	// network and endpoint operations
 	Init(configStr string) error
 	Deinit()
 	Network
@@ -63,12 +62,11 @@ type InstanceInfo struct {
 	HostLabel   string      `json:"host-label"`
 }
 
-type Driver interface {
-	// A driver implements the programming logic
-}
+// Driver implements the programming logic
+type Driver interface{}
 
+// NetworkDriver implements the programming logic for network
 type NetworkDriver interface {
-	// A network driver implements the programming logic for network
 	Driver
 	Init(config *Config, info *InstanceInfo) error
 	Deinit()
@@ -76,8 +74,8 @@ type NetworkDriver interface {
 	DeleteNetwork(id string) error
 }
 
+// EndpointDriver implements the programming logic for endpoints
 type EndpointDriver interface {
-	// An endpoint driver implements the programming logic for endpoints
 	Driver
 	Init(config *Config, info *InstanceInfo) error
 	Deinit()
@@ -91,12 +89,12 @@ type WatchState struct {
 	Prev State
 }
 
+// StateDriver provides the mechanism for reading/writing state for networks,
+// endpoints and meta-data managed by the core. The state is assumed to be
+// stored as key-value pairs with keys of type 'string' and value to be an
+// opaque binary string, encoded/decoded by the logic specific to the
+// high-level(consumer) interface.
 type StateDriver interface {
-	// A state driver provides mechanism for reading/writing state for networks,
-	// endpoints and meta-data managed by the core. The state is assumed to be
-	// stored as key-value pairs with keys of type 'string' and value to be an
-	// opaque binary string, encoded/decoded by the logic specific to the
-	// high-level(consumer) interface.
 	Driver
 	Init(config *Config) error
 	Deinit()
@@ -119,9 +117,9 @@ type StateDriver interface {
 	ClearState(key string) error
 }
 
+// Resource defines a allocatable unit. A resource is uniquely identified
+// by 'ID'. A resource description identifies the nature of the resource.
 type Resource interface {
-	// Resource defines a allocatable unit. A resource is uniquely identified
-	// by 'ID'. A resource description identifies the nature of the resource.
 	State
 	Init(rsrcCfg interface{}) error
 	Deinit()
@@ -130,10 +128,10 @@ type Resource interface {
 	Deallocate(interface{}) error
 }
 
+// ResourceManager provides mechanism to manage (define/undefine,
+// allocate/deallocate) resources. Example, it may provide management in
+// logically centralized manner in a distributed system
 type ResourceManager interface {
-	// A resource manager provides mechanism to manage (define/undefine,
-	// allocate/deallocate) resources. Example, it may provide management in
-	// logically centralized manner in a distributed system
 	Init() error
 	Deinit()
 	DefineResource(id, desc string, rsrcCfg interface{}) error

--- a/crt/crt_test.go
+++ b/crt/crt_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func TestCrtInit(t *testing.T) {
+func TestCRTInit(t *testing.T) {
 	configStr := `{
                     "docker" : {
                         "socket" : "unix:///var/run/docker.sock"
@@ -28,7 +28,7 @@ func TestCrtInit(t *testing.T) {
                         "type": "docker"
                     }
                   }`
-	crt := Crt{}
+	crt := CRT{}
 	err := crt.Init(configStr)
 	if err != nil {
 		t.Fatalf("crt init failed: Error: %s", err)
@@ -36,39 +36,39 @@ func TestCrtInit(t *testing.T) {
 	defer func() { crt.Deinit() }()
 }
 
-func TestCrtInitInvalidConfigMissingCrt(t *testing.T) {
+func TestCRTInitInvalidConfigMissingCRT(t *testing.T) {
 	configStr := `{
                     "docker" : {
                         "socket" : "unix:///var/run/docker.sock"
                     }
                   }`
-	crt := Crt{}
+	crt := CRT{}
 	err := crt.Init(configStr)
 	if err == nil {
 		t.Fatalf("crt init succeeded!")
 	}
 }
 
-func TestCrtInitInvalidConfigMissingCrtIf(t *testing.T) {
+func TestCRTInitInvalidConfigMissingCRTIf(t *testing.T) {
 	configStr := `{
                     "crt" : {
                         "type": "docker"
                     }
                   }`
-	crt := Crt{}
+	crt := CRT{}
 	err := crt.Init(configStr)
 	if err == nil {
 		t.Fatalf("crt init succeeded!")
 	}
 }
 
-func TestCrtInitInvalidConfigInvalidCrt(t *testing.T) {
+func TestCRTInitInvalidConfigInvalidCRT(t *testing.T) {
 	configStr := `{
                     "crt" : {
                         "type": "rocket"
                     }
                   }`
-	crt := Crt{}
+	crt := CRT{}
 	err := crt.Init(configStr)
 	if err == nil {
 		t.Fatalf("crt init succeeded!")

--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -101,6 +101,7 @@ func (d *OvsDriver) populateCache(updates libovsdb.TableUpdates) {
 	}
 }
 
+// Update updates the ovsdb with the libovsdb.TableUpdates.
 func (d *OvsDriver) Update(context interface{}, tableUpdates libovsdb.TableUpdates) {
 	d.populateCache(tableUpdates)
 }

--- a/gstate/gstate_test.go
+++ b/gstate/gstate_test.go
@@ -27,7 +27,7 @@ var (
 	gstateSD     = &state.FakeStateDriver{}
 )
 
-func TestGlobalConfigAutoVlans(t *testing.T) {
+func TestGlobalConfigAutoVLANs(t *testing.T) {
 	cfgData := []byte(`
         {
             "Version" : "0.01",
@@ -36,8 +36,8 @@ func TestGlobalConfigAutoVlans(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "1-10",
-                "Vxlans"            : "15000-17000"
+                "VLANs"             : "1-10",
+                "VXLANs"            : "15000-17000"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vlan"
@@ -61,7 +61,7 @@ func TestGlobalConfigAutoVlans(t *testing.T) {
 		t.Fatalf("error '%s' processing config %v \n", err, gc)
 	}
 
-	vlan, err = gc.AllocVlan(gstateTestRA)
+	vlan, err = gc.AllocVLAN(gstateTestRA)
 	if err != nil {
 		t.Fatalf("error - allocating vlan - %s \n", err)
 	}
@@ -72,13 +72,13 @@ func TestGlobalConfigAutoVlans(t *testing.T) {
 		t.Fatalf("error - expecting vlan %d but allocated %d \n", 1, vlan)
 	}
 
-	err = gc.FreeVlan(gstateTestRA, vlan)
+	err = gc.FreeVLAN(gstateTestRA, vlan)
 	if err != nil {
 		t.Fatalf("error freeing allocated vlan %d - err '%s' \n", vlan, err)
 	}
 }
 
-func TestGlobalConfigAutoVxlan(t *testing.T) {
+func TestGlobalConfigAutoVXLAN(t *testing.T) {
 	cfgData := []byte(`
         {
             "Version" : "0.01",
@@ -87,14 +87,14 @@ func TestGlobalConfigAutoVxlan(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "1-10",
-                "Vxlans"            : "15000-17000"
+                "VLANs"             : "1-10",
+                "VXLANs"            : "15000-17000"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vxlan"
             }
         }`)
-	var vxlan, localVlan uint
+	var vxlan, localVLAN uint
 
 	gc, err := Parse(cfgData)
 	if err != nil {
@@ -112,25 +112,25 @@ func TestGlobalConfigAutoVxlan(t *testing.T) {
 		t.Fatalf("error '%s' processing config %v \n", err, gc)
 	}
 
-	vxlan, localVlan, err = gc.AllocVxlan(gstateTestRA)
+	vxlan, localVLAN, err = gc.AllocVXLAN(gstateTestRA)
 	if err != nil {
 		t.Fatalf("error - allocating vxlan - %s \n", err)
 	}
 	if vxlan == 0 {
 		t.Fatalf("error - invalid vxlan allocated %d \n", vxlan)
 	}
-	if localVlan == 0 {
-		t.Fatalf("error - invalid vlan allocated %d \n", localVlan)
+	if localVLAN == 0 {
+		t.Fatalf("error - invalid vlan allocated %d \n", localVLAN)
 	}
 
-	err = gc.FreeVxlan(gstateTestRA, vxlan, localVlan)
+	err = gc.FreeVXLAN(gstateTestRA, vxlan, localVLAN)
 	if err != nil {
 		t.Fatalf("error freeing allocated vxlan %d localvlan %d - err '%s' \n",
-			vxlan, localVlan, err)
+			vxlan, localVLAN, err)
 	}
 }
 
-func TestGlobalConfigDefaultVxlanWithVlans(t *testing.T) {
+func TestGlobalConfigDefaultVXLANWithVLANs(t *testing.T) {
 	cfgData := []byte(`
         {
             "Version" : "0.01",
@@ -139,14 +139,14 @@ func TestGlobalConfigDefaultVxlanWithVlans(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "100-400,500-900",
-                "Vxlans"            : "10000-12000"
+                "VLANs"             : "100-400,500-900",
+                "VXLANs"            : "10000-12000"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vxlan"
             }
         }`)
-	var vlan, localVlan, vxlan uint
+	var vlan, localVLAN, vxlan uint
 
 	gc, err := Parse(cfgData)
 	if err != nil {
@@ -164,7 +164,7 @@ func TestGlobalConfigDefaultVxlanWithVlans(t *testing.T) {
 		t.Fatalf("error '%s' processing config %v \n", err, gc)
 	}
 
-	vlan, err = gc.AllocVlan(gstateTestRA)
+	vlan, err = gc.AllocVLAN(gstateTestRA)
 	if err != nil {
 		t.Fatalf("error - allocating vlan - %s \n", err)
 	}
@@ -172,30 +172,30 @@ func TestGlobalConfigDefaultVxlanWithVlans(t *testing.T) {
 		t.Fatalf("error - expecting vlan %d but allocated %d \n", 100, vlan)
 	}
 
-	vxlan, localVlan, err = gc.AllocVxlan(gstateTestRA)
+	vxlan, localVLAN, err = gc.AllocVXLAN(gstateTestRA)
 	if err != nil {
 		t.Fatalf("error - allocating vxlan - %s \n", err)
 	}
 	if vxlan != 10000 {
 		t.Fatalf("error - expecting vlan %d but allocated %d \n", 10000, vxlan)
 	}
-	if localVlan == 0 {
-		t.Fatalf("error - invalid vlan allocated %d \n", localVlan)
+	if localVLAN == 0 {
+		t.Fatalf("error - invalid vlan allocated %d \n", localVLAN)
 	}
 
-	err = gc.FreeVlan(gstateTestRA, vlan)
+	err = gc.FreeVLAN(gstateTestRA, vlan)
 	if err != nil {
 		t.Fatalf("error freeing allocated vlan %d - err '%s' \n", vlan, err)
 	}
 
-	err = gc.FreeVxlan(gstateTestRA, vxlan, localVlan)
+	err = gc.FreeVXLAN(gstateTestRA, vxlan, localVLAN)
 	if err != nil {
 		t.Fatalf("error freeing allocated vxlan %d localvlan %d - err '%s' \n",
-			vxlan, localVlan, err)
+			vxlan, localVLAN, err)
 	}
 }
 
-func TestInvalidGlobalConfigNoLocalVlans(t *testing.T) {
+func TestInvalidGlobalConfigNoLocalVLANs(t *testing.T) {
 	cfgData := []byte(`
         {
             "Version" : "0.01",
@@ -204,8 +204,8 @@ func TestInvalidGlobalConfigNoLocalVlans(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "1-4095",
-                "Vxlans"            : "10000-10001"
+                "VLANs"             : "1-4095",
+                "VXLANs"            : "10000-10001"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vlan"
@@ -229,7 +229,7 @@ func TestInvalidGlobalConfigNoLocalVlans(t *testing.T) {
 	}
 }
 
-func TestInvalidGlobalConfigMoreThan4KVlans(t *testing.T) {
+func TestInvalidGlobalConfigMoreThan4KVLANs(t *testing.T) {
 	cfgData := []byte(`
         {
             "Version" : "0.01",
@@ -238,8 +238,8 @@ func TestInvalidGlobalConfigMoreThan4KVlans(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "1-5000",
-                "Vxlans"            : "10000-10001"
+                "VLANs"             : "1-5000",
+                "VXLANs"            : "10000-10001"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vlan"
@@ -261,8 +261,8 @@ func TestInvalidGlobalConfig(t *testing.T) {
                 "SubnetPool"        : "11..5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "100-400,500-900",
-                "Vxlans"            : "10000-20000"
+                "VLANs"             : "100-400,500-900",
+                "VXLANs"            : "10000-20000"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vlan"
@@ -282,8 +282,8 @@ func TestInvalidGlobalConfig(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 16,
                 "AllocSubnetLen"    : 24,
-                "Vlans"             : "100-400,900-500",
-                "Vxlans"            : "10000-20000"
+                "VLANs"             : "100-400,900-500",
+                "VXLANs"            : "10000-20000"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vlan"
@@ -303,8 +303,8 @@ func TestInvalidGlobalConfig(t *testing.T) {
                 "SubnetPool"        : "11.5.0.0",
                 "SubnetLen"         : 22,
                 "AllocSubnetLen"    : 20,
-                "Vlans"             : "100-400,500-900",
-                "Vxlans"            : "10000-20000"
+                "VLANs"             : "100-400,500-900",
+                "VXLANs"            : "10000-20000"
             },
             "Deploy" : {
                 "DefaultNetType"    : "vlan"

--- a/netdcli/netdcli.go
+++ b/netdcli/netdcli.go
@@ -191,11 +191,11 @@ func init() {
 	flagSet.StringVar(&opts.pktTag,
 		"tag",
 		"auto",
-		"Vlan/Vxlan tag of the network")
+		"VLAN/VXLAN tag of the network")
 	flagSet.StringVar(&opts.pktTagType,
 		"tag-type",
 		"vlan",
-		"Vlan/Vxlan tag of the network")
+		"VLAN/VXLAN tag of the network")
 	flagSet.StringVar(&opts.subnetCidr,
 		"subnet",
 		"",
@@ -452,8 +452,8 @@ func executeOpts(opts *cliOpts) error {
 			gcfg.Deploy.DefaultNetType = opts.pktTagType
 			gcfg.Auto.SubnetPool = opts.subnetIP
 			gcfg.Auto.SubnetLen = opts.subnetLen
-			gcfg.Auto.Vlans = opts.vlans
-			gcfg.Auto.Vxlans = opts.vxlans
+			gcfg.Auto.VLANs = opts.vlans
+			gcfg.Auto.VXLANs = opts.vxlans
 			gcfg.Auto.AllocSubnetLen = opts.allocSubnetLen
 			err = gcfg.Write()
 		}
@@ -468,12 +468,12 @@ func executeOpts(opts *cliOpts) error {
 	case CLI_CONSTRUCT_SUBNET_RSRC:
 		if opts.oper.Get() == CLI_OPER_GET {
 			if CLI_CONSTRUCT_VLAN_RSRC == opts.construct.Get() {
-				rsrc := &resources.AutoVlanCfgResource{}
+				rsrc := &resources.AutoVLANCfgResource{}
 				rsrc.StateDriver = etcdDriver
 				coreState = rsrc
 			}
 			if CLI_CONSTRUCT_VXLAN_RSRC == opts.construct.Get() {
-				rsrc := &resources.AutoVxlanCfgResource{}
+				rsrc := &resources.AutoVXLANCfgResource{}
 				rsrc.StateDriver = etcdDriver
 				coreState = rsrc
 			}

--- a/netmaster/intent.go
+++ b/netmaster/intent.go
@@ -63,8 +63,8 @@ type ConfigTenant struct {
 	DefaultNetType string
 	SubnetPool     string
 	AllocSubnetLen uint
-	Vlans          string
-	Vxlans         string
+	VLANs          string
+	VXLANs         string
 
 	Networks []ConfigNetwork
 }

--- a/netutils/netutils_test.go
+++ b/netutils/netutils_test.go
@@ -22,22 +22,22 @@ import (
 type testSubnetInfo struct {
 	subnetIP  string
 	subnetLen uint
-	hostId    uint
+	hostID    uint
 	hostIP    string
 }
 
 var testSubnets = []testSubnetInfo{
-	{subnetIP: "11.2.1.0", subnetLen: 24, hostId: 5, hostIP: "11.2.1.5"},
-	{subnetIP: "10.123.16.0", subnetLen: 22, hostId: 513, hostIP: "10.123.18.1"},
-	{subnetIP: "172.12.0.0", subnetLen: 16, hostId: 261, hostIP: "172.12.1.5"},
+	{subnetIP: "11.2.1.0", subnetLen: 24, hostID: 5, hostIP: "11.2.1.5"},
+	{subnetIP: "10.123.16.0", subnetLen: 22, hostID: 513, hostIP: "10.123.18.1"},
+	{subnetIP: "172.12.0.0", subnetLen: 16, hostID: 261, hostIP: "172.12.1.5"},
 }
 
 func TestGetSubnetIP(t *testing.T) {
 	for _, te := range testSubnets {
-		hostIP, err := GetSubnetIP(te.subnetIP, te.subnetLen, 32, te.hostId)
+		hostIP, err := GetSubnetIP(te.subnetIP, te.subnetLen, 32, te.hostID)
 		if err != nil {
 			t.Fatalf("error getting host ip from subnet %s/%d for hostid %d - err '%s'",
-				te.subnetIP, te.subnetLen, te.hostId, err)
+				te.subnetIP, te.subnetLen, te.hostID, err)
 		}
 		if hostIP != te.hostIP {
 			t.Fatalf("obtained ip %s doesn't match expected ip %s for subnet %s/%d\n",
@@ -47,31 +47,31 @@ func TestGetSubnetIP(t *testing.T) {
 }
 
 var testInvalidSubnets = []testSubnetInfo{
-	{subnetIP: "11.2.1.0", subnetLen: 32, hostId: 5, hostIP: "11.2.1.5"},
-	{subnetIP: "10.123.16.0", subnetLen: 22, hostId: 1025, hostIP: "10.123.18.1"},
-	{subnetIP: "172.12.0.0", subnetLen: 4, hostId: 261, hostIP: "172.12.1.5"},
+	{subnetIP: "11.2.1.0", subnetLen: 32, hostID: 5, hostIP: "11.2.1.5"},
+	{subnetIP: "10.123.16.0", subnetLen: 22, hostID: 1025, hostIP: "10.123.18.1"},
+	{subnetIP: "172.12.0.0", subnetLen: 4, hostID: 261, hostIP: "172.12.1.5"},
 }
 
 func TestInvalidGetSubnetIP(t *testing.T) {
 	for _, te := range testInvalidSubnets {
-		_, err := GetSubnetIP(te.subnetIP, te.subnetLen, 32, te.hostId)
+		_, err := GetSubnetIP(te.subnetIP, te.subnetLen, 32, te.hostID)
 		if err == nil {
 			t.Fatalf("Expecting error on invalid config subnet %s/%d for hostid %d",
-				te.subnetIP, te.subnetLen, te.hostId)
+				te.subnetIP, te.subnetLen, te.hostID)
 		}
 	}
 }
 
 func TestGetIPNumber(t *testing.T) {
 	for _, te := range testSubnets {
-		hostId, err := GetIPNumber(te.subnetIP, te.subnetLen, 32, te.hostIP)
+		hostID, err := GetIPNumber(te.subnetIP, te.subnetLen, 32, te.hostIP)
 		if err != nil {
 			t.Fatalf("error getting host ip from subnet %s/%d for hostid %d ",
-				te.subnetIP, te.subnetLen, te.hostId)
+				te.subnetIP, te.subnetLen, te.hostID)
 		}
-		if hostId != te.hostId {
+		if hostID != te.hostID {
 			t.Fatalf("obtained ip %d doesn't match with expected ip %d \n",
-				hostId, te.hostId)
+				hostID, te.hostID)
 		}
 	}
 }
@@ -152,25 +152,25 @@ type testSubnetAllocInfo struct {
 	subnetIP       string
 	subnetLen      uint
 	subnetAllocLen uint
-	hostId         uint
+	hostID         uint
 	hostIP         string
 }
 
 var testSubnetAllocs = []testSubnetAllocInfo{
 	{subnetIP: "11.1.0.0", subnetLen: 16, subnetAllocLen: 24,
-		hostId: 5, hostIP: "11.1.5.0"},
+		hostID: 5, hostIP: "11.1.5.0"},
 	{subnetIP: "10.0.0.0", subnetLen: 8, subnetAllocLen: 24,
-		hostId: 5, hostIP: "10.0.5.0"},
+		hostID: 5, hostIP: "10.0.5.0"},
 }
 
 func TestGetSubnetAlloc(t *testing.T) {
 	for _, te := range testSubnetAllocs {
 		hostIP, err := GetSubnetIP(te.subnetIP, te.subnetLen,
-			te.subnetAllocLen, te.hostId)
+			te.subnetAllocLen, te.hostID)
 		if err != nil {
 			t.Fatalf("error getting subnet ip from subnet-range %s/%d alloc-size %d "+
 				"for id %d - err '%s'",
-				te.subnetIP, te.subnetLen, te.subnetAllocLen, te.hostId, err)
+				te.subnetIP, te.subnetLen, te.subnetAllocLen, te.hostID, err)
 		}
 		if hostIP != te.hostIP {
 			t.Fatalf("obtained ip %s doesn't match expected ip %s for subnet %s/%d "+
@@ -182,17 +182,17 @@ func TestGetSubnetAlloc(t *testing.T) {
 
 func TestGetSubnetNumber(t *testing.T) {
 	for _, te := range testSubnetAllocs {
-		hostId, err := GetIPNumber(te.subnetIP, te.subnetLen,
+		hostID, err := GetIPNumber(te.subnetIP, te.subnetLen,
 			te.subnetAllocLen, te.hostIP)
 		if err != nil {
 			t.Fatalf("error getting subnet ip from subnet %s/%d for hostid %d "+
 				"for subnet alloc size %d \n",
-				te.subnetIP, te.subnetLen, te.hostId, te.subnetAllocLen)
+				te.subnetIP, te.subnetLen, te.hostID, te.subnetAllocLen)
 		}
-		if hostId != te.hostId {
+		if hostID != te.hostID {
 			t.Fatalf("obtained subnet ip %d doesn't match with expected ip %d "+
 				"for subnet %s/%d alloc size %d \n",
-				hostId, te.hostId, te.subnetIP, te.subnetLen, te.subnetAllocLen)
+				hostID, te.hostID, te.subnetIP, te.subnetLen, te.subnetAllocLen)
 		}
 	}
 }

--- a/resources/etcdresourceallocator_test.go
+++ b/resources/etcdresourceallocator_test.go
@@ -55,9 +55,9 @@ func (r *TestResource) ReadAll() ([]core.State, error) {
 	if gReadCtr == 0 {
 		gReadCtr = 1
 		return []core.State{}, nil
-	} else {
-		return []core.State{core.State(r)}, nil
 	}
+
+	return []core.State{core.State(r)}, nil
 }
 
 func (r *TestResource) Init(rsrcCfg interface{}) error {
@@ -83,8 +83,8 @@ var fakeDriver = &state.FakeStateDriver{}
 
 func TestEtcdResourceManagerDefineResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	err := ra.DefineResource(testResourceID, testResourceDesc, &TestResource{})
@@ -109,8 +109,8 @@ func TestEtcdResourceManagerDefineInvalidResource(t *testing.T) {
 
 func TestEtcdResourceManagerUndefineResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	err := ra.DefineResource(testResourceID, testResourceDesc, &TestResource{})
@@ -140,8 +140,8 @@ func TestEtcdResourceManagerUndefineInvalidResource(t *testing.T) {
 
 func TestEtcdResourceManagerUndefineNonexistentResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	err := ra.UndefineResource(testResourceID, testResourceDesc)
@@ -157,8 +157,8 @@ func TestEtcdResourceManagerUndefineNonexistentResource(t *testing.T) {
 
 func TestEtcdResourceManagerAllocateResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	err := ra.DefineResource(testResourceID, testResourceDesc, &TestResource{})
@@ -188,8 +188,8 @@ func TestEtcdResourceManagerAllocateInvalidResource(t *testing.T) {
 
 func TestEtcdResourceManagerAllocateiNonexistentResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	_, err := ra.AllocateResourceVal(testResourceID, testResourceDesc)
@@ -205,8 +205,8 @@ func TestEtcdResourceManagerAllocateiNonexistentResource(t *testing.T) {
 
 func TestEtcdResourceManagerDeallocateResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	err := ra.DefineResource(testResourceID, testResourceDesc, &TestResource{})
@@ -241,8 +241,8 @@ func TestEtcdResourceManagerDeallocateInvalidResource(t *testing.T) {
 
 func TestEtcdResourceManagerDeallocateiNonexistentResource(t *testing.T) {
 	ra := &EtcdResourceManager{Etcd: fakeDriver}
-	ResourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
-	defer func() { delete(ResourceRegistry, testResourceDesc) }()
+	resourceRegistry[testResourceDesc] = reflect.TypeOf(TestResource{})
+	defer func() { delete(resourceRegistry, testResourceDesc) }()
 
 	gReadCtr = 0
 	err := ra.DeallocateResourceVal(testResourceID, testResourceDesc, 0)

--- a/resources/subnetresource_test.go
+++ b/resources/subnetresource_test.go
@@ -27,7 +27,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-var subnetRsrcStateDriver *testSubnetRsrcStateDriver = &testSubnetRsrcStateDriver{}
+var subnetRsrcStateDriver = &testSubnetRsrcStateDriver{}
 
 type subnetRsrcValidator struct {
 	// slice (stack) of expected config and oper states.
@@ -120,12 +120,12 @@ const (
 	SubnetRsrcAllocateExhaustID = "SubnetRsrcAllocateExhaustID"
 	SubnetRsrcDeallocateID      = "SubnetRsrcDeallocateID"
 
-	SUBNET_RSRC_OP_WRITE = iota
-	SUBNET_RSRC_OP_READ
-	SUBNET_RSRC_OP_CLEAR
+	subnetResourceOpWrite = iota
+	subnetResourceOpRead
+	subnetResourceOpClear
 )
 
-var subnetRsrcValidationStateMap map[string]*subnetRsrcValidator = map[string]*subnetRsrcValidator{
+var subnetRsrcValidationStateMap = map[string]*subnetRsrcValidator{
 	SubnetRsrcValidInitID: &subnetRsrcValidator{
 		expCfg: []AutoSubnetCfgResource{
 			{
@@ -286,15 +286,15 @@ func (d *testSubnetRsrcStateDriver) validate(key string, state core.State,
 	}
 
 	switch op {
-	case SUBNET_RSRC_OP_WRITE:
+	case subnetResourceOpWrite:
 		err := v.ValidateState(state)
 		if err != nil {
 			return err
 		}
 		return nil
-	case SUBNET_RSRC_OP_READ:
+	case subnetResourceOpRead:
 		return v.CopyState(state)
-	case SUBNET_RSRC_OP_CLEAR:
+	case subnetResourceOpClear:
 		fallthrough
 	default:
 		return nil
@@ -302,12 +302,12 @@ func (d *testSubnetRsrcStateDriver) validate(key string, state core.State,
 }
 
 func (d *testSubnetRsrcStateDriver) ClearState(key string) error {
-	return d.validate(key, nil, SUBNET_RSRC_OP_CLEAR)
+	return d.validate(key, nil, subnetResourceOpClear)
 }
 
 func (d *testSubnetRsrcStateDriver) ReadState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) error {
-	return d.validate(key, value, SUBNET_RSRC_OP_READ)
+	return d.validate(key, value, subnetResourceOpRead)
 }
 
 func (d *testSubnetRsrcStateDriver) ReadAllState(key string, value core.State,
@@ -322,7 +322,7 @@ func (d *testSubnetRsrcStateDriver) WatchAllState(baseKey string, sType core.Sta
 
 func (d *testSubnetRsrcStateDriver) WriteState(key string, value core.State,
 	marshal func(interface{}) ([]byte, error)) error {
-	return d.validate(key, value, SUBNET_RSRC_OP_WRITE)
+	return d.validate(key, value, subnetResourceOpWrite)
 }
 
 func TestAutoSubnetCfgResourceInit(t *testing.T) {

--- a/resources/vlanresource_test.go
+++ b/resources/vlanresource_test.go
@@ -26,14 +26,14 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-var vlanRsrcStateDriver *testVlanRsrcStateDriver = &testVlanRsrcStateDriver{}
+var vlanRsrcStateDriver = &testVlanRsrcStateDriver{}
 
 type vlanRsrcValidator struct {
 	// slice (stack) of expected config and oper states.
 	// nextState modifies this slice after every state validate (write)
 	// or copy (read)
-	expCfg  []AutoVlanCfgResource
-	expOper []AutoVlanOperResource
+	expCfg  []AutoVLANCfgResource
+	expOper []AutoVLANOperResource
 }
 
 func (vt *vlanRsrcValidator) nextCfgState() {
@@ -55,11 +55,11 @@ func (vt *vlanRsrcValidator) nextOperState() {
 }
 
 func (vt *vlanRsrcValidator) ValidateState(state core.State) error {
-	rcvdCfg, okCfg := state.(*AutoVlanCfgResource)
+	rcvdCfg, okCfg := state.(*AutoVLANCfgResource)
 	if okCfg {
 		log.Printf("cfg length: %d", len(vt.expCfg))
 		if rcvdCfg.ID != vt.expCfg[0].ID ||
-			!rcvdCfg.Vlans.Equal(vt.expCfg[0].Vlans) {
+			!rcvdCfg.VLANs.Equal(vt.expCfg[0].VLANs) {
 			errStr := fmt.Sprintf("cfg mismatch. Expctd: %+v, Rcvd: %+v",
 				vt.expCfg[0], rcvdCfg)
 			//panic so we can catch the exact backtrace
@@ -69,11 +69,11 @@ func (vt *vlanRsrcValidator) ValidateState(state core.State) error {
 		return nil
 	}
 
-	rcvdOper, okOper := state.(*AutoVlanOperResource)
+	rcvdOper, okOper := state.(*AutoVLANOperResource)
 	if okOper {
 		log.Printf("oper length: %d", len(vt.expOper))
 		if rcvdOper.ID != vt.expOper[0].ID ||
-			!rcvdOper.FreeVlans.Equal(vt.expOper[0].FreeVlans) {
+			!rcvdOper.FreeVLANs.Equal(vt.expOper[0].FreeVLANs) {
 			errStr := fmt.Sprintf("oper mismatch. Expctd: %+v, Rcvd: %+v",
 				vt.expOper[0], rcvdOper)
 			//panic so we can catch the exact backtrace
@@ -87,18 +87,18 @@ func (vt *vlanRsrcValidator) ValidateState(state core.State) error {
 }
 
 func (vt *vlanRsrcValidator) CopyState(state core.State) error {
-	rcvdCfg, okCfg := state.(*AutoVlanCfgResource)
+	rcvdCfg, okCfg := state.(*AutoVLANCfgResource)
 	if okCfg {
 		rcvdCfg.ID = vt.expCfg[0].ID
-		rcvdCfg.Vlans = vt.expCfg[0].Vlans.Clone()
+		rcvdCfg.VLANs = vt.expCfg[0].VLANs.Clone()
 		vt.nextCfgState()
 		return nil
 	}
 
-	rcvdOper, okOper := state.(*AutoVlanOperResource)
+	rcvdOper, okOper := state.(*AutoVLANOperResource)
 	if okOper {
 		rcvdOper.ID = vt.expOper[0].ID
-		rcvdOper.FreeVlans = vt.expOper[0].FreeVlans.Clone()
+		rcvdOper.FreeVLANs = vt.expOper[0].FreeVLANs.Clone()
 		vt.nextOperState()
 		return nil
 	}
@@ -115,111 +115,111 @@ const (
 	VlanRsrcAllocateExhaustID = "VlanRsrcAllocateExhaustID"
 	VlanRsrcDeallocateID      = "VlanRsrcDeallocateID"
 
-	VLAN_RSRC_OP_WRITE = iota
-	VLAN_RSRC_OP_READ
-	VLAN_RSRC_OP_CLEAR
+	vLANResourceOperWrite = iota
+	vLANResourceOperRead
+	vLANResourceOperClear
 )
 
-var vlanRsrcValidationStateMap map[string]*vlanRsrcValidator = map[string]*vlanRsrcValidator{
+var vlanRsrcValidationStateMap = map[string]*vlanRsrcValidator{
 	VlanRsrcValidInitID: &vlanRsrcValidator{
-		expCfg: []AutoVlanCfgResource{
+		expCfg: []AutoVLANCfgResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcValidInitID},
-				Vlans:       bitset.New(1).Set(1),
+				VLANs:       bitset.New(1).Set(1),
 			},
 		},
-		expOper: []AutoVlanOperResource{
+		expOper: []AutoVLANOperResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcValidInitID},
-				FreeVlans:   bitset.New(1).Set(1),
+				FreeVLANs:   bitset.New(1).Set(1),
 			},
 		},
 	},
 	VlanRsrcValidDeinitID: &vlanRsrcValidator{
-		expCfg: []AutoVlanCfgResource{
+		expCfg: []AutoVLANCfgResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcValidDeinitID},
-				Vlans:       bitset.New(1).Set(0),
+				VLANs:       bitset.New(1).Set(0),
 			},
 		},
-		expOper: []AutoVlanOperResource{
+		expOper: []AutoVLANOperResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcValidDeinitID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcValidDeinitID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 		},
 	},
 	VlanRsrcAllocateID: &vlanRsrcValidator{
-		expCfg: []AutoVlanCfgResource{
+		expCfg: []AutoVLANCfgResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateID},
-				Vlans:       bitset.New(1).Set(0),
+				VLANs:       bitset.New(1).Set(0),
 			},
 		},
-		expOper: []AutoVlanOperResource{
+		expOper: []AutoVLANOperResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateID},
-				FreeVlans:   bitset.New(1).Clear(0),
+				FreeVLANs:   bitset.New(1).Clear(0),
 			},
 		},
 	},
 	VlanRsrcAllocateExhaustID: &vlanRsrcValidator{
-		expCfg: []AutoVlanCfgResource{
+		expCfg: []AutoVLANCfgResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateExhaustID},
-				Vlans:       bitset.New(1).Clear(0),
+				VLANs:       bitset.New(1).Clear(0),
 			},
 		},
-		expOper: []AutoVlanOperResource{
+		expOper: []AutoVLANOperResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateExhaustID},
-				FreeVlans:   bitset.New(1).Clear(0),
+				FreeVLANs:   bitset.New(1).Clear(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcAllocateExhaustID},
-				FreeVlans:   bitset.New(1).Clear(0),
+				FreeVLANs:   bitset.New(1).Clear(0),
 			},
 		},
 	},
 	VlanRsrcDeallocateID: &vlanRsrcValidator{
-		expCfg: []AutoVlanCfgResource{
+		expCfg: []AutoVLANCfgResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcDeallocateID},
-				Vlans:       bitset.New(1).Set(0),
+				VLANs:       bitset.New(1).Set(0),
 			},
 		},
-		expOper: []AutoVlanOperResource{
+		expOper: []AutoVLANOperResource{
 			{
 				CommonState: core.CommonState{nil, VlanRsrcDeallocateID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcDeallocateID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcDeallocateID},
-				FreeVlans:   bitset.New(1).Clear(0),
+				FreeVLANs:   bitset.New(1).Clear(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcDeallocateID},
-				FreeVlans:   bitset.New(1).Clear(0),
+				FreeVLANs:   bitset.New(1).Clear(0),
 			},
 			{
 				CommonState: core.CommonState{nil, VlanRsrcDeallocateID},
-				FreeVlans:   bitset.New(1).Set(0),
+				FreeVLANs:   bitset.New(1).Set(0),
 			},
 		},
 	},
@@ -263,15 +263,15 @@ func (d *testVlanRsrcStateDriver) validate(key string, state core.State,
 	}
 
 	switch op {
-	case VLAN_RSRC_OP_WRITE:
+	case vLANResourceOperWrite:
 		err := v.ValidateState(state)
 		if err != nil {
 			return err
 		}
 		return nil
-	case VLAN_RSRC_OP_READ:
+	case vLANResourceOperRead:
 		return v.CopyState(state)
-	case VLAN_RSRC_OP_CLEAR:
+	case vLANResourceOperClear:
 		fallthrough
 	default:
 		return nil
@@ -279,12 +279,12 @@ func (d *testVlanRsrcStateDriver) validate(key string, state core.State,
 }
 
 func (d *testVlanRsrcStateDriver) ClearState(key string) error {
-	return d.validate(key, nil, VLAN_RSRC_OP_CLEAR)
+	return d.validate(key, nil, vLANResourceOperClear)
 }
 
 func (d *testVlanRsrcStateDriver) ReadState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) error {
-	return d.validate(key, value, VLAN_RSRC_OP_READ)
+	return d.validate(key, value, vLANResourceOperRead)
 }
 
 func (d *testVlanRsrcStateDriver) ReadAllState(key string, value core.State,
@@ -299,25 +299,25 @@ func (d *testVlanRsrcStateDriver) WatchAllState(baseKey string, sType core.State
 
 func (d *testVlanRsrcStateDriver) WriteState(key string, value core.State,
 	marshal func(interface{}) ([]byte, error)) error {
-	return d.validate(key, value, VLAN_RSRC_OP_WRITE)
+	return d.validate(key, value, vLANResourceOperWrite)
 }
 
-func TestAutoVlanCfgResourceInit(t *testing.T) {
-	rsrc := &AutoVlanCfgResource{}
+func TestAutoVLANCfgResourceInit(t *testing.T) {
+	rsrc := &AutoVLANCfgResource{}
 	rsrc.StateDriver = vlanRsrcStateDriver
 	rsrc.ID = VlanRsrcValidInitID
-	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].Vlans.Clone()
+	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].VLANs.Clone()
 	err := rsrc.Init(vlans)
 	if err != nil {
 		t.Fatalf("Vlan resource init failed. Error: %s", err)
 	}
 }
 
-func TestAutoVlanCfgResourceDeInit(t *testing.T) {
-	rsrc := &AutoVlanCfgResource{}
+func TestAutoVLANCfgResourceDeInit(t *testing.T) {
+	rsrc := &AutoVLANCfgResource{}
 	rsrc.StateDriver = vlanRsrcStateDriver
 	rsrc.ID = VlanRsrcValidDeinitID
-	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].Vlans.Clone()
+	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].VLANs.Clone()
 	err := rsrc.Init(vlans)
 	if err != nil {
 		t.Fatalf("Vlan resource init failed. Error: %s", err)
@@ -326,11 +326,11 @@ func TestAutoVlanCfgResourceDeInit(t *testing.T) {
 	rsrc.Deinit()
 }
 
-func TestAutoVlanCfgResourceAllocate(t *testing.T) {
-	rsrc := &AutoVlanCfgResource{}
+func TestAutoVLANCfgResourceAllocate(t *testing.T) {
+	rsrc := &AutoVLANCfgResource{}
 	rsrc.StateDriver = vlanRsrcStateDriver
 	rsrc.ID = VlanRsrcAllocateID
-	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].Vlans.Clone()
+	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].VLANs.Clone()
 	err := rsrc.Init(vlans)
 	if err != nil {
 		t.Fatalf("Vlan resource init failed. Error: %s", err)
@@ -345,11 +345,11 @@ func TestAutoVlanCfgResourceAllocate(t *testing.T) {
 	}
 }
 
-func TestAutoVlanCfgResourceAllocateExhaustion(t *testing.T) {
-	rsrc := &AutoVlanCfgResource{}
+func TestAutoVLANCfgResourceAllocateExhaustion(t *testing.T) {
+	rsrc := &AutoVLANCfgResource{}
 	rsrc.StateDriver = vlanRsrcStateDriver
 	rsrc.ID = VlanRsrcAllocateExhaustID
-	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].Vlans.Clone()
+	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].VLANs.Clone()
 	err := rsrc.Init(vlans)
 	if err != nil {
 		t.Fatalf("Vlan resource init failed. Error: %s", err)
@@ -365,11 +365,11 @@ func TestAutoVlanCfgResourceAllocateExhaustion(t *testing.T) {
 	}
 }
 
-func TestAutoVlanCfgResourceDeAllocate(t *testing.T) {
-	rsrc := &AutoVlanCfgResource{}
+func TestAutoVLANCfgResourceDeAllocate(t *testing.T) {
+	rsrc := &AutoVLANCfgResource{}
 	rsrc.StateDriver = vlanRsrcStateDriver
 	rsrc.ID = VlanRsrcDeallocateID
-	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].Vlans.Clone()
+	vlans := vlanRsrcValidationStateMap[rsrc.ID].expCfg[0].VLANs.Clone()
 	err := rsrc.Init(vlans)
 	if err != nil {
 		t.Fatalf("Vlan resource init failed. Error: %s", err)

--- a/resources/vxlanresource_test.go
+++ b/resources/vxlanresource_test.go
@@ -26,14 +26,14 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-var vxlanRsrcStateDriver *testVxlanRsrcStateDriver = &testVxlanRsrcStateDriver{}
+var vxlanRsrcStateDriver = &testVXLANRsrcStateDriver{}
 
 type vxlanRsrcValidator struct {
 	// slice (stack) of expected config and oper states.
 	// nextState modifies this slice after every state validate (write)
 	// or copy (read)
-	expCfg  []AutoVxlanCfgResource
-	expOper []AutoVxlanOperResource
+	expCfg  []AutoVXLANCfgResource
+	expOper []AutoVXLANOperResource
 }
 
 func (vt *vxlanRsrcValidator) nextCfgState() {
@@ -55,12 +55,12 @@ func (vt *vxlanRsrcValidator) nextOperState() {
 }
 
 func (vt *vxlanRsrcValidator) ValidateState(state core.State) error {
-	rcvdCfg, okCfg := state.(*AutoVxlanCfgResource)
+	rcvdCfg, okCfg := state.(*AutoVXLANCfgResource)
 	if okCfg {
 		log.Printf("cfg length: %d", len(vt.expCfg))
 		if rcvdCfg.ID != vt.expCfg[0].ID ||
-			!rcvdCfg.Vxlans.Equal(vt.expCfg[0].Vxlans) ||
-			!rcvdCfg.LocalVlans.Equal(vt.expCfg[0].LocalVlans) {
+			!rcvdCfg.VXLANs.Equal(vt.expCfg[0].VXLANs) ||
+			!rcvdCfg.LocalVLANs.Equal(vt.expCfg[0].LocalVLANs) {
 			errStr := fmt.Sprintf("cfg mismatch. Expctd: %+v, Rcvd: %+v",
 				vt.expCfg[0], rcvdCfg)
 			//panic so we can catch the exact backtrace
@@ -70,12 +70,12 @@ func (vt *vxlanRsrcValidator) ValidateState(state core.State) error {
 		return nil
 	}
 
-	rcvdOper, okOper := state.(*AutoVxlanOperResource)
+	rcvdOper, okOper := state.(*AutoVXLANOperResource)
 	if okOper {
 		log.Printf("oper length: %d", len(vt.expOper))
 		if rcvdOper.ID != vt.expOper[0].ID ||
-			!rcvdOper.FreeVxlans.Equal(vt.expOper[0].FreeVxlans) ||
-			!rcvdOper.FreeLocalVlans.Equal(vt.expOper[0].FreeLocalVlans) {
+			!rcvdOper.FreeVXLANs.Equal(vt.expOper[0].FreeVXLANs) ||
+			!rcvdOper.FreeLocalVLANs.Equal(vt.expOper[0].FreeLocalVLANs) {
 			errStr := fmt.Sprintf("oper mismatch. Expctd: %+v, Rcvd: %+v",
 				vt.expOper[0], rcvdOper)
 			//panic so we can catch the exact backtrace
@@ -89,20 +89,20 @@ func (vt *vxlanRsrcValidator) ValidateState(state core.State) error {
 }
 
 func (vt *vxlanRsrcValidator) CopyState(state core.State) error {
-	rcvdCfg, okCfg := state.(*AutoVxlanCfgResource)
+	rcvdCfg, okCfg := state.(*AutoVXLANCfgResource)
 	if okCfg {
 		rcvdCfg.ID = vt.expCfg[0].ID
-		rcvdCfg.Vxlans = vt.expCfg[0].Vxlans.Clone()
-		rcvdCfg.LocalVlans = vt.expCfg[0].LocalVlans.Clone()
+		rcvdCfg.VXLANs = vt.expCfg[0].VXLANs.Clone()
+		rcvdCfg.LocalVLANs = vt.expCfg[0].LocalVLANs.Clone()
 		vt.nextCfgState()
 		return nil
 	}
 
-	rcvdOper, okOper := state.(*AutoVxlanOperResource)
+	rcvdOper, okOper := state.(*AutoVXLANOperResource)
 	if okOper {
 		rcvdOper.ID = vt.expOper[0].ID
-		rcvdOper.FreeVxlans = vt.expOper[0].FreeVxlans.Clone()
-		rcvdOper.FreeLocalVlans = vt.expOper[0].FreeLocalVlans.Clone()
+		rcvdOper.FreeVXLANs = vt.expOper[0].FreeVXLANs.Clone()
+		rcvdOper.FreeLocalVLANs = vt.expOper[0].FreeLocalVLANs.Clone()
 		vt.nextOperState()
 		return nil
 	}
@@ -113,189 +113,189 @@ func (vt *vxlanRsrcValidator) CopyState(state core.State) error {
 type vxlanRsrcValidateOp int
 
 const (
-	VxlanRsrcValidInitID            = "VxlanRsrcValidInitID"
-	VxlanRsrcValidDeinitID          = "VxlanRsrcValidDeinitID"
-	VxlanRsrcAllocateID             = "VxlanRsrcAllocateID"
-	VxlanRsrcAllocateExhaustVxlanID = "VxlanRsrcAllocateExhaustVxlanID"
-	VxlanRsrcAllocateExhaustVlanID  = "VxlanRsrcAllocateExhaustVlanID"
-	VxlanRsrcDeallocateID           = "VxlanRsrcDeallocateID"
+	VXLANRsrcValidInitID            = "VXLANRsrcValidInitID"
+	VXLANRsrcValidDeinitID          = "VXLANRsrcValidDeinitID"
+	VXLANRsrcAllocateID             = "VXLANRsrcAllocateID"
+	VXLANRsrcAllocateExhaustVXLANID = "VXLANRsrcAllocateExhaustVXLANID"
+	VXLANRsrcAllocateExhaustVLANID  = "VXLANRsrcAllocateExhaustVLANID"
+	VXLANRsrcDeallocateID           = "VXLANRsrcDeallocateID"
 
-	VXLAN_RSRC_OP_WRITE = iota
-	VXLAN_RSRC_OP_READ
-	VXLAN_RSRC_OP_CLEAR
+	vXLANResourceOpWrite = iota
+	vXLANResourceOpRead
+	vXLANResourceOpClear
 )
 
-var vxlanRsrcValidationStateMap map[string]*vxlanRsrcValidator = map[string]*vxlanRsrcValidator{
-	VxlanRsrcValidInitID: &vxlanRsrcValidator{
-		expCfg: []AutoVxlanCfgResource{
+var vxlanRsrcValidationStateMap = map[string]*vxlanRsrcValidator{
+	VXLANRsrcValidInitID: &vxlanRsrcValidator{
+		expCfg: []AutoVXLANCfgResource{
 			{
-				CommonState: core.CommonState{nil, VxlanRsrcValidInitID},
-				Vxlans:      bitset.New(1).Set(0),
-				LocalVlans:  bitset.New(1).Set(0),
+				CommonState: core.CommonState{nil, VXLANRsrcValidInitID},
+				VXLANs:      bitset.New(1).Set(0),
+				LocalVLANs:  bitset.New(1).Set(0),
 			},
 		},
-		expOper: []AutoVxlanOperResource{
+		expOper: []AutoVXLANOperResource{
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcValidInitID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
-			},
-		},
-	},
-	VxlanRsrcValidDeinitID: &vxlanRsrcValidator{
-		expCfg: []AutoVxlanCfgResource{
-			{
-				CommonState: core.CommonState{nil, VxlanRsrcValidDeinitID},
-				Vxlans:      bitset.New(1).Set(0),
-				LocalVlans:  bitset.New(1).Set(0),
-			},
-		},
-		expOper: []AutoVxlanOperResource{
-			{
-				CommonState:    core.CommonState{nil, VxlanRsrcValidDeinitID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
-			},
-			{
-				CommonState:    core.CommonState{nil, VxlanRsrcValidDeinitID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcValidInitID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 		},
 	},
-	VxlanRsrcAllocateID: &vxlanRsrcValidator{
-		expCfg: []AutoVxlanCfgResource{
+	VXLANRsrcValidDeinitID: &vxlanRsrcValidator{
+		expCfg: []AutoVXLANCfgResource{
 			{
-				CommonState: core.CommonState{nil, VxlanRsrcAllocateID},
-				Vxlans:      bitset.New(1).Set(0),
-				LocalVlans:  bitset.New(1).Set(0),
+				CommonState: core.CommonState{nil, VXLANRsrcValidDeinitID},
+				VXLANs:      bitset.New(1).Set(0),
+				LocalVLANs:  bitset.New(1).Set(0),
 			},
 		},
-		expOper: []AutoVxlanOperResource{
+		expOper: []AutoVXLANOperResource{
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcValidDeinitID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
-			},
-			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateID},
-				FreeVxlans:     bitset.New(1).Clear(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcValidDeinitID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 		},
 	},
-	VxlanRsrcAllocateExhaustVxlanID: &vxlanRsrcValidator{
-		expCfg: []AutoVxlanCfgResource{
+	VXLANRsrcAllocateID: &vxlanRsrcValidator{
+		expCfg: []AutoVXLANCfgResource{
 			{
-				CommonState: core.CommonState{nil, VxlanRsrcAllocateExhaustVxlanID},
-				Vxlans:      bitset.New(1).Clear(0),
-				LocalVlans:  bitset.New(1).Clear(0),
+				CommonState: core.CommonState{nil, VXLANRsrcAllocateID},
+				VXLANs:      bitset.New(1).Set(0),
+				LocalVLANs:  bitset.New(1).Set(0),
 			},
 		},
-		expOper: []AutoVxlanOperResource{
+		expOper: []AutoVXLANOperResource{
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateExhaustVxlanID},
-				FreeVxlans:     bitset.New(1).Clear(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateExhaustVxlanID},
-				FreeVxlans:     bitset.New(1).Clear(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
-			},
-		},
-	},
-	VxlanRsrcAllocateExhaustVlanID: &vxlanRsrcValidator{
-		expCfg: []AutoVxlanCfgResource{
-			{
-				CommonState: core.CommonState{nil, VxlanRsrcAllocateExhaustVlanID},
-				Vxlans:      bitset.New(1).Set(0),
-				LocalVlans:  bitset.New(1).Clear(0),
-			},
-		},
-		expOper: []AutoVxlanOperResource{
-			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateExhaustVlanID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcAllocateExhaustVlanID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateID},
+				FreeVXLANs:     bitset.New(1).Clear(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
 			},
 		},
 	},
-	VxlanRsrcDeallocateID: &vxlanRsrcValidator{
-		expCfg: []AutoVxlanCfgResource{
+	VXLANRsrcAllocateExhaustVXLANID: &vxlanRsrcValidator{
+		expCfg: []AutoVXLANCfgResource{
 			{
-				CommonState: core.CommonState{nil, VxlanRsrcDeallocateID},
-				Vxlans:      bitset.New(1).Set(0),
-				LocalVlans:  bitset.New(1).Set(0),
+				CommonState: core.CommonState{nil, VXLANRsrcAllocateExhaustVXLANID},
+				VXLANs:      bitset.New(1).Clear(0),
+				LocalVLANs:  bitset.New(1).Clear(0),
 			},
 		},
-		expOper: []AutoVxlanOperResource{
+		expOper: []AutoVXLANOperResource{
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcDeallocateID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateExhaustVXLANID},
+				FreeVXLANs:     bitset.New(1).Clear(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcDeallocateID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateExhaustVXLANID},
+				FreeVXLANs:     bitset.New(1).Clear(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
+			},
+		},
+	},
+	VXLANRsrcAllocateExhaustVLANID: &vxlanRsrcValidator{
+		expCfg: []AutoVXLANCfgResource{
+			{
+				CommonState: core.CommonState{nil, VXLANRsrcAllocateExhaustVLANID},
+				VXLANs:      bitset.New(1).Set(0),
+				LocalVLANs:  bitset.New(1).Clear(0),
+			},
+		},
+		expOper: []AutoVXLANOperResource{
+			{
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateExhaustVLANID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcDeallocateID},
-				FreeVxlans:     bitset.New(1).Clear(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcAllocateExhaustVLANID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
+			},
+		},
+	},
+	VXLANRsrcDeallocateID: &vxlanRsrcValidator{
+		expCfg: []AutoVXLANCfgResource{
+			{
+				CommonState: core.CommonState{nil, VXLANRsrcDeallocateID},
+				VXLANs:      bitset.New(1).Set(0),
+				LocalVLANs:  bitset.New(1).Set(0),
+			},
+		},
+		expOper: []AutoVXLANOperResource{
+			{
+				CommonState:    core.CommonState{nil, VXLANRsrcDeallocateID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcDeallocateID},
-				FreeVxlans:     bitset.New(1).Clear(0),
-				FreeLocalVlans: bitset.New(1).Clear(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcDeallocateID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 			{
-				CommonState:    core.CommonState{nil, VxlanRsrcDeallocateID},
-				FreeVxlans:     bitset.New(1).Set(0),
-				FreeLocalVlans: bitset.New(1).Set(0),
+				CommonState:    core.CommonState{nil, VXLANRsrcDeallocateID},
+				FreeVXLANs:     bitset.New(1).Clear(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
+			},
+			{
+				CommonState:    core.CommonState{nil, VXLANRsrcDeallocateID},
+				FreeVXLANs:     bitset.New(1).Clear(0),
+				FreeLocalVLANs: bitset.New(1).Clear(0),
+			},
+			{
+				CommonState:    core.CommonState{nil, VXLANRsrcDeallocateID},
+				FreeVXLANs:     bitset.New(1).Set(0),
+				FreeLocalVLANs: bitset.New(1).Set(0),
 			},
 		},
 	},
 }
 
-type testVxlanRsrcStateDriver struct {
+type testVXLANRsrcStateDriver struct {
 }
 
-func (d *testVxlanRsrcStateDriver) Init(config *core.Config) error {
+func (d *testVXLANRsrcStateDriver) Init(config *core.Config) error {
 	return core.Errorf("Shouldn't be called!")
 }
 
-func (d *testVxlanRsrcStateDriver) Deinit() {
+func (d *testVXLANRsrcStateDriver) Deinit() {
 }
 
-func (d *testVxlanRsrcStateDriver) Write(key string, value []byte) error {
+func (d *testVXLANRsrcStateDriver) Write(key string, value []byte) error {
 	return core.Errorf("Shouldn't be called!")
 }
 
-func (d *testVxlanRsrcStateDriver) Read(key string) ([]byte, error) {
+func (d *testVXLANRsrcStateDriver) Read(key string) ([]byte, error) {
 	return nil, core.Errorf("Shouldn't be called!")
 }
 
-func (d *testVxlanRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
+func (d *testVXLANRsrcStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return nil, core.Errorf("Shouldn't be called!")
 }
 
-func (d *testVxlanRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
+func (d *testVXLANRsrcStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
 	return core.Errorf("not supported")
 }
 
-func (d *testVxlanRsrcStateDriver) validate(key string, state core.State,
+func (d *testVXLANRsrcStateDriver) validate(key string, state core.State,
 	op vxlanRsrcValidateOp) error {
 	strs := strings.Split(key, "/")
 	id := strs[len(strs)-1]
@@ -307,140 +307,140 @@ func (d *testVxlanRsrcStateDriver) validate(key string, state core.State,
 	}
 
 	switch op {
-	case VXLAN_RSRC_OP_WRITE:
+	case vXLANResourceOpWrite:
 		err := v.ValidateState(state)
 		if err != nil {
 			return err
 		}
 		return nil
-	case VXLAN_RSRC_OP_READ:
+	case vXLANResourceOpRead:
 		return v.CopyState(state)
-	case VXLAN_RSRC_OP_CLEAR:
+	case vXLANResourceOpClear:
 		fallthrough
 	default:
 		return nil
 	}
 }
 
-func (d *testVxlanRsrcStateDriver) ClearState(key string) error {
-	return d.validate(key, nil, VXLAN_RSRC_OP_CLEAR)
+func (d *testVXLANRsrcStateDriver) ClearState(key string) error {
+	return d.validate(key, nil, vXLANResourceOpClear)
 }
 
-func (d *testVxlanRsrcStateDriver) ReadState(key string, value core.State,
+func (d *testVXLANRsrcStateDriver) ReadState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) error {
-	return d.validate(key, value, VXLAN_RSRC_OP_READ)
+	return d.validate(key, value, vXLANResourceOpRead)
 }
 
-func (d *testVxlanRsrcStateDriver) ReadAllState(key string, value core.State,
+func (d *testVXLANRsrcStateDriver) ReadAllState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return nil, core.Errorf("Shouldn't be called!")
 }
 
-func (d *testVxlanRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
+func (d *testVXLANRsrcStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
 	return core.Errorf("not supported")
 }
 
-func (d *testVxlanRsrcStateDriver) WriteState(key string, value core.State,
+func (d *testVXLANRsrcStateDriver) WriteState(key string, value core.State,
 	marshal func(interface{}) ([]byte, error)) error {
-	return d.validate(key, value, VXLAN_RSRC_OP_WRITE)
+	return d.validate(key, value, vXLANResourceOpWrite)
 }
 
-func TestAutoVxlanCfgResourceInit(t *testing.T) {
-	rsrc := &AutoVxlanCfgResource{}
+func TestAutoVXLANCfgResourceInit(t *testing.T) {
+	rsrc := &AutoVXLANCfgResource{}
 	rsrc.StateDriver = vxlanRsrcStateDriver
-	rsrc.ID = VxlanRsrcValidInitID
+	rsrc.ID = VXLANRsrcValidInitID
 	err := rsrc.Init(&vxlanRsrcValidationStateMap[rsrc.ID].expCfg[0])
 	if err != nil {
-		t.Fatalf("Vxlan resource init failed. Error: %s", err)
+		t.Fatalf("VXLAN resource init failed. Error: %s", err)
 	}
 }
 
-func TestAutoVxlanCfgResourceDeInit(t *testing.T) {
-	rsrc := &AutoVxlanCfgResource{}
+func TestAutoVXLANCfgResourceDeInit(t *testing.T) {
+	rsrc := &AutoVXLANCfgResource{}
 	rsrc.StateDriver = vxlanRsrcStateDriver
-	rsrc.ID = VxlanRsrcValidDeinitID
+	rsrc.ID = VXLANRsrcValidDeinitID
 	err := rsrc.Init(&vxlanRsrcValidationStateMap[rsrc.ID].expCfg[0])
 	if err != nil {
-		t.Fatalf("Vxlan resource init failed. Error: %s", err)
+		t.Fatalf("VXLAN resource init failed. Error: %s", err)
 	}
 
 	rsrc.Deinit()
 }
 
-func TestAutoVxlanCfgResourceAllocate(t *testing.T) {
-	rsrc := &AutoVxlanCfgResource{}
+func TestAutoVXLANCfgResourceAllocate(t *testing.T) {
+	rsrc := &AutoVXLANCfgResource{}
 	rsrc.StateDriver = vxlanRsrcStateDriver
-	rsrc.ID = VxlanRsrcAllocateID
+	rsrc.ID = VXLANRsrcAllocateID
 	err := rsrc.Init(&vxlanRsrcValidationStateMap[rsrc.ID].expCfg[0])
 	if err != nil {
-		t.Fatalf("Vxlan resource init failed. Error: %s", err)
+		t.Fatalf("VXLAN resource init failed. Error: %s", err)
 	}
 
 	p, err1 := rsrc.Allocate()
 	if err1 != nil {
-		t.Fatalf("Vxlan resource allocation failed. Error: %s", err1)
+		t.Fatalf("VXLAN resource allocation failed. Error: %s", err1)
 	}
-	pair := p.(VxlanVlanPair)
-	if pair.Vxlan != 0 || pair.Vlan != 0 {
+	pair := p.(VXLANVLANPair)
+	if pair.VXLAN != 0 || pair.VLAN != 0 {
 		t.Fatalf("Allocated vxlan mismatch. expected: (0,0), rcvd: %v", pair)
 	}
 }
 
-func TestAutoVxlanCfgResourceAllocateVxlanExhaustion(t *testing.T) {
-	rsrc := &AutoVxlanCfgResource{}
+func TestAutoVXLANCfgResourceAllocateVXLANExhaustion(t *testing.T) {
+	rsrc := &AutoVXLANCfgResource{}
 	rsrc.StateDriver = vxlanRsrcStateDriver
-	rsrc.ID = VxlanRsrcAllocateExhaustVxlanID
+	rsrc.ID = VXLANRsrcAllocateExhaustVXLANID
 	err := rsrc.Init(&vxlanRsrcValidationStateMap[rsrc.ID].expCfg[0])
 	if err != nil {
-		t.Fatalf("Vxlan resource init failed. Error: %s", err)
+		t.Fatalf("VXLAN resource init failed. Error: %s", err)
 	}
 
 	_, err = rsrc.Allocate()
 	if err == nil {
-		t.Fatalf("Vxlan resource allocation succeeded, expected to fail!")
+		t.Fatalf("VXLAN resource allocation succeeded, expected to fail!")
 	}
 	if !strings.Contains(err.Error(), "no vxlans available.") {
-		t.Fatalf("Vxlan resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
+		t.Fatalf("VXLAN resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
 			"no vxlans available.", err)
 	}
 }
 
-func TestAutoVxlanCfgResourceAllocateVlanExhaustion(t *testing.T) {
-	rsrc := &AutoVxlanCfgResource{}
+func TestAutoVXLANCfgResourceAllocateVLANExhaustion(t *testing.T) {
+	rsrc := &AutoVXLANCfgResource{}
 	rsrc.StateDriver = vxlanRsrcStateDriver
-	rsrc.ID = VxlanRsrcAllocateExhaustVlanID
+	rsrc.ID = VXLANRsrcAllocateExhaustVLANID
 	err := rsrc.Init(&vxlanRsrcValidationStateMap[rsrc.ID].expCfg[0])
 	if err != nil {
-		t.Fatalf("Vxlan resource init failed. Error: %s", err)
+		t.Fatalf("VXLAN resource init failed. Error: %s", err)
 	}
 
 	_, err = rsrc.Allocate()
 	if err == nil {
-		t.Fatalf("Vxlan resource allocation succeeded, expected to fail!")
+		t.Fatalf("VXLAN resource allocation succeeded, expected to fail!")
 	}
 	if !strings.Contains(err.Error(), "no local vlans available.") {
-		t.Fatalf("Vxlan resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
+		t.Fatalf("VXLAN resource allocation failure reason mismatch. Expected: %s, rcvd: %s",
 			"no local vlans available.", err)
 	}
 }
 
-func TestAutoVxlanCfgResourceDeAllocate(t *testing.T) {
-	rsrc := &AutoVxlanCfgResource{}
+func TestAutoVXLANCfgResourceDeAllocate(t *testing.T) {
+	rsrc := &AutoVXLANCfgResource{}
 	rsrc.StateDriver = vxlanRsrcStateDriver
-	rsrc.ID = VxlanRsrcDeallocateID
+	rsrc.ID = VXLANRsrcDeallocateID
 	err := rsrc.Init(&vxlanRsrcValidationStateMap[rsrc.ID].expCfg[0])
 	if err != nil {
-		t.Fatalf("Vxlan resource init failed. Error: %s", err)
+		t.Fatalf("VXLAN resource init failed. Error: %s", err)
 	}
 
 	pair, err1 := rsrc.Allocate()
 	if err1 != nil {
-		t.Fatalf("Vxlan resource allocation failed. Error: %s", err1)
+		t.Fatalf("VXLAN resource allocation failed. Error: %s", err1)
 	}
 
 	err = rsrc.Deallocate(pair)
 	if err != nil {
-		t.Fatalf("Vxlan resource deallocation failed. Error: %s", err)
+		t.Fatalf("VXLAN resource deallocation failed. Error: %s", err)
 	}
 }

--- a/state/fakestatedriver.go
+++ b/state/fakestatedriver.go
@@ -8,37 +8,41 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-// The FakeStateDriver implements core.StateDriver interface for use with
-// unit-tests
-
-type ValueData struct {
+type valueData struct {
 	value []byte
 }
 
-type FakeStateDriverConfig struct {
-}
+// FakeStateDriverConfig represents the configuration of the fake statedriver,
+// which is an empty struct.
+type FakeStateDriverConfig struct{}
 
+// FakeStateDriver implements core.StateDriver interface for use with
+// unit-tests
 type FakeStateDriver struct {
-	TestState map[string]ValueData
+	TestState map[string]valueData
 }
 
+// Init the driver
 func (d *FakeStateDriver) Init(config *core.Config) error {
-	d.TestState = make(map[string]ValueData)
+	d.TestState = make(map[string]valueData)
 
 	return nil
 }
 
+// Deinit the driver
 func (d *FakeStateDriver) Deinit() {
 	d.TestState = nil
 }
 
+// Write value to key
 func (d *FakeStateDriver) Write(key string, value []byte) error {
-	val := ValueData{value: value}
+	val := valueData{value: value}
 	d.TestState[key] = val
 
 	return nil
 }
 
+// Read value from key
 func (d *FakeStateDriver) Read(key string) ([]byte, error) {
 	if val, ok := d.TestState[key]; ok {
 		return val.value, nil
@@ -47,6 +51,7 @@ func (d *FakeStateDriver) Read(key string) ([]byte, error) {
 	return []byte{}, core.Errorf("Key not found!")
 }
 
+// ReadAll values from baseKey
 func (d *FakeStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	values := [][]byte{}
 
@@ -58,10 +63,12 @@ func (d *FakeStateDriver) ReadAll(baseKey string) ([][]byte, error) {
 	return values, nil
 }
 
+// WatchAll values from baseKey
 func (d *FakeStateDriver) WatchAll(baseKey string, rsps chan [2][]byte) error {
 	return core.Errorf("not supported")
 }
 
+// ClearState clears key
 func (d *FakeStateDriver) ClearState(key string) error {
 	if _, ok := d.TestState[key]; ok {
 		delete(d.TestState, key)
@@ -69,6 +76,7 @@ func (d *FakeStateDriver) ClearState(key string) error {
 	return nil
 }
 
+// ReadState unmarshals state into a core.State
 func (d *FakeStateDriver) ReadState(key string, value core.State,
 	unmarshal func([]byte, interface{}) error) error {
 	encodedState, err := d.Read(key)
@@ -84,16 +92,19 @@ func (d *FakeStateDriver) ReadState(key string, value core.State,
 	return nil
 }
 
+// ReadAllState reads all state from baseKey of a given type
 func (d *FakeStateDriver) ReadAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error) ([]core.State, error) {
 	return ReadAllStateCommon(d, baseKey, sType, unmarshal)
 }
 
+// WatchAllState reads all state from baseKey of a given type
 func (d *FakeStateDriver) WatchAllState(baseKey string, sType core.State,
 	unmarshal func([]byte, interface{}) error, rsps chan core.WatchState) error {
 	return core.Errorf("not supported")
 }
 
+// WriteState writes a core.State to key.
 func (d *FakeStateDriver) WriteState(key string, value core.State,
 	marshal func(interface{}) ([]byte, error)) error {
 	encodedState, err := marshal(value)
@@ -109,8 +120,9 @@ func (d *FakeStateDriver) WriteState(key string, value core.State,
 	return nil
 }
 
+// DumpState is a debugging tool.
 func (d *FakeStateDriver) DumpState() {
-	for key, _ := range d.TestState {
+	for key := range d.TestState {
 		log.Printf("key: %q\n", key)
 	}
 }


### PR DESCRIPTION
There will be a third pass which I hope to complete either later tonight or tomorrow. For now, this is probably too much to review as is, sorry about that.

acronyms: since golint requires 'IP' and 'ID' to be spelled in upper case, I took it upon myself to make some appropriate conversions of the other acronyms we use a lot. Therefore VXLAN and VLAN are now uppercase throughout the source, where before they were just capitalized.

The comments aren't that great and I apologize for that -- please correct me where I made mistakes. I'm sure I got a few things wrong.