### PR TITLE
README: use mkdir -p to create directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ that lives behind an OVS bridge and has its own unique interfaces.
 
 ```
 $ export GOPATH=`pwd`
-$ mkdir src/github.com/contiv
+$ mkdir -p src/github.com/contiv
 $ cd src/github.com/contiv
 $ git clone https://github.com/contiv/netplugin
 $ cd netplugin; make build demo ssh


### PR DESCRIPTION
The `src/github.com` directories might not exist and we should tell the users to use `mkdir -p` to create the whole directory structure.