### PR TITLE
Add system-tests for consul state-store integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ unit-test: build
 system-test: build
 	CONTIV_HOST_GOPATH=$(GOPATH) godep go test -v -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/singlehost 
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -v -run "sanity" \
+	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 50m -v -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
 # setting CONTIV_SOE=1 while calling 'make regress-test' will stop the test

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -569,7 +570,7 @@ func main() {
 	flagSet.StringVar(&opts.hostLabel,
 		"host-label",
 		defHostLabel,
-		"label used to identify endpoints homed for this host, default is host name")
+		"label used to identify endpoints homed for this host, default is host name. If -config flag is used then host-label must be specified in the the configuration passed.")
 	flagSet.BoolVar(&opts.nativeInteg,
 		"native-integration",
 		false,
@@ -623,7 +624,7 @@ func main() {
                     "docker" : {
                         "socket" : "unix:///var/run/docker.sock"
                     }
-                  }`, utils.OvsNameStr, utils.OvsNameStr, utils.OvsNameStr, opts.hostLabel)
+                  }`, utils.OvsNameStr, utils.OvsNameStr, opts.hostLabel, utils.OvsNameStr)
 
 	netPlugin := &plugin.NetPlugin{}
 
@@ -643,6 +644,19 @@ func main() {
 			log.Fatalf("reading config from file failed. Error: %s", err)
 		}
 	}
