### PR TITLE
simplify make demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This will provide you with a minimal experience of uploading the intent and
 seeing the netplugin system act on it. It will create a network on your host
 that lives behind an OVS bridge and has its own unique interfaces.
 
-#### Step 1: Clone the project:
+#### Step 1: Clone the project and bringup the VMs
 
 ```
 $ git clone https://github.com/contiv/netplugin

--- a/README.md
+++ b/README.md
@@ -22,28 +22,18 @@ that lives behind an OVS bridge and has its own unique interfaces.
 #### Step 1: Clone the project:
 
 ```
-$ export GOPATH=`pwd`
-$ mkdir -p src/github.com/contiv
-$ cd src/github.com/contiv
 $ git clone https://github.com/contiv/netplugin
-$ cd netplugin; make build demo ssh
+$ cd netplugin; make demo
+$ vagrant ssh netplugin-node1
 ```
 
-#### Step 2: Inside the VM, boot `netmaster` and `netplugin`
+#### Step 2: Create a network
 
 ```
-$ cd /opt/gopath/src/github.com/contiv/netplugin
-$ sudo $GOPATH/bin/netmaster &
-$ sudo $GOPATH/bin/netplugin -docker-plugin &
+$ netctl net create contiv-net --subnet=20.1.1.0/24 --gateway=20.1.1.254 --pkt-tag=200
 ```
 
-#### Step 3: Create a network
-
-```
-$ $GOPATH/bin/netctl net create contiv-net --subnet=20.1.1.0/24 --gateway=20.1.1.254 --pktTag=200
-```
-
-#### Step 4: Run your containers and enjoy the networking!
+#### Step 3: Run your containers and enjoy the networking!
 
 ```
 $ docker run -itd --name=web --net=contiv-net ubuntu /bin/bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.box = "contiv/ubuntu1504-netplugin"
         config.vm.box_version = "0.3.1"
     end
-    num_nodes = 1
+    num_nodes = 2
     if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then
         num_nodes = ENV['CONTIV_NODES'].to_i
     end
@@ -119,10 +119,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
             # mount the host directories
             node.vm.synced_folder "bin", File.join(gopath_folder, "bin")
-            if ENV["GOPATH"]
+            if ENV["GOPATH"] && ENV['GOPATH'] != ""
               node.vm.synced_folder File.join(ENV["GOPATH"].split(":").first, "src"), File.join(gopath_folder, "src"), rsync: true
             else
-              puts "!!! No GOPATH, mounting netplugin by itself"
               node.vm.synced_folder ".", File.join(gopath_folder, "src/github.com/contiv/netplugin"), rsync: true
             end
 


### PR DESCRIPTION
- Changes Vagrantfile to start two VMs by default
- start netplugin/netmaster automatically during "make demo"
- Simplify steps in Readme
- remove contivctl.py from $GOPATH/bin in favor of new contivctl tool