### PR TITLE
Misc changes for parallel sanity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,12 @@ TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/
 HOST_GOBIN := `which go | xargs dirname`
 HOST_GOROOT := `go env GOROOT`
 
-all: build unit-test system-test system-test-dind
+all: build unit-test system-test system-test-dind centos-tests
+
+# 'all-CI' target is used by the scripts/CI.sh that passes appropriate set of
+# ENV variables (from the jenkins job) to run OS (centos, ubuntu etc) and
+# sandbox specific(vagrant, docker-in-docker)
+all-CI: build unit-test system-test
 
 default: build
 
@@ -51,15 +56,15 @@ unit-test-centos: build
 # on first failure and leave setup in that state. This can be useful for debugging
 # as part of development.
 system-test: build
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -v -run "sanity" \
+	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/singlehost 
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 80m -v -run "sanity" \
+	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 80m -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
 system-test-centos: build
-	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -v -run "sanity" \
+	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/singlehost
-	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 90m -v -run "sanity" \
+	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 90m -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
 centos-tests: unit-test-centos system-test-centos
@@ -68,9 +73,9 @@ centos-tests: unit-test-centos system-test-centos
 # on first failure and leave setup in that state. This can be useful for debugging
 # as part of development.
 regress-test: build
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test -v -run "regress" \
+	CONTIV_HOST_GOPATH=$(GOPATH) godep go test -run "regress" \
 					   github.com/contiv/netplugin/systemtests/singlehost
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 60m -v -run "regress" \
+	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 60m -run "regress" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
 # Setting CONTIV_TESTBED=DIND uses docker in docker as the testbed instead of vagrant VMs.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,9 +53,9 @@ fi
 ## pass the env-var args to docker and restart the service. This helps passing
 ## stuff like http-proxy etc
 if [ $# -gt 0 ]; then
-    (echo "export $@" >> /etc/default/docker && \
-     service docker restart) || exit 1
+    (echo "export $@" >> /etc/default/docker) || exit 1
 fi
+(service docker restart) || exit 1
 
 ## install openvswitch and enable ovsdb-server to listen for incoming requests
 #(apt-get install -y openvswitch-switch > /dev/null) || exit 1
@@ -85,10 +85,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.box = "contiv/centos"
     else
       config.vm.box = "contiv/ubuntu-v4"
-      # Commenting out the url since we host the image on Atlas.
-      # config.vm.box_url = "https://cisco.box.com/shared/static/27u8utb1em5730rzprhr5szeuv2p0wir.box"
     end
-    num_nodes = 2
+    num_nodes = 1
     if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then
         num_nodes = ENV['CONTIV_NODES'].to_i
     end

--- a/scripts/CI.sh
+++ b/scripts/CI.sh
@@ -12,4 +12,4 @@ export GOSRC=$GOPATH/src
 export PATH=$PATH:/sbin/:/usr/local/go/bin:$GOBIN
 
 cd $GOSRC/github.com/contiv/netplugin
-make
+make all-CI

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -61,7 +61,7 @@ for pkg in ${test_packages}
 do
   # running in the sand box
   (cd $GOSRC/github.com/contiv/netplugin && \
-  godep go test -v ${pkg}) || exit 1
+  godep go test ${pkg}) || exit 1
 done
 
 echo "Sandbox: Tests succeeded!"


### PR DESCRIPTION
- Added 'all-CI' make target that is used by jenkins upstream job to launch parallel sanities by passing OS and sandbox specific environment variables to each. The CI script builds this target.
- Removed verbose output flag from test targets to make test out more readable and contained.
- Fixes in Vagrantfile to restar docker service always  as it doesn't get started automatically in centos environment causing centos tests to fail.