### PR TITLE
Add utility functions for driver instantiation

### DIFF
--- a/drivers/fakenetepdriver.go
+++ b/drivers/fakenetepdriver.go
@@ -1,0 +1,46 @@
+package drivers
+
+import "github.com/contiv/netplugin/core"
+
+// FakeNetEpDriverConfig represents the configuration of the fakedriver,
+// which is an empty struct.
+type FakeNetEpDriverConfig struct{}
+
+// FakeNetEpDriver implements core.NetworkDriver and core.EndpointDriver interface
+// for use with unit-tests
+type FakeNetEpDriver struct {
+}
+
+// Init is not implemented.
+func (d *FakeNetEpDriver) Init(config *core.Config, info *core.InstanceInfo) error {
+	return nil
+}
+
+// Deinit is not implemented.
+func (d *FakeNetEpDriver) Deinit() {
+}
+
+// CreateNetwork is not implemented.
+func (d *FakeNetEpDriver) CreateNetwork(id string) error {
+	return core.Errorf("Not implemented")
+}
+
+// DeleteNetwork is not implemented.
+func (d *FakeNetEpDriver) DeleteNetwork(id string) error {
+	return core.Errorf("Not implemented")
+}
+
+// CreateEndpoint is not implemented.
+func (d *FakeNetEpDriver) CreateEndpoint(id string) error {
+	return core.Errorf("Not implemented")
+}
+
+// DeleteEndpoint is not implemented.
+func (d *FakeNetEpDriver) DeleteEndpoint(id string) (err error) {
+	return core.Errorf("Not implemented")
+}
+
+// MakeEndpointAddress is not implemented.
+func (d *FakeNetEpDriver) MakeEndpointAddress() (*core.Address, error) {
+	return nil, core.Errorf("Not implemented")
+}

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/contiv/netplugin/crtclient/docker"
 	"github.com/contiv/netplugin/drivers"
 	"github.com/contiv/netplugin/plugin"
+	"github.com/contiv/netplugin/utils"
 	"github.com/samalba/dockerclient"
 
 	log "github.com/Sirupsen/logrus"
