### PR TITLE
Release automation changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: all build clean default system-test unit-test
+.PHONY: all all-CI build clean default system-test unit-test release tar
 
 # find all verifiable packages.
 # XXX: explore a better way that doesn't need multiple 'find'
@@ -8,6 +8,16 @@ PKGS += `find . -mindepth 2 -maxdepth 2 -type d -name '*'| grep -vE '/\..*$\|God
 TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/dockcontivnet/
 HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(which go); fi`
 HOST_GOROOT := `go env GOROOT`
+NAME := netplugin
+# We are using date based versioning, so for consistent version during a build
+# we evaluate and set the value of version once in a file and use it in 'tar'
+# and 'release' targets.
+VERSION_FILE := /tmp/$(NAME)-version
+VERSION := `cat $(VERSION_FILE)`
+TAR_EXT := tar.bz2
+TAR_FILENAME := $(NAME)-$(VERSION).$(TAR_EXT)
+TAR_LOC := .
+TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 
 all: build unit-test system-test system-test-dind centos-tests
 
@@ -88,3 +98,22 @@ system-test-dind:
 
 regress-test-dind:
 	CONTIV_TESTBED=DIND make regress-test
+
+tar: clean-tar build
+	@echo "v0.0.`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
+	@tar -jcf $(TAR_FILE) -C $(GOPATH)/bin netplugin netdcli netmaster dockcontivnet k8contivnet
+
+clean-tar:
+	@rm -f $(TAR_LOC)/*.$(TAR_EXT)
+
+# GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release
+release: tar
+	@latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \
+		comparison="$$latest_tag..HEAD"; \
+		changelog=$$(git log $$comparison --oneline --no-merges --reverse); \
+		if [ -z "$$changelog" ]; then echo "No new changes to release!"; exit 0; fi; \
+		set -x; \
+		( ( github-release -v release -p -r netplugin -t $(VERSION) -d "**Changelog**<br/>$$changelog" ) && \
+		( github-release -v upload -r netplugin -t $(VERSION) -n $(TAR_FILENAME) -f $(TAR_FILE) || \
+		github-release -v delete -r netplugin -t $(VERSION) ) ) || exit 1
+	@make clean-tar

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ regress-test-dind:
 	CONTIV_TESTBED=DIND make regress-test
 
 tar: clean-tar build
-	@echo "v0.0.`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
+	@echo "v0.0.0-`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
 	@tar -jcf $(TAR_FILE) -C $(GOPATH)/bin netplugin netdcli netmaster dockcontivnet k8contivnet
 
 clean-tar:

--- a/scripts/CI.sh
+++ b/scripts/CI.sh
@@ -5,11 +5,6 @@
 # - push to master
 # - pull request on master
 
-#$WORKSPACE points to the Jenkins' workspace root
-export GOPATH=$WORKSPACE
-export GOBIN=$GOPATH/bin
-export GOSRC=$GOPATH/src
-export PATH=$PATH:/sbin/:/usr/local/go/bin:$GOBIN
-
+. `dirname $0`/env.sh
 cd $GOSRC/github.com/contiv/netplugin
 make all-CI

--- a/scripts/REL.sh
+++ b/scripts/REL.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script is called from the Jenkins CI after the push sanity succeeds.
+# It shall publish a new release on github with the changes pushed.
+
+. `dirname $0`/env.sh
+cd $GOSRC/github.com/contiv/netplugin
+make release

--- a/scripts/deps
+++ b/scripts/deps
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 go get github.com/tools/godep
+go get github.com/c4milo/github-release
 
 if ! go get github.com/golang/lint/golint
 then

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script is used by Jenkins CI scripts to setup commn environment
+
+#$WORKSPACE points to the Jenkins' workspace root
+export GOPATH=$WORKSPACE
+export GOBIN=$GOPATH/bin
+export GOSRC=$GOPATH/src
+export PATH=$PATH:/sbin/:/usr/local/go/bin:$GOBIN


### PR DESCRIPTION
These changes shall allow automating the process to publish releases in github.

Just a few notes:
- I have used the date/time of the build as the minor version in our releases (Example, `v0.0.16-21-2015.06-51-06.UTC`). This makes auto-generating version numbers a bit simple without needing much logic around managing them. But we can change it in case we find issues with this scheme as we try this out.

- I am planning to create a release everytime we push a change to the netplugin project as number of commits per day is pretty low. Once the commit volume goes above, we can push a release once a day or even slower.