### PR TITLE
Update core.Errorf to calculate the stack trace at the point of construction.

### DIFF
--- a/core/error_test.go
+++ b/core/error_test.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -10,12 +12,47 @@ func TestErrorStringFormat(t *testing.T) {
 	e := Errorf("%s", refStr)
 
 	fileName := "error_test.go"
-	lineNum := 10 // line number where error was formed
+	lineNum := 12 // line number where error was formed
+	funcName := "github.com/contiv/netplugin/core.TestErrorStringFormat"
 
-	expectedStr := fmt.Sprintf("%s [%s %d]", refStr, fileName, lineNum)
+	expectedStr := fmt.Sprintf("%s [%s %s %d]", refStr, funcName, fileName, lineNum)
 
 	if e.Error() != expectedStr {
 		t.Fatalf("error string mismatch. Expected: %q, got %q", expectedStr,
 			e.Error())
+	}
+}
+
+func getError(msg string) *Error {
+	return Errorf(msg)
+}
+
+func TestErrorStackTrace(t *testing.T) {
+	msg := "an error"
+	e := getError(msg)
+
+	if e.desc != msg {
+		t.Fatal("Description did not match provided")
+	}
+
+	fileName := "error_test.go"
+	lineNum := 27 // line number where error was formed
+	funcName := "github.com/contiv/netplugin/core.getError"
+
+	expectedStr := fmt.Sprintf("%s [%s %s %d]", msg, funcName, fileName, lineNum)
+
+	if e.Error() != expectedStr {
+		t.Fatalf("Error message yielded an incorrect result with CONTIV_TRACE unset: %s", e.Error())
+	}
+
+	os.Setenv("CONTIV_TRACE", "1")
+	if e.Error() == "an error\n" {
+		t.Fatal("Error message did not yield stack trace with CONTIV_TRACE set")
+	}
+
+	lines := strings.Split(e.Error(), "\n")
+
+	if len(lines) != 6 {
+		t.Fatalf("Stack trace yielded incorrect count: %d", len(lines))
 	}
 }

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -585,6 +585,7 @@ func main() {
 
 	if opts.debug {
 		log.SetLevel(log.DebugLevel)
+		os.Setenv("CONTIV_TRACE", "1")
 	}
 
 	if opts.jsonLog {


### PR DESCRIPTION
This allows us to show a trace, which will be provided on any
`(*core.Error).Error()` (used in logging and printing functions) call if
`CONTIV_TRACE` is set.

Not exactly required but I think will prove handy. The original error messages are enhanced to contain the function name (including the namespace). 

PTAL and let me know what you think.