@@ -602,14 +603,14 @@ func main() {
 
 	defConfigStr := fmt.Sprintf(`{
                     "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
+                       "network": %q,
+                       "endpoint": %q,
                        "state": "etcd"
                     },
                     "plugin-instance": {
-                       "host-label": "%s"
+                       "host-label": %q
                     },
-                    "ovs" : {
+                    %q : {
                        "dbip": "127.0.0.1",
                        "dbport": 6640
                     },
@@ -622,7 +623,7 @@ func main() {
                     "docker" : {
                         "socket" : "unix:///var/run/docker.sock"
                     }
-                  }`, opts.hostLabel)
+                  }`, utils.OvsNameStr, utils.OvsNameStr, utils.OvsNameStr, opts.hostLabel)
 
 	netPlugin := &plugin.NetPlugin{}
 

--- a/plugin/netplugin_test.go
+++ b/plugin/netplugin_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package plugin
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/contiv/netplugin/state"
@@ -25,12 +24,6 @@ import (
 var fakeStateDriver *state.FakeStateDriver
 
 func TestNetPluginInit(t *testing.T) {
-	/* make a temporary entry for statedriver for unit-tests*/
-	stateDriverRegistry["fakedriver"] = driverConfigTypes{
-		DriverType: reflect.TypeOf(state.FakeStateDriver{}),
-		ConfigType: reflect.TypeOf(state.FakeStateDriverConfig{}),
-	}
-
 	configStr := `{
                     "drivers" : {
                        "network": "ovs",

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -17,6 +17,7 @@ test_packages="github.com/contiv/netplugin/drivers \
     github.com/contiv/netplugin/netmaster \
     github.com/contiv/netplugin/resources \
     github.com/contiv/netplugin/core \
+    github.com/contiv/netplugin/utils \
     "
 
 while [ "${#}" -gt 0 ]

--- a/utils/driverfactory.go
+++ b/utils/driverfactory.go
@@ -1,0 +1,175 @@
+package utils
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/drivers"
+	"github.com/contiv/netplugin/state"
+)
+
+// implement utilities for instantiating the supported core.Driver
+// (state, network and endpoint) instances
+
+type driverConfigTypes struct {
+	DriverType reflect.Type
+	ConfigType reflect.Type
+}
+
+var networkDriverRegistry = map[string]driverConfigTypes{
+	OvsNameStr: driverConfigTypes{
+		DriverType: reflect.TypeOf(drivers.OvsDriver{}),
+		ConfigType: reflect.TypeOf(drivers.OvsDriverConfig{}),
+	},
+	// fakedriver is used for tests, so not exposing a public name for it.
+	"fakedriver": driverConfigTypes{
+		DriverType: reflect.TypeOf(drivers.FakeNetEpDriver{}),
+		ConfigType: reflect.TypeOf(drivers.FakeNetEpDriverConfig{}),
+	},
+}
+
+var endpointDriverRegistry = map[string]driverConfigTypes{
+	OvsNameStr: driverConfigTypes{
+		DriverType: reflect.TypeOf(drivers.OvsDriver{}),
+		ConfigType: reflect.TypeOf(drivers.OvsDriverConfig{}),
+	},
+	// fakedriver is used for tests, so not exposing a public name for it.
+	"fakedriver": driverConfigTypes{
+		DriverType: reflect.TypeOf(drivers.FakeNetEpDriver{}),
+		ConfigType: reflect.TypeOf(drivers.FakeNetEpDriverConfig{}),
+	},
+}
+
+var stateDriverRegistry = map[string]driverConfigTypes{
+	EtcdNameStr: driverConfigTypes{
+		DriverType: reflect.TypeOf(state.EtcdStateDriver{}),
+		ConfigType: reflect.TypeOf(state.EtcdStateDriverConfig{}),
+	},
+	ConsulNameStr: driverConfigTypes{
+		DriverType: reflect.TypeOf(state.ConsulStateDriver{}),
+		ConfigType: reflect.TypeOf(state.ConsulStateDriverConfig{}),
+	},
+	// fakestate-driver is used for tests, so not exposing a public name for it.
+	"fakedriver": driverConfigTypes{
+		DriverType: reflect.TypeOf(state.FakeStateDriver{}),
+		ConfigType: reflect.TypeOf(state.FakeStateDriverConfig{}),
+	},
+}
+
+const (
+	// EtcdNameStr is a string constant for etcd state-store
+	EtcdNameStr = "etcd"
+	// ConsulNameStr is a string constant for consul state-store
+	ConsulNameStr = "consul"
+	// OvsNameStr is a string constant for ovs driver
+	OvsNameStr = "ovs"
+)
+
+var (
+	gStateDriver core.StateDriver
+)
+
+// initHelper initializes the NetPlugin by mapping driver names to
+// configuration, then it imports the configuration.
+func initHelper(driverRegistry map[string]driverConfigTypes,
+	driverName string, configStr string) (core.Driver, *core.Config, error) {
+	if _, ok := driverRegistry[driverName]; ok {
+		configType := driverRegistry[driverName].ConfigType
+		driverType := driverRegistry[driverName].DriverType
+
+		driverConfig := reflect.New(configType).Interface()
+		err := json.Unmarshal([]byte(configStr), driverConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		config := &core.Config{V: driverConfig}
+		driver := reflect.New(driverType).Interface()
+		return driver, config, nil
+	}
+
+	return nil, nil, core.Errorf("Failed to find a registered driver for: %s", driverName)
+}
+
+// NewStateDriver instantiates a 'named' state-driver with specified configuration
+func NewStateDriver(name, configStr string) (core.StateDriver, error) {
+	if name == "" || configStr == "" {
+		return nil, core.Errorf("invalid driver name or configuration passed.")
+	}
+
+	if gStateDriver != nil {
+		return nil, core.Errorf("statedriver instance already exists.")
+	}
+
+	driver, drvConfig, err := initHelper(stateDriverRegistry, name, configStr)
+	if err != nil {
+		return nil, err
+	}
+
+	d := driver.(core.StateDriver)
+	err = d.Init(drvConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	gStateDriver = d
+	return d, nil
+}
+
+// GetStateDriver returns the singleton instance of the state-driver
+func GetStateDriver() (core.StateDriver, error) {
+	if gStateDriver == nil {
+		return nil, core.Errorf("statedriver has not been not created.")
+	}
+
+	return gStateDriver, nil
+}
+
+// ReleaseStateDriver releases the singleton instance of the state-driver
+func ReleaseStateDriver() {
+	if gStateDriver != nil {
+		gStateDriver.Deinit()
+	}
+	gStateDriver = nil
+}
+
+// NewNetworkDriver instantiates a 'named' network-driver with specified configuration
+func NewNetworkDriver(name, configStr string, instInfo *core.InstanceInfo) (core.NetworkDriver, error) {
+	if name == "" || configStr == "" {
+		return nil, core.Errorf("invalid driver name or configuration passed.")
+	}
+
+	driver, drvConfig, err := initHelper(networkDriverRegistry, name, configStr)
+	if err != nil {
+		return nil, err
+	}
+
+	d := driver.(core.NetworkDriver)
+	err = d.Init(drvConfig, instInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// NewEndpointDriver instantiates a 'named' endpoint-driver with specified configuration
+func NewEndpointDriver(name, configStr string, instInfo *core.InstanceInfo) (core.EndpointDriver, error) {
+	if name == "" || configStr == "" {
+		return nil, core.Errorf("invalid driver name or configuration passed.")
+	}
+
+	driver, drvConfig, err := initHelper(endpointDriverRegistry, name, configStr)
+	if err != nil {
+		return nil, err
+	}
+
+	d := driver.(core.EndpointDriver)
+	err = d.Init(drvConfig, instInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}

--- a/utils/driverfactory_test.go
+++ b/utils/driverfactory_test.go
@@ -1,0 +1,151 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/drivers"
+	"github.com/contiv/netplugin/state"
+)
+
+func TestNewStateDriverValidConfig(t *testing.T) {
+	config := &core.Config{V: &state.FakeStateDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	drv, err := NewStateDriver("fakedriver", string(cfgBytes))
+	defer func() { ReleaseStateDriver() }()
+	if err != nil {
+		t.Fatalf("failed to instantiate state driver. Error: %s", err)
+	}
+	if drv == nil {
+		t.Fatalf("nil driver instance was returned")
+	}
+}
+
+func TestNewStateDriverInvalidConfig(t *testing.T) {
+	_, err := NewStateDriver("fakedriver", "")
+	if err == nil {
+		t.Fatalf("state driver instantiation succeeded, expected to fail")
+	}
+}
+
+func TestNewStateDriverInvalidDriverName(t *testing.T) {
+	config := &core.Config{V: &state.FakeStateDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	_, err = NewStateDriver("non-existent-name", string(cfgBytes))
+	if err == nil {
+		t.Fatalf("state driver instantiation succeeded, expected to fail")
+	}
+}
+
+func TestNewStateDriverSecondCreate(t *testing.T) {
+	config := &core.Config{V: &state.FakeStateDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	_, err = NewStateDriver("fakedriver", string(cfgBytes))
+	defer func() { ReleaseStateDriver() }()
+	if err != nil {
+		t.Fatalf("failed to instantiate state driver. Error: %s", err)
+	}
+
+	_, err = NewStateDriver("fakedriver", string(cfgBytes))
+	if err == nil {
+		t.Fatalf("second state driver instantiation succeeded, expected to fail")
+	}
+}
+
+func TestGetStateDriverNonExistentStateDriver(t *testing.T) {
+	_, err := GetStateDriver()
+	if err == nil {
+		t.Fatalf("getting state-driver succeeded, expected to fail")
+	}
+}
+
+func TestNewNetworkDriverValidConfig(t *testing.T) {
+	config := &core.Config{V: &drivers.FakeNetEpDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	instInfo := &core.InstanceInfo{}
+	drv, err := NewNetworkDriver("fakedriver", string(cfgBytes), instInfo)
+	if err != nil {
+		t.Fatalf("failed to instantiate network driver. Error: %s", err)
+	}
+	if drv == nil {
+		t.Fatalf("nil driver instance was returned")
+	}
+}
+
+func TestNewNetworkDriverInvalidConfig(t *testing.T) {
+	instInfo := &core.InstanceInfo{}
+	_, err := NewNetworkDriver("fakedriver", "", instInfo)
+	if err == nil {
+		t.Fatalf("network driver instantiation succeeded, expected to fail")
+	}
+}
+
+func TestNewNetworkDriverInvalidDriverName(t *testing.T) {
+	config := &core.Config{V: &drivers.FakeNetEpDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	instInfo := &core.InstanceInfo{}
+	_, err = NewNetworkDriver("non-existent-name", string(cfgBytes), instInfo)
+	if err == nil {
+		t.Fatalf("network driver instantiation succeeded, expected to fail")
+	}
+}
+
+func TestNewEndpointDriverValidConfig(t *testing.T) {
+	config := &core.Config{V: &drivers.FakeNetEpDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	instInfo := &core.InstanceInfo{}
+	drv, err := NewEndpointDriver("fakedriver", string(cfgBytes), instInfo)
+	if err != nil {
+		t.Fatalf("failed to instantiate endpoint driver. Error: %s", err)
+	}
+	if drv == nil {
+		t.Fatalf("nil driver instance was returned")
+	}
+}
+
+func TestNewEndpointDriverInvalidConfig(t *testing.T) {
+	instInfo := &core.InstanceInfo{}
+	_, err := NewEndpointDriver("fakedriver", "", instInfo)
+	if err == nil {
+		t.Fatalf("endpoint driver instantiation succeeded, expected to fail")
+	}
+}
+
+func TestNewEndpointDriverInvalidDriverName(t *testing.T) {
+	config := &core.Config{V: &drivers.FakeNetEpDriverConfig{}}
+	cfgBytes, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("marshalling configuration failed. Error: %s", err)
+	}
+
+	instInfo := &core.InstanceInfo{}
+	_, err = NewEndpointDriver("non-existent-name", string(cfgBytes), instInfo)
+	if err == nil {
+		t.Fatalf("endpoint driver instantiation succeeded, expected to fail")
+	}
+}


### PR DESCRIPTION
This aids sharing code for instantiating drivers (particularly state-drivers) between different binaries (viz. netplugin, netdcli) that use state-drivers directly.