### PR TITLE
Contivctl changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # XXX: explore a better way that doesn't need multiple 'find'
 PKGS := `find . -mindepth 1 -maxdepth 1 -type d -name '*' | grep -vE '/\..*$\|Godeps|examples|docs|scripts|mgmtfn|systemtests|bin'`
 PKGS += `find . -mindepth 2 -maxdepth 2 -type d -name '*'| grep -vE '/\..*$\|Godeps|examples|docs|scripts|bin'`
-TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/dockcontivnet/ ./contivctl/contivctl/
+TO_BUILD := ./netplugin/ ./netmaster/ ./netdcli/ ./mgmtfn/k8contivnet/ ./mgmtfn/dockcontivnet/ ./netctl/netctl/
 HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(which go); fi`
 HOST_GOROOT := `go env GOROOT`
 NAME := netplugin

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -1,4 +1,4 @@
-package contivctl
+package netctl
 
 import (
 	"github.com/codegangsta/cli"

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -1,8 +1,6 @@
 package netctl
 
-import (
-	"github.com/codegangsta/cli"
-)
+import "github.com/codegangsta/cli"
 
 var tenantFlag = cli.StringFlag{
 	Name:  "tenant, t",
@@ -18,6 +16,16 @@ var allFlag = cli.BoolFlag{
 var jsonFlag = cli.BoolFlag{
 	Name:  "json, j",
 	Usage: "Output list in JSON format",
+}
+
+// NetmasterFlags encapsulates the flags required for talking to the netmaster.
+var NetmasterFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:   "netmaster",
+		Value:  DefaultMaster,
+		Usage:  "The hostname of the netmaster",
+		EnvVar: "NETMASTER",
+	},
 }
 
 // Commands are all the commands that go into `contivctl`, the end-user tool.

--- a/netctl/exit.go
+++ b/netctl/exit.go
@@ -1,4 +1,4 @@
-package contivctl
+package netctl
 
 import (
 	"fmt"

--- a/netctl/http.go
+++ b/netctl/http.go
@@ -13,7 +13,7 @@ import (
 var client = &http.Client{}
 
 func baseURL(ctx *cli.Context) string {
-	return ctx.GlobalString("master")
+	return ctx.GlobalString("netmaster")
 }
 
 func policyURL(ctx *cli.Context) string {

--- a/netctl/http.go
+++ b/netctl/http.go
@@ -1,4 +1,4 @@
-package contivctl
+package netctl
 
 import (
 	"bytes"

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -1,4 +1,4 @@
-package contivctl
+package netctl
 
 import (
 	"encoding/json"

--- a/netctl/netctl/main.go
+++ b/netctl/netctl/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/contiv/netplugin/contivctl"
+	"github.com/contiv/netplugin/netctl"
 )
 
 func main() {
@@ -12,13 +12,13 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "master",
-			Value:  contivctl.DefaultMaster,
+			Value:  netctl.DefaultMaster,
 			Usage:  "The hostname of the netmaster",
 			EnvVar: "NETMASTER",
 		},
 	}
 
 	app.Version = ""
-	app.Commands = contivctl.Commands
+	app.Commands = netctl.Commands
 	app.Run(os.Args)
 }

--- a/netctl/netctl/main.go
+++ b/netctl/netctl/main.go
@@ -9,15 +9,7 @@ import (
 
 func main() {
 	app := cli.NewApp()
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "master",
-			Value:  netctl.DefaultMaster,
-			Usage:  "The hostname of the netmaster",
-			EnvVar: "NETMASTER",
-		},
-	}
-
+	app.Flags = netctl.NetmasterFlags
 	app.Version = ""
 	app.Commands = netctl.Commands
 	app.Run(os.Args)


### PR DESCRIPTION
this renames contivctl to netctl in anticipation of github.com/contiv/contivctl.

it also changes a flag name: `--master` is now `--netmaster`. This will make it easier to integrate into contivctl.

PTAL ASAP, I need this for the next step.