### PR TITLE
Changing TrimRight to TrimSuffix to truncate string only when default…

### DIFF
--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -41,7 +41,7 @@ var testMode = false
 
 // Trim default tenant from network name
 func trimDefaultTenant(networkName string) string {
-	return strings.TrimRight(strings.TrimRight(networkName, defaultTenantName), ".")
+	return strings.TrimRight(strings.TrimSuffix(networkName, defaultTenantName), ".")
 }
 
 func validateNetworkConfig(tenant *intent.ConfigTenant) error {

--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -39,7 +39,7 @@ const (
 
 var testMode = false
 
-// Trim default tenant from network name
+// trimDefaultTenant trims default tenant from network name
 func trimDefaultTenant(networkName string) string {
 	return strings.TrimRight(strings.TrimSuffix(networkName, defaultTenantName), ".")
 }


### PR DESCRIPTION
TrimRight was leading to truncated names,
vagrant@netplugin-node1:~$ docker network ls | grep contiv
09cb20d2a6e3        private.contiv-tenan   netplugin
b0b76e8564a1        public.contiv-tenan    netplugin
vagrant@netplugin-node1:~$

TrimSuffix fixes it.