### PR TITLE
Makefile, Vagrantfile: use GOBIN properly as a complement to $GOROOT/bin, not a replacement.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PKGS := `find . -mindepth 1 -maxdepth 1 -type d -name '*' | grep -vE '/\..*$\|Go
 PKGS += `find . -mindepth 2 -maxdepth 2 -type d -name '*'| grep -vE '/\..*$\|Godeps|examples|docs|scripts'`
 TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/pslibnet/
 HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(which go); fi`
-HOST_GO_BINARY := `dirname $$(which go)`
 HOST_GOROOT := `go env GOROOT`
 
 all: build unit-test system-test system-test-dind centos-tests
@@ -26,10 +25,10 @@ checks:
 	./scripts/checks "$(PKGS)"
 
 build: deps checks
-	rm -rf Godeps/_workspace/pkg
 	godep go install -v $(TO_BUILD)
 
 clean: deps
+	rm -rf Godeps/_workspace/pkg
 	godep go clean -i -v ./...
 
 # setting CONTIV_NODES=<number> while calling 'make demo' can be used to bring
@@ -45,6 +44,9 @@ start-dockerdemo:
 
 clean-dockerdemo:
 	scripts/dockerhost/cleanup-dockerhosts
+
+ssh:
+	@vagrant ssh netplugin-node1 || echo 'Please run "make demo"'
 
 unit-test: build
 	CONTIV_HOST_GOPATH=$(GOPATH) CONTIV_HOST_GOBIN=$(HOST_GOBIN) \

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ checks:
 	./scripts/checks "$(PKGS)"
 
 build: deps checks
+	rm -rf Godeps/_workspace/pkg
 	godep go install -v $(TO_BUILD)
 
 clean: deps

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 PKGS := `find . -mindepth 1 -maxdepth 1 -type d -name '*' | grep -vE '/\..*$\|Godeps|examples|docs|scripts|mgmtfn|systemtests'`
 PKGS += `find . -mindepth 2 -maxdepth 2 -type d -name '*'| grep -vE '/\..*$\|Godeps|examples|docs|scripts'`
 TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/pslibnet/
-HOST_GOBIN := `which go | xargs dirname`
+HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(which go); fi`
+HOST_GO_BINARY := `dirname $$(which go)`
 HOST_GOROOT := `go env GOROOT`
 
 all: build unit-test system-test system-test-dind centos-tests

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ echo 'export GOPATH=#{netplugin_synced_gopath}' > /etc/profile.d/envvar.sh
 echo 'export GOBIN=$GOPATH/bin' >> /etc/profile.d/envvar.sh
 echo 'export GOSRC=$GOPATH/src' >> /etc/profile.d/envvar.sh
 echo 'export GOROOT=#{host_goroot_path}' >> /etc/profile.d/envvar.sh
-echo 'export PATH=$PATH:#{host_gobin_path}:$GOBIN' >> /etc/profile.d/envvar.sh
+echo 'export PATH=$PATH:#{host_goroot_path}/bin:#{host_gobin_path}:$GOBIN' >> /etc/profile.d/envvar.sh
 if [ $# -gt 0 ]; then
     echo "export $@" >> /etc/profile.d/envvar.sh
 fi


### PR DESCRIPTION
@mapuri 
This fixes `$GOBIN` support. `$GOBIN` is the target for `go install -v` and may differ from `$GOROOT/bin` which is the path to the go toolchain.

If you do this right now, you will notice that it can't find godep; this is because on my system GOBIN and GOROOT (both unified) and GOPATH (per-project) are all different.

Signed-off-by: Erik Hollensbe <erik+github@hollensbe.org>