### PR TITLE
Fix the WatchAll test case for create to wait a little before triggering create

### DIFF
--- a/state/etcdstatedriver_test.go
+++ b/state/etcdstatedriver_test.go
@@ -291,7 +291,8 @@ func commonTestStateDriverWatchAllStateCreate(t *testing.T, d core.StateDriver) 
 		}
 	}(stateCh, recvErr)
 
-	// trigger create
+	// trigger create after a slight pause to ensure that events are not missed
+	time.Sleep(time.Second)
 	err := d.WriteState(key, state, json.Marshal)
 	if err != nil {
 		t.Fatalf("failed to write state. Error: %s", err)


### PR DESCRIPTION
This allows the go routine running WatchAll() to get a chance to run and not miss events.

fixes #100