### PR TITLE
Allow docker to be injected from the GOPATH if it exists.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: all build clean default system-test unit-test
 
-TO_BUILD := ./netplugin/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/pslibnet/
+TO_BUILD := ./netplugin/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/pslibnet/ ./mgmtfn/docknet
 HOST_GOBIN := `which go | xargs dirname`
 HOST_GOROOT := `go env GOROOT`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,11 +55,11 @@ if [ $# -gt 0 ]; then
     (echo "export $@" >> /etc/default/docker && \
      service docker restart) || exit 1
 fi
-
 ## install openvswitch and enable ovsdb-server to listen for incoming requests
 #(apt-get install -y openvswitch-switch > /dev/null) || exit 1
 (ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
  ovs-vsctl set-manager ptcp:6640) || exit 1
+
 SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"
@@ -132,6 +132,13 @@ provision_node = <<SCRIPT
  -listen-peer-urls http://#{node_addr}:2380 \
  -initial-cluster #{node_peers} \
  -initial-cluster-state new 0<&- &>/tmp/etcd.log &) || exit 1
+
+if [ -f "#{netplugin_synced_gopath}/bin/docker" ]
+then
+  service docker stop
+  cp -v "#{netplugin_synced_gopath}/bin/docker" /usr/bin/docker
+  service docker restart
+fi
 SCRIPT
             node.vm.provision "shell" do |s|
                 s.inline = provision_node


### PR DESCRIPTION
Small patch to import docker from $GOPATH if it is placed there, the idea being that we can run bleeding edge versions of docker this way. Quick n' Dirty. Let me know if you would like this done another way.