### PR TITLE
adding support for generating code coverage stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,14 @@ host-unit-test:
 	@echo dev: running unit tests...
 	cd $(GOPATH)/src/github.com/contiv/netplugin && sudo -E PATH=$(PATH) scripts/unittests
 
+host-unit-test-coverage:
+	@echo dev: running unit tests...
+	cd $(GOPATH)/src/github.com/contiv/netplugin && sudo -E PATH=$(PATH) scripts/unittests --coverage-basic
+
+host-unit-test-coverage-detail:
+	@echo dev: running unit tests...
+	cd $(GOPATH)/src/github.com/contiv/netplugin && sudo -E PATH=$(PATH) scripts/unittests --coverage-detail
+
 host-sanity-test:
 	@echo dev: running sanity tests...
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./sanity.py -nodes ${CLUSTER_NODE_IPS}

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -9,6 +9,8 @@ USAGE="${0} -vagrant"
 PATH=$PATH:/usr/local/go/bin
 
 run_in_vagrant=false
+coverage_basic=false
+coverage_detail=false
 test_packages="github.com/contiv/netplugin/drivers \
     github.com/contiv/netplugin/state \
     github.com/contiv/netplugin/netplugin/plugin \
@@ -28,7 +30,13 @@ do
     case "${1}" in
         -vagrant)
             run_in_vagrant=true
-            break;;
+	    ;;
+        -c0|--coverage-basic)
+            coverage_basic=true
+            ;;
+        -c1|--coverage-detail)
+            coverage_detail=true
+            ;;
         *)
             echo "${USAGE}" 1>&2
             exit 1;;
@@ -62,8 +70,17 @@ fi
 for pkg in ${test_packages}
 do
   # running in the sand box
-  (cd $GOSRC/github.com/contiv/netplugin && \
-  $GOBIN/godep go test ${pkg}) || exit 1
+  if ${coverage_basic}; then
+      (cd $GOSRC/github.com/contiv/netplugin && \
+      $GOBIN/godep go test ${pkg} -coverprofile=cover.out) || exit 1
+  elif ${coverage_detail}; then
+      (cd $GOSRC/github.com/contiv/netplugin && \
+      $GOBIN/godep go test ${pkg} -coverprofile=cover.out && \
+      $GOBIN/godep go tool cover -func=cover.out) || exit 1
+  else
+      (cd $GOSRC/github.com/contiv/netplugin && \
+      $GOBIN/godep go test ${pkg}) || exit 1
+  fi
 done
 
 echo "Sandbox: Tests succeeded!"


### PR DESCRIPTION
#### changes:
(1) added Makefile targets for code-coverage.
(2) added options in the unit-test script to run different levels of code coverage

##### sample output:
```
vagrant@netplugin-node1:/opt/gopath/src/github.com/contiv/netplugin$ make host-unit-test-coverage
ok      github.com/contiv/netplugin/drivers     17.710s coverage: 50.0% of statements
ok      github.com/contiv/netplugin/state       9.107s  coverage: 58.0% of statements
ok      github.com/contiv/netplugin/netplugin/plugin    5.277s  coverage: 66.7% of statements
ok      github.com/contiv/netplugin/utils/netutils      0.014s  coverage: 55.6% of statements
ok      github.com/contiv/netplugin/gstate      0.023s  coverage: 67.8% of statements
ok      github.com/contiv/netplugin/netmaster/master    0.065s  coverage: 21.0% of statements
ok      github.com/contiv/netplugin/netmaster/mastercfg 0.014s  coverage: 10.4% of statements
ok      github.com/contiv/netplugin/netmaster/client    0.014s  coverage: 61.5% of statements
ok      github.com/contiv/netplugin/resources   0.020s  coverage: 79.7% of statements
ok      github.com/contiv/netplugin/core        0.007s  coverage: 88.0% of statements
ok      github.com/contiv/netplugin/utils       0.017s  coverage: 73.8% of statements
ok      github.com/contiv/netplugin/mgmtfn/k8splugin/contivk8s  0.010s  coverage: 86.0% of statements
Sandbox: Tests succeeded!
```

```
vagrant@netplugin-node1:/opt/gopath/src/github.com/contiv/netplugin$ make host-unit-test-coverage-detail
ok      github.com/contiv/netplugin/drivers     17.128s coverage: 50.0% of statements
github.com/contiv/netplugin/drivers/fakenetepdriver.go:15:      Init                    0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:20:      Deinit                  0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:24:      CreateNetwork           0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:29:      DeleteNetwork           0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:34:      CreateEndpoint          0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:39:      DeleteEndpoint          0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:44:      AddPeerHost             0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:49:      DeletePeerHost          0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:54:      AddMaster               0.0%
github.com/contiv/netplugin/drivers/fakenetepdriver.go:59:      DeleteMaster            0.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:45:            NewOvsSwitch            81.5%
github.com/contiv/netplugin/drivers/ovsSwitch.go:98:            Delete                  100.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:111:           CreateNetwork           0.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:125:           DeleteNetwork           0.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:139:           createVethPair          66.7%
github.com/contiv/netplugin/drivers/ovsSwitch.go:161:           deleteVethPair          66.7%
github.com/contiv/netplugin/drivers/ovsSwitch.go:183:           setLinkUp               75.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:192:           setLinkMtu              75.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:201:           getOvsPostName          80.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:214:           CreatePort              45.2%
github.com/contiv/netplugin/drivers/ovsSwitch.go:306:           UpdatePort              23.1%
github.com/contiv/netplugin/drivers/ovsSwitch.go:342:           DeletePort              45.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:389:           vxlanIfName             0.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:394:           CreateVtep              0.0%
github.com/contiv/netplugin/drivers/ovsSwitch.go:431:
...
...
...
```