### PR TITLE
Makefile, Vagrantfile: refactor of build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ _testmain.go
 
 # vagrant
 .vagrant
+
+bin/*
+
+resolv.conf

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,15 @@ deps:
 checks:
 	./scripts/checks "$(PKGS)"
 
+host-build:
+	sudo /bin/bash -c 'source /etc/profile.d/envvar.sh; make run-build'
+
 run-build: deps checks
 	godep go install -v $(TO_BUILD)
 
 build: start
 	vagrant ssh netplugin-node1 -c 'sudo -i bash -lc "source /etc/profile.d/envvar.sh && cd /opt/golang/src/github.com/contiv/netplugin && make run-build"'
+	make stop
 
 clean: deps
 	rm -rf Godeps/_workspace/pkg
@@ -55,7 +59,7 @@ demo-centos:
 stop:
 	CONTIV_NODES=$${CONTIV_NODES:-2} vagrant destroy -f
 
-demo: stop start build
+demo: stop start
 
 start-dockerdemo:
 	scripts/dockerhost/start-dockerhosts

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ checks:
 host-build:
 	sudo /bin/bash -c 'source /etc/profile.d/envvar.sh; make run-build'
 
-run-build: deps checks
+run-build: deps checks clean
 	godep go install -v $(TO_BUILD)
 
 build: start

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 # find all verifiable packages.
 # XXX: explore a better way that doesn't need multiple 'find'
-PKGS := `find . -mindepth 1 -maxdepth 1 -type d -name '*' | grep -vE '/\..*$\|Godeps|examples|docs|scripts|mgmtfn|systemtests'`
-PKGS += `find . -mindepth 2 -maxdepth 2 -type d -name '*'| grep -vE '/\..*$\|Godeps|examples|docs|scripts'`
+PKGS := `find . -mindepth 1 -maxdepth 1 -type d -name '*' | grep -vE '/\..*$\|Godeps|examples|docs|scripts|mgmtfn|systemtests|bin'`
+PKGS += `find . -mindepth 2 -maxdepth 2 -type d -name '*'| grep -vE '/\..*$\|Godeps|examples|docs|scripts|bin'`
 TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/dockcontivnet/
 HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(which go); fi`
 HOST_GOROOT := `go env GOROOT`
@@ -34,8 +34,11 @@ deps:
 checks:
 	./scripts/checks "$(PKGS)"
 
-build: deps checks
+run-build: deps checks
 	godep go install -v $(TO_BUILD)
+
+build: start
+	vagrant ssh netplugin-node1 -c 'sudo -i bash -lc "source /etc/profile.d/envvar.sh && cd /opt/golang/src/github.com/contiv/netplugin && make run-build"'
 
 clean: deps
 	rm -rf Godeps/_workspace/pkg
@@ -43,11 +46,16 @@ clean: deps
 
 # setting CONTIV_NODES=<number> while calling 'make demo' can be used to bring
 # up a cluster of <number> nodes. By default <number> = 1
-demo: build
-	CONTIV_HOST_GOBIN=$(HOST_GOBIN) CONTIV_HOST_GOROOT=$(HOST_GOROOT) vagrant up
+start:
+	CONTIV_NODE_OS=${CONTIV_NODE_OS} vagrant up
 
-clean-demo:
-	vagrant destroy -f
+demo-centos:
+	CONTIV_NODE_OS=centos make demo
+
+stop:
+	CONTIV_NODES=2 vagrant destroy -f
+
+demo: stop start build
 
 start-dockerdemo:
 	scripts/dockerhost/start-dockerhosts
@@ -58,28 +66,31 @@ clean-dockerdemo:
 ssh:
 	@vagrant ssh netplugin-node1 || echo 'Please run "make demo"'
 
-unit-test: build
-	CONTIV_HOST_GOPATH=$(GOPATH) CONTIV_HOST_GOBIN=$(HOST_GOBIN) \
-					   CONTIV_HOST_GOROOT=$(HOST_GOROOT) ./scripts/unittests -vagrant
+unit-test: stop clean build
+	./scripts/unittests -vagrant
 
-unit-test-centos: build
-	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) CONTIV_HOST_GOBIN=$(HOST_GOBIN) \
-					   CONTIV_HOST_GOROOT=$(HOST_GOROOT) ./scripts/unittests -vagrant
+unit-test-centos: stop clean
+	CONTIV_NODE_OS=centos make build
+	CONTIV_NODE_OS=centos ./scripts/unittests -vagrant
 
 # setting CONTIV_SOE=1 while calling 'make system-test' will stop the test
 # on first failure and leave setup in that state. This can be useful for debugging
 # as part of development.
-system-test: build
-	CONTIV_HOST_GOROOT=$(HOST_GOROOT) CONTIV_HOST_GOBIN=$(HOST_GOBIN) CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -run "sanity" \
+system-test: system-test-singlehost system-test-multihost
+
+# the `make stop` here and below are necessary because build leaves around a VM (intentionally)
+system-test-singlehost: stop clean build
+	make stop
+	godep go test -v --timeout 30m -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/singlehost 
-	CONTIV_HOST_GOROOT=$(HOST_GOROOT) CONTIV_HOST_GOBIN=$(HOST_GOBIN) CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 80m -run "sanity" \
+
+system-test-multihost: stop clean
+	make build stop
+	godep go test -v --timeout 80m -run "sanity" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
-system-test-centos: build
-	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 30m -run "sanity" \
-					   github.com/contiv/netplugin/systemtests/singlehost
-	CONTIV_NODE_OS=centos CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 90m -run "sanity" \
-					   github.com/contiv/netplugin/systemtests/twohosts
+system-test-centos: stop clean
+	CONTIV_NODE_OS=centos make build stop system-test-singlehost system-test-multihost
 
 centos-tests: unit-test-centos system-test-centos
 
@@ -87,9 +98,9 @@ centos-tests: unit-test-centos system-test-centos
 # on first failure and leave setup in that state. This can be useful for debugging
 # as part of development.
 regress-test: build
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test -run "regress" \
+	godep go test -run "regress" \
 					   github.com/contiv/netplugin/systemtests/singlehost
-	CONTIV_HOST_GOPATH=$(GOPATH) godep go test --timeout 60m -run "regress" \
+	godep go test --timeout 60m -run "regress" \
 					   github.com/contiv/netplugin/systemtests/twohosts
 
 # Setting CONTIV_TESTBED=DIND uses docker in docker as the testbed instead of vagrant VMs.

--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,12 @@ clean: deps
 	rm -rf Godeps/_workspace/pkg
 	godep go clean -i -v ./...
 
+update:
+	vagrant box update
+
 # setting CONTIV_NODES=<number> while calling 'make demo' can be used to bring
 # up a cluster of <number> nodes. By default <number> = 1
-start:
+start: update
 	CONTIV_NODE_OS=${CONTIV_NODE_OS} vagrant up
 
 demo-centos:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ demo-centos:
 	CONTIV_NODE_OS=centos make demo
 
 stop:
-	CONTIV_NODES=2 vagrant destroy -f
+	CONTIV_NODES=$${CONTIV_NODES:-2} vagrant destroy -f
 
 demo: stop start build
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Please do not use this code in production, until code goes through more testing 
 
 ###Building and Testing
 
+**Note:** Vagrant 1.7.4 and VirtualBox 5.0+ are required to build and test netplugin.
+
 - Build:
 
   `make build`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,52 +42,10 @@ if [ $# -gt 5 ]; then
     echo "export $@" >> /etc/profile.d/envvar.sh
 fi
 
-### install basic packages
-#(apt-get update -qq > /dev/null && apt-get install -y vim curl python-software-properties git > /dev/null) || exit 1
-#
-### install Go 1.4
-#(cd /usr/local/ && \
-#curl -L https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz -o go1.4.linux-amd64.tar.gz && \
-#tar -xzf go1.4.linux-amd64.tar.gz) || exit 1
-#
-### install etcd
-#(cd /tmp && \
-#curl -L  https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.tar.gz -o etcd-v2.0.0-linux-amd64.tar.gz && \
-#tar -xzf etcd-v2.0.0-linux-amd64.tar.gz && \
-#mv /tmp/etcd-v2.0.0-linux-amd64/etcd /usr/bin/ && \
-#mv /tmp/etcd-v2.0.0-linux-amd64/etcdctl /usr/bin/ ) || exit 1
-#
-### install and start docker
-#(curl -sSL https://get.docker.com/ubuntu/ | sh > /dev/null) || exit 1
-#
-## pass the env-var args to docker and restart the service. This helps passing
-## stuff like http-proxy etc
-# if [ $# -gt 0 ]; then
-#     (echo "export $@" >> /etc/default/docker) || exit 1
-# fi
-
 (service docker restart) || exit 1
-
-## install openvswitch and enable ovsdb-server to listen for incoming requests
-#(apt-get install -y openvswitch-switch > /dev/null) || exit 1
-## Install OVS 2.3.1
-# (wget -nv -O ovs-common.deb https://cisco.box.com/shared/static/v1dvgoboo5zgqrtn6tu27vxeqtdo2bdl.deb &&
-#  wget -nv -O ovs-switch.deb https://cisco.box.com/shared/static/ymbuwvt2qprs4tquextw75b82hyaxwon.deb) || exit 1
-# (dpkg -i ovs-common.deb &&
-#  dpkg -i ovs-switch.deb) || exit 1
 
 (ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
  ovs-vsctl set-manager ptcp:6640) || exit 1
-
-### install consul
-#(apt-get install -y unzip && cd /tmp && \
-# wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip && \
-# unzip 0.5.2_linux_amd64.zip && \
-# mv /tmp/consul /usr/bin) || exit 1
-
-# add vagrant user to docker group
-# (usermod -a -G docker vagrant)
-
 SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"
@@ -121,9 +79,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
         config.vm.define node_name do |node|
             # node.vm.hostname = node_name
-            # # create an interface for etcd cluster
+            # create an interface for etcd cluster
             node.vm.network :private_network, ip: node_addr, virtualbox__intnet: "true", auto_config: false
-            # # create an interface for bridged network
+            # create an interface for bridged network
             node.vm.network :private_network, ip: "0.0.0.0", virtualbox__intnet: "true", auto_config: false
             node.vm.provider "virtualbox" do |v|
                 # make all nics 'virtio' to take benefit of builtin vlan tag

--- a/netutils/netutils.go
+++ b/netutils/netutils.go
@@ -211,40 +211,6 @@ func ParseTagRanges(ranges string, tagType string) ([]TagRange, error) {
 	return tagRanges, nil
 }
 
-// GetLocalIP obtains the first IP on a local interface on the host.
-func GetLocalIP() (string, error) {
-	var addrs []netlink.Addr
-	localIPAddr := ""
-
-	for idx := 0; idx < 3; idx++ {
-		linkName := "eth" + strconv.Itoa(idx)
-		link, err := netlink.LinkByName(linkName)
-		if err != nil {
-			if strings.Contains(err.Error(), "Link not found") {
-				continue
-			}
-			return "", err
-		}
-		addrs, err = netlink.AddrList(link, netlink.FAMILY_V4)
-		if err != nil {
-			if strings.Contains(err.Error(), "Link not found") {
-				continue
-			}
-			return "", err
-		}
-		if len(addrs) > 0 {
-			localIPAddr = addrs[0].IP.String()
-		}
-	}
-
-	err := core.Errorf("local ip not found")
-	if localIPAddr != "" {
-		err = nil
-	}
-
-	return localIPAddr, err
-}
-
 // ParseCIDR parses a CIDR string into a gateway IP and length.
 func ParseCIDR(cidrStr string) (string, uint, error) {
 	strs := strings.Split(cidrStr, "/")

--- a/netutils/netutils_test.go
+++ b/netutils/netutils_test.go
@@ -196,10 +196,3 @@ func TestGetSubnetNumber(t *testing.T) {
 		}
 	}
 }
-
-func TestGetLocalIP(t *testing.T) {
-	ipAddr, err := GetLocalIP()
-	if ipAddr == "" {
-		t.Fatalf("error obtaining local IP of the host '%s' \n", err)
-	}
-}

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -36,7 +36,7 @@ done
 
 # running on host
 if ${run_in_vagrant}; then
-    (CONTIV_NODES=1 vagrant up)
+    (CONTIV_NODE_OS="${CONTIV_NODE_OS}" CONTIV_NODES=1 vagrant up)
     ret=$?
     if [ ${ret} -ne 0 ]; then
         (CONTIV_NODES=1 vagrant destroy -f)

--- a/systemtests/utils/utils.go
+++ b/systemtests/utils/utils.go
@@ -134,8 +134,7 @@ func StartNetPluginWithConfig(t *testing.T, nodes []TestbedNode, nativeInteg boo
 			cmdStr = fmt.Sprintf("netplugin %s 1>/tmp/netplugin-%s.log 2>&1",
 				flagsStr, time.Now().Format("15:04:05.999999999"))
 		} else {
-			cmdStr = fmt.Sprintf("sudo PATH=$PATH nohup netplugin %s 0<&- &>/tmp/netplugin-%s.log",
-				flagsStr, time.Now().Format("15:04:05.999999999"))
+			cmdStr = fmt.Sprintf("sudo PATH=$PATH nohup netplugin -force-delete-ep=true %s 0<&- &>/tmp/netplugin.log-%s", flagsStr, time.Now().Format("15:04:05.999999999"))
 		}
 		output, err := node.RunCommandBackground(cmdStr)
 		if err != nil {
@@ -154,6 +153,8 @@ func StartNetPlugin(t *testing.T, nodes []TestbedNode, nativeInteg bool) {
 
 // StartNetmasterWithFlags starts netplugin on specified testbed nodes with specified flags
 func StartNetmasterWithFlags(t *testing.T, node TestbedNode, flags map[string]string) {
+	time.Sleep(5 * time.Second)
+
 	var (
 		cmdStr   string
 		flagsStr string
@@ -174,6 +175,7 @@ func StartNetmasterWithFlags(t *testing.T, node TestbedNode, flags map[string]st
 			err, cmdStr, output)
 	}
 
+	time.Sleep(5 * time.Second)
 }
 
 // StartNetmaster starts netplugin on specified testbed node


### PR DESCRIPTION
This implements several features for the build system:

* Builds happen on the VM in a consistent way, so they can happen on non linux
  platforms.
* New builder images include:
  * First class support of 4.0 (Ubuntu) and 4.1 (CentOS) mainline kernels
  * Docker 1.8.1
  * systemd (with proxy support)

Signed-off-by: Erik Hollensbe <github@hollensbe.org>