+
+	// extract host-label from the configuration
+	tmpInstInfo := &struct {
+		Instance core.InstanceInfo `json:"plugin-instance"`
+	}{}
+	err = json.Unmarshal(config, tmpInstInfo)
+	if err != nil {
+		log.Fatalf("Failed to parse configuration. Error: %s", err)
+	}
+	if tmpInstInfo.Instance.HostLabel == "" {
+		log.Fatalf("Empty host-label passed in configuration")
+	}
+	opts.hostLabel = tmpInstInfo.Instance.HostLabel
 
 	err = netPlugin.Init(string(config))
 	if err != nil {

--- a/scripts/cleanup
+++ b/scripts/cleanup
@@ -27,6 +27,7 @@ then
 fi
 
 etcdctl rm -recursive /contiv > /dev/null 2>&1
+curl -X DELETE http://localhost:8500/v1/kv/contiv?recurse > /dev/null 2>&1
 ovs-vsctl del-br contivBridge > /dev/null 2>&1
 
 echo "cleanup complete!"

--- a/systemtests/singlehost/regression_test.go
+++ b/systemtests/singlehost/regression_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/contiv/netplugin/systemtests/utils"
+	u "github.com/contiv/netplugin/utils"
 )
 
 func TestOneHostMultipleNets_regress(t *testing.T) {
@@ -41,7 +42,7 @@ func TestOneHostMultipleNets_regress(t *testing.T) {
 	defer func() {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
-	ipAddress := utils.GetIPAddress(t, node1, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node1, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node1, "myContainer2", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node1, "myContainer2")
@@ -51,7 +52,7 @@ func TestOneHostMultipleNets_regress(t *testing.T) {
 	defer func() {
 		utils.DockerCleanup(t, node1, "myContainer4")
 	}()
-	ipAddress = utils.GetIPAddress(t, node1, "purple-myContainer4")
+	ipAddress = utils.GetIPAddress(t, node1, "purple-myContainer4", u.EtcdNameStr)
 	utils.StartClient(t, node1, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node1, "myContainer3")
@@ -78,7 +79,7 @@ func TestOneHostVlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node1, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node1, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node1, "myContainer2", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node1, "myContainer2")

--- a/systemtests/singlehost/sanity_test.go
+++ b/systemtests/singlehost/sanity_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/contiv/netplugin/systemtests/utils"
+	u "github.com/contiv/netplugin/utils"
 )
 
 // Testcase:
@@ -63,7 +64,7 @@ func TestSingleHostSingleVlanPingSuccess_sanity(t *testing.T) {
 		utils.DockerCleanup(t, node, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node, "myContainer2", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node, "myContainer2")
@@ -123,7 +124,7 @@ func TestSingleHostMultiVlanPingSuccess_sanity(t *testing.T) {
 		utils.DockerCleanup(t, node, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node, "myContainer2", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node, "myContainer2")
@@ -134,7 +135,7 @@ func TestSingleHostMultiVlanPingSuccess_sanity(t *testing.T) {
 		utils.DockerCleanup(t, node, "myContainer4")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node, "purple-myContainer4")
+	ipAddress = utils.GetIPAddress(t, node, "purple-myContainer4", u.EtcdNameStr)
 	utils.StartClient(t, node, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node, "myContainer3")
@@ -187,7 +188,7 @@ func TestSingleHostMultiVlanPingFailure_sanity(t *testing.T) {
 		utils.DockerCleanup(t, node, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClientFailure(t, node, "myContainer2", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node, "myContainer2")

--- a/systemtests/twohosts/regression_test.go
+++ b/systemtests/twohosts/regression_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/contiv/netplugin/systemtests/utils"
+	u "github.com/contiv/netplugin/utils"
 )
 
 func TestMultipleEpsInContainer_regress(t *testing.T) {
@@ -44,13 +45,13 @@ func TestMultipleEpsInContainer_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node1, "orange-myContainer2")
+	ipAddress := utils.GetIPAddress(t, node1, "orange-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node1, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node1, "myContainer3")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -62,7 +63,7 @@ func TestMultipleEpsInContainer_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress = utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -100,7 +101,7 @@ func TestTwoHostVlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node2, "myContainer4")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer2")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -110,7 +111,7 @@ func TestTwoHostVlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "orange-myContainer4")
+	ipAddress = utils.GetIPAddress(t, node2, "orange-myContainer4", u.EtcdNameStr)
 	utils.DockerCleanup(t, node2, "myContainer3")
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
@@ -150,7 +151,7 @@ func TestTwoHostVxlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node2, "myContainer4")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer2")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -160,7 +161,7 @@ func TestTwoHostVxlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "orange-myContainer4")
+	ipAddress = utils.GetIPAddress(t, node2, "orange-myContainer4", u.EtcdNameStr)
 	utils.DockerCleanup(t, node2, "myContainer3")
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
@@ -196,7 +197,7 @@ func TestTwoHostsMultipleTenants_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -208,7 +209,7 @@ func TestTwoHostsMultipleTenants_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -237,7 +238,7 @@ func TestTwoHostsMultipleTenantsMixVlanVxlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -249,7 +250,7 @@ func TestTwoHostsMultipleTenantsMixVlanVxlan_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -278,7 +279,7 @@ func TestTwoHostsMultipleVlansNets_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.DockerCleanup(t, node2, "myContainer3")
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
@@ -291,7 +292,7 @@ func TestTwoHostsMultipleVlansNets_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -320,7 +321,7 @@ func TestTwoHostsMultipleVxlansNets_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -332,7 +333,7 @@ func TestTwoHostsMultipleVxlansNets_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -367,7 +368,7 @@ func TestTwoHostsMultipleVxlansNetsLateHostBindings_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer1")
 	}()
 
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
@@ -379,7 +380,7 @@ func TestTwoHostsMultipleVxlansNetsLateHostBindings_regress(t *testing.T) {
 		utils.DockerCleanup(t, node1, "myContainer2")
 	}()
 
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -421,12 +422,12 @@ func TestTwoHostsMultipleVxlansNetsLateContainerBindings_regress(t *testing.T) {
 	utils.ApplyHostBindingsConfig(t, jsonCfgStr, node1)
 
 	// start client containers and test ping: myContainer1 and myContainer4
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myContainer1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
 	}()
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myContainer2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")
@@ -475,12 +476,12 @@ func TestTwoHostsMultipleVxlansNetsInfraContainerBindings_regress(t *testing.T) 
 	utils.ApplyHostBindingsConfig(t, jsonCfgStr, node1)
 
 	// start client containers and test ping: myContainer1 and myContainer4
-	ipAddress := utils.GetIPAddress(t, node2, "orange-myPod1")
+	ipAddress := utils.GetIPAddress(t, node2, "orange-myPod1", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer3", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer3")
 	}()
-	ipAddress = utils.GetIPAddress(t, node2, "purple-myPod2")
+	ipAddress = utils.GetIPAddress(t, node2, "purple-myPod2", u.EtcdNameStr)
 	utils.StartClient(t, node2, "myContainer4", ipAddress)
 	defer func() {
 		utils.DockerCleanup(t, node2, "myContainer4")


### PR DESCRIPTION
Changes are mostly around modifying the test-infra to take netplugin configuration with consul.

In addition there is a:
- fix in netd.go to correctly setup host-label when netplugin configuration is passed from command-line
- fix in consul driver to trim a leading / in the keys as consul driver rejects the keys otherwise.
