### PR TITLE
update the go version check to v1.5.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,8 +56,10 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "centos" then
         config.vm.box = "contiv/centos71-netplugin"
+        config.vm.box_version = "0.2.0"
     else
         config.vm.box = "contiv/ubuntu1504-netplugin"
+        config.vm.box_version = "0.2.0"
     end
     num_nodes = 1
     if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then

--- a/scripts/checks
+++ b/scripts/checks
@@ -13,8 +13,8 @@ BUILD_PKGS=$1
 
 echo "+++ Checking Go version..."
 ver=$(go version | awk '{print $3}')
-minVer="go1.4.2"
-maxVer="go1.4.2"
+minVer="go1.5.1"
+maxVer="go1.5.1"
 if [[ ${ver} < ${minVer} ]]; then
     echo "!!! Go version check failed. Expected >=${minVer} but found ${ver}"
     exit 1


### PR DESCRIPTION
This is needed after our recent move to the new go version in our vagrant images.

Also set the Vagrantbox image version, so that the checks version and vagrant box image can be changed together in future.
