### PR TITLE
Minor refactoring to accommodate state-based resource-managers

### DIFF
--- a/netmaster/netmaster.go
+++ b/netmaster/netmaster.go
@@ -123,16 +123,12 @@ func CreateTenant(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 		return err
 	}
 
-	// XXX: instead of initing resource-manager always, just init and
-	// store it once. Also the type of resource-manager should be picked up
-	// based on configuration.
-	ra := &resources.EtcdResourceManager{Etcd: stateDriver}
-	err = ra.Init()
+	tempRm, err := resources.GetStateResourceManager()
 	if err != nil {
 		return err
 	}
 
-	err = gCfg.Process(core.ResourceManager(ra))
+	err = gCfg.Process(core.ResourceManager(tempRm))
 	if err != nil {
 		log.Errorf("Error updating the config %+v. Error: %s", gCfg, err)
 		return err
@@ -460,15 +456,11 @@ func CreateNetworks(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 		return err
 	}
 
-	// XXX: instead of initing resource-manager always, just init and
-	// store it once. Also the type of resource-manager should be picked up
-	// based on configuration.
-	tempRa := &resources.EtcdResourceManager{Etcd: stateDriver}
-	err = tempRa.Init()
+	tempRm, err := resources.GetStateResourceManager()
 	if err != nil {
 		return err
 	}
-	ra := core.ResourceManager(tempRa)
+	rm := core.ResourceManager(tempRm)
 
 	err = validateNetworkConfig(tenant)
 	if err != nil {
@@ -505,12 +497,12 @@ func CreateNetworks(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 		}
 		if nwMasterCfg.PktTag == "" {
 			if nwCfg.PktTagType == "vlan" {
-				pktTag, err = gCfg.AllocVLAN(ra)
+				pktTag, err = gCfg.AllocVLAN(rm)
 				if err != nil {
 					return err
 				}
 			} else if nwCfg.PktTagType == "vxlan" {
-				extPktTag, pktTag, err = gCfg.AllocVXLAN(ra)
+				extPktTag, pktTag, err = gCfg.AllocVXLAN(rm)
 				if err != nil {
 					return err
 				}
@@ -529,7 +521,7 @@ func CreateNetworks(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 
 		if nwCfg.SubnetIP == "" {
 			nwCfg.SubnetLen = gCfg.Auto.AllocSubnetLen
-			nwCfg.SubnetIP, err = gCfg.AllocSubnet(ra)
+			nwCfg.SubnetIP, err = gCfg.AllocSubnet(rm)
 			if err != nil {
 				return err
 			}
@@ -578,24 +570,20 @@ func CreateNetworks(stateDriver core.StateDriver, tenant *ConfigTenant) error {
 func freeNetworkResources(stateDriver core.StateDriver, nwMasterCfg *MasterNwConfig,
 	nwCfg *drivers.OvsCfgNetworkState, gCfg *gstate.Cfg) (err error) {
 
-	// XXX: instead of initing resource-manager always, just init and
-	// store it once. Also the type of resource-manager should be picked up
-	// based on configuration.
-	tempRa := &resources.EtcdResourceManager{Etcd: stateDriver}
-	err = tempRa.Init()
+	tempRm, err := resources.GetStateResourceManager()
 	if err != nil {
 		return err
 	}
-	ra := core.ResourceManager(tempRa)
+	rm := core.ResourceManager(tempRm)
 
 	if nwCfg.PktTagType == "vlan" {
-		err = gCfg.FreeVLAN(ra, uint(nwCfg.PktTag))
+		err = gCfg.FreeVLAN(rm, uint(nwCfg.PktTag))
 		if err != nil {
 			return err
 		}
 	} else if nwCfg.PktTagType == "vxlan" {
 		log.Infof("freeing vlan %d vxlan %d", nwCfg.PktTag, nwCfg.ExtPktTag)
-		err = gCfg.FreeVXLAN(ra, uint(nwCfg.ExtPktTag), uint(nwCfg.PktTag))
+		err = gCfg.FreeVXLAN(rm, uint(nwCfg.ExtPktTag), uint(nwCfg.PktTag))
 		if err != nil {
 			return err
 		}
@@ -603,7 +591,7 @@ func freeNetworkResources(stateDriver core.StateDriver, nwMasterCfg *MasterNwCon
 
 	if nwMasterCfg.SubnetIP == "" {
 		log.Infof("freeing subnet %s/%s", nwCfg.SubnetIP, nwCfg.SubnetLen)
-		err = gCfg.FreeSubnet(ra, nwCfg.SubnetIP)
+		err = gCfg.FreeSubnet(rm, nwCfg.SubnetIP)
 		if err != nil {
 			return err
 		}

--- a/netmaster/netmaster_test.go
+++ b/netmaster/netmaster_test.go
@@ -17,9 +17,11 @@ package netmaster
 
 import (
 	"encoding/json"
+	"log"
 	"strings"
 	"testing"
 
+	"github.com/contiv/netplugin/resources"
 	"github.com/contiv/netplugin/state"
 )
 
@@ -33,6 +35,12 @@ func applyConfig(t *testing.T, cfgBytes []byte) {
 	}
 
 	fakeDriver.Init(nil)
+	_, err = resources.NewStateResourceManager(fakeDriver)
+	if err != nil {
+		log.Fatalf("state store initialization failed. Error: %s", err)
+	}
+	defer func() { resources.ReleaseStateResourceManager() }()
+
 	for _, host := range cfg.Hosts {
 		err = CreateHost(fakeDriver, &host)
 		if err != nil {


### PR DESCRIPTION
Renamed the current ResourceManager implementation to imply that it is based of a distributed statestore. This enables integration with different underlying statestores.

Note that this also now requires the StateStore interfaces to be added/defined for consistent/atomic
read/writes, which shall be handled as separate commit.