### PR TITLE
fix the http: panic serving while net delete

### DIFF
--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -157,7 +157,7 @@ func deleteDockNet(networkName string) error {
 	if err != nil {
 		log.Errorf("Error deleting network %s. Err: %v", networkName, err)
 		// FIXME: Ignore errors till we fully move to docker 1.9
-		return nil
+		return err
 	}
 
 	return nil
@@ -425,6 +425,7 @@ func DeleteNetworkID(stateDriver core.StateDriver, netID string) error {
 	err = deleteDockNet(netID)
 	if err != nil {
 		log.Errorf("Error deleting network %s. Err: %v", netID, err)
+		return err
 	}
 
 	// Free resource associated with the network


### PR DESCRIPTION
It should not panic, no matter what. With this change, the panic is gone, but the errors will remain.

Subnet:20.1.1.0/24 TenantName:default LinkSets:{EndpointGroups:map[] Services:map[]} Links:{Tenant:{ObjType:tenant ObjKey:default mutex:{state:0 sema:0}}}}
INFO[4987] Deleting docker network: test
ERRO[4987] Error deleting network test. Err: 500 Internal Server Error: network test has active endpoints

INFO[4987] freeing vlan 200 vxlan 200
2015/11/14 20:00:06 http: panic serving [::1]:48625: runtime error: makeslice: len out of range
goroutine 128 [running]:
net/http.(*conn).serve.func1(0xc8202c2420, 0x7fcda4453118, 0xc820094408)
    /usr/local/go/src/net/http/server.go:1287 +0xb5
github.com/jainvipin/bitset.(*BitSet).Set(0xc8202d2a60, 0xfffffffffffffcdf, 0xc82051b0e0)
    /opt/gopath/src/github.com/contiv/netplugin/Godeps/_workspace/src/github.com/jainvipin/bitset/bitset.go:122 +0x1b3
github.com/contiv/netplugin/resources.(*AutoVXLANCfgResource).Deallocate(0xc820453620, 0x9a23a0, 0xc82051b0e0, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/resources/vxlanresource.go:173 +0x1e2
github.com/contiv/netplugin/resources.(*StateResourceManager).DeallocateResourceVal(0xc820112a30, 0xc82051ab20, 0x7, 0xa6a1b0, 0xa, 0x9a23a0, 0xc82051b0e0, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/resources/stateresourcemanager.go:187 +0x311
github.com/contiv/netplugin/gstate.(*Cfg).FreeVXLAN(0xc8202c2790, 0x7fcda157d000, 0xc820112a30, 0xc8, 0xc8, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/gstate/gstate.go:305 +0x1b1
github.com/contiv/netplugin/netmaster/master.freeNetworkResources(0x7fcda1dbe338, 0xc820118090, 0xc8201169c0, 0xc8202c2790, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/netmaster/master/network.go:385 +0x5ec
github.com/contiv/netplugin/netmaster/master.DeleteNetworkID(0x7fcda1dbe338, 0xc820118090, 0xc82051a750, 0xc, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/netmaster/master/network.go:431 +0x610
github.com/contiv/netplugin/netmaster/objApi.(*APIController).NetworkDelete(0xc8200940b8, 0xc8202c22c0, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/netmaster/objApi/apiController.go:453 +0x338
github.com/contiv/objmodel/contivModel.DeleteNetwork(0xc8204527c5, 0xc, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/Godeps/_workspace/src/github.com/contiv/objmodel/contivModel/contivModel.go:1450 +0x3cc
github.com/contiv/objmodel/contivModel.httpDeleteNetwork(0x7fcda44532d8, 0xc8202c24d0, 0xc820102540, 0xc820452870, 0x0, 0x0, 0x0, 0x0)
    /opt/gopath/src/github.com/contiv/netplugin/Godeps/_workspace/src/github.com/contiv/objmodel/contivModel/contivModel.go:1368 +0x153
github.com/contiv/objmodel/contivModel.makeHttpHandler.func1(0x7fcda44532d8, 0xc8202c24d0, 0xc820102540)
    /opt/gopath/src/github.com/contiv/netplugin/Godeps/_workspace/src/github.com/contiv/objmodel/contivModel/contivModel.go:445 +0x73
net/http.HandlerFunc.ServeHTTP(0xc8201cdba0, 0x7fcda44532d8, 0xc8202c24d0, 0xc820102540)
    /usr/local/go/src/net/http/server.go:1422 +0x3a
github.com/gorilla/mux.(*Router).ServeHTTP(0xc820096be0, 0x7fcda44532d8, 0xc8202c24d0, 0xc820102540)
    /opt/gopath/src/github.com/contiv/netplugin/Godeps/_workspace/src/github.com/gorilla/mux/mux.go:98 +0x29e
net/http.serverHandler.ServeHTTP(0xc82023d7a0, 0x7fcda44532d8, 0xc8202c24d0, 0xc820102540)
    /usr/local/go/src/net/http/server.go:1862 +0x19e
net/http.(*conn).serve(0xc8202c2420)
    /usr/local/go/src/net/http/server.go:1361 +0xbee
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1910 +0x3f6