### PR TITLE
netdcli now returns JSON output when queried with `-oper get`

### DIFF
--- a/netdcli/netdcli.go
+++ b/netdcli/netdcli.go
@@ -16,12 +16,12 @@ limitations under the License.
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/drivers"
@@ -500,10 +500,11 @@ func executeOpts(opts *cliOpts) error {
 		if err != nil {
 			log.Fatalf("Failed to read %s. Error: %s", opts.construct.Get(), err)
 		} else {
-			//XXX: poor man's pretty print for struct to keep output greppable
-			//on individual structure fields
-			log.Infof("%s State: \n%s\n", opts.construct.Get(),
-				strings.Replace(fmt.Sprintf("%+v", coreState), " ", ",\n\t", -1))
+			content, err := json.MarshalIndent(coreState, "", "  ")
+			if err != nil {
+				log.Fatalf("Failed to marshal corestate %+v", coreState)
+			}
+			fmt.Println(string(content))
 		}
 	case cliOperAttach, cliOperDetach, cliOperCreate:
 		err = coreState.Write()


### PR DESCRIPTION
I'd like this to eliminate the bespoke parsers we have in a lot of places to scrape netdcli's output.

Note that this breaks pslibnet and k8contivnet; I was hoping since you guys have testbeds, etc for these you could make the appropriate corrections. As you can see in the system tests it's not very complicated to change.

the `drivers` reference while unmarshalling is something we need to shove in a struct in netmaster, I think, to abstract it from OVS. I talked to @mapuri yesterday about a network driver I want to write, and that will alleviate this problem then.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>