### PR TITLE
Re-enable dind system tests

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -31,7 +31,7 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "71287c33566a0b4e552280eddbc66655ac2ac5e1"
+			"Rev": "745d8b6ec38fcff41e7123f9db524ab329a91444"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/etcdserver/etcdhttp/httptypes",

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/
 HOST_GOBIN := `which go | xargs dirname`
 HOST_GOROOT := `go env GOROOT`
 
-all: build unit-test system-test
+all: build unit-test system-test system-test-dind
 
 default: build
 
@@ -48,7 +48,7 @@ unit-test: build
 # as part of development.
 system-test: build
 	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -v -run "sanity" \
-					   github.com/contiv/netplugin/systemtests/singlehost 
+					   github.com/contiv/netplugin/systemtests/singlehost
 	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 60m -v -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
@@ -57,11 +57,11 @@ system-test: build
 # as part of development.
 regress-test: build
 	CONTIV_HOST_GOPATH=$(GOPATH) godep go test -v -run "regress" \
-					   github.com/contiv/netplugin/systemtests/singlehost 
+					   github.com/contiv/netplugin/systemtests/singlehost
 	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 60m -v -run "regress" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
-# Setting CONTIV_TESTBED=DIND uses docker in docker as the testbed instead of vagrant VMs. 
+# Setting CONTIV_TESTBED=DIND uses docker in docker as the testbed instead of vagrant VMs.
 system-test-dind:
 	CONTIV_TESTBED=DIND make system-test
 

--- a/scripts/dockerhost/start-dockerhosts
+++ b/scripts/dockerhost/start-dockerhosts
@@ -56,7 +56,9 @@ echo $scriptdir
 
 # Create a linux bridge between containers
 sudo brctl addbr br-em1
+sudo brctl addbr br-em2
 sudo ip link set br-em1 up
+sudo ip link set br-em2 up
 
 num_nodes=1
 if [ -n "$CONTIV_NODES" ];
@@ -95,17 +97,25 @@ do
         -c "/gopath/src/github.com/contiv/netplugin/scripts/dockerhost/start-service.sh & bash"
     sudo docker exec $host hostname $host
     sudo docker exec $host sh -c 'echo $(hostname -I | cut -d\  -f1) $(hostname) | tee -a /etc/hosts'
+    # Create eth1
     sudo ip link add $i-int type veth peer name $i-ext
     sudo brctl addif br-em1 $i-ext
     sudo ip link set $i-ext up
     sudo ip link set netns $($scriptdir/docker-pid $host) dev $i-int
-    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set dev $i-int name eth2
-    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set eth2 up
+    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set dev $i-int name eth1
+    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set eth1 up
     addr=$((10+$i-1))
     ip_addr="192.168.2."$addr"/32"
     echo "IP address = "$ip_addr
-    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip addr add $ip_addr dev eth2
-    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip route add "192.168.2.0/24" dev eth2
+    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip addr add $ip_addr dev eth1
+    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip route add "192.168.2.0/24" dev eth1
+    # Create eth2
+    sudo ip link add $i-int2 type veth peer name $i-ext2
+    sudo brctl addif br-em2 $i-ext2
+    sudo ip link set $i-ext2 up
+    sudo ip link set netns $($scriptdir/docker-pid $host) dev $i-int2
+    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set dev $i-int2 name eth2
+    sudo nsenter -t $($scriptdir/docker-pid $host) -n ip link set eth2 up
     if [ $i -gt "1" ]; then
 	cluster=$cluster",";
     fi

--- a/systemtests/utils/dindnode.go
+++ b/systemtests/utils/dindnode.go
@@ -15,10 +15,6 @@ limitations under the License.
 
 package utils
 
-import (
-	"time"
-)
-
 // DindNode implements a node in docker-in-docker (dind) testbed
 type DindNode struct {
 	Name    string
@@ -36,9 +32,6 @@ func (n DindNode) RunCommand(cmd string) error {
 func (n DindNode) RunCommandWithOutput(cmd string) (string, error) {
 	tcmd := &TestCommand{ContivNodes: n.NodeNum}
 	output, err := tcmd.RunWithOutput("sh", "-c", "sudo docker exec "+n.Name+" "+cmd)
-
-	time.Sleep(500 * time.Millisecond)
-
 	return string(output), err
 }
 
@@ -46,9 +39,6 @@ func (n DindNode) RunCommandWithOutput(cmd string) (string, error) {
 func (n DindNode) RunCommandBackground(cmd string) (string, error) {
 	tcmd := &TestCommand{ContivNodes: n.NodeNum}
 	output, err := tcmd.RunWithOutput("sh", "-c", "sudo docker exec -d "+n.Name+" "+cmd)
-
-	time.Sleep(1 * time.Second)
-
 	return string(output), err
 }
 

--- a/systemtests/utils/dindnode.go
+++ b/systemtests/utils/dindnode.go
@@ -15,6 +15,10 @@ limitations under the License.
 
 package utils
 
+import (
+	"time"
+)
+
 // DindNode implements a node in docker-in-docker (dind) testbed
 type DindNode struct {
 	Name    string
@@ -32,6 +36,9 @@ func (n DindNode) RunCommand(cmd string) error {
 func (n DindNode) RunCommandWithOutput(cmd string) (string, error) {
 	tcmd := &TestCommand{ContivNodes: n.NodeNum}
 	output, err := tcmd.RunWithOutput("sh", "-c", "sudo docker exec "+n.Name+" "+cmd)
+
+	time.Sleep(500 * time.Millisecond)
+
 	return string(output), err
 }
 
@@ -39,6 +46,9 @@ func (n DindNode) RunCommandWithOutput(cmd string) (string, error) {
 func (n DindNode) RunCommandBackground(cmd string) (string, error) {
 	tcmd := &TestCommand{ContivNodes: n.NodeNum}
 	output, err := tcmd.RunWithOutput("sh", "-c", "sudo docker exec -d "+n.Name+" "+cmd)
+
+	time.Sleep(1 * time.Second)
+
 	return string(output), err
 }
 

--- a/systemtests/utils/utils.go
+++ b/systemtests/utils/utils.go
@@ -127,7 +127,7 @@ func StartNetPluginWithConfig(t *testing.T, nodes []TestbedNode, nativeInteg boo
 		}
 	}
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 }
 
 // StartNetPlugin starts netplugin on  specified testbed nodes

--- a/systemtests/utils/utils.go
+++ b/systemtests/utils/utils.go
@@ -126,6 +126,8 @@ func StartNetPluginWithConfig(t *testing.T, nodes []TestbedNode, nativeInteg boo
 				err, cmdStr, output)
 		}
 	}
+
+	time.Sleep(1 * time.Second)
 }
 
 // StartNetPlugin starts netplugin on  specified testbed nodes


### PR DESCRIPTION
I had disabled dind system tests to build a new docker image with ovs2.3.1 and fix some timing issues.
This change will:

- Enable dind system tests
- Pull new contiv/ubuntu docker image with ovs2.3.1 and docker 1.7
- Fix some timing issues seen in dind tests.
- changes dind docker network interfaces to be same as vagrant setup