### PR TITLE
Build cluster using k8s and contiv binaries from release repos

### DIFF
--- a/mgmtfn/k8splugin/README.md
+++ b/mgmtfn/k8splugin/README.md
@@ -8,6 +8,10 @@ Networking and Policy can be used for Pod inter-connectivity in a Kubernetes clu
 This step-by-step procedure will guide you through a minimal experience of creating
 a Kubernetes cluster with Contiv networking and applying policy between pods.
 
+Before starting, please be sure to set http/https proxies if your network requires it.
+*(Note that https_proxy should be set to point to a http:// URL (not https://).
+This is an ansible requirement.)*
+
 #### Step 1: Clone contrib and netplugin repos
 
 ```
@@ -19,16 +23,7 @@ $ cd ~/go/src/github.com/k8s
 $ git clone https://github.com/contiv/netplugin
 ```
 
-#### Step 2: Set proxies if your network requires http/https proxy.
-
-```
-$ export http_proxy=http://<....>
-$ export https_proxy=http://<....>
-```
-*Note that https_proxy should be set to point to a http:// URL (not https://).
-This is an ansible requirement.*
-
-#### Step 3: Create cluster
+#### Step 2: Create cluster
 
 ```
 $ cd ~/go/src/github.com/k8s/netplugin
@@ -39,7 +34,7 @@ This step will run Vagrant and ansible commands to bring a kubernetes cluster
 with one master and two worker nodes. This will take some time. Please be 
 patient.
 
-When step 3 completes, you should a message like the one below:
+When step 2 completes, you should a message like the one below:
 
 ```
 PLAY RECAP ******************************************************************** 
@@ -55,14 +50,14 @@ If that happens, just re-issue the command (usually, it's caused by a temporary
 unavailability of a repo on the web). If the problem persists, you should open an
 issue on github.*
 
-You should proceed to Step 4 **only if** the previous step completed successfully.
+You should proceed to Step 3 **only if** the previous step completed successfully.
 
 This demo utilizes a **busybox** image built to include a full **netcat** utility.
 However, you can try other images as well if you like. *The Dockerfile used for 
 building the nc-busybox is available in the /shared folder of the k8master node
-(you will get to this directory in Step 4).*
+(you will get to this directory in Step 3).*
 
-#### Step 4: Start the demo and ssh to the kubernetes master
+#### Step 3: Start the demo and ssh to the kubernetes master
 
 This step will start network services and log you into the kubernetes master node.
 
@@ -70,7 +65,7 @@ This step will start network services and log you into the kubernetes master nod
 $ make k8s-demo-start
 ```
 
-When step 4 completes, you will get a shell prompt from the master. Use *sudo su* to
+When step 3 completes, you will get a shell prompt from the master. Use *sudo su* to
 enter sudo mode. Try a few commands.
 
 

--- a/mgmtfn/k8splugin/README.md
+++ b/mgmtfn/k8splugin/README.md
@@ -8,35 +8,18 @@ Networking and Policy can be used for Pod inter-connectivity in a Kubernetes clu
 This step-by-step procedure will guide you through a minimal experience of creating
 a Kubernetes cluster with Contiv networking and applying policy between pods.
 
-#### Step 1: Clone and build kubernetes
+#### Step 1: Clone contrib and netplugin repos
 
 ```
-$ mkdir ~/go/src/github.com/k8s
-$ cd ~/go/src/github.com/k8s
-$ git clone https://github.com/kubernetes/kubernetes
-$ cd kubernetes; make
-```
-
-Note: If the build fails, please retry.
-
-#### Step 2: Clone contrib repo
-
-```
+$ mkdir -p ~/go/src/github.com/k8s
 $ cd ~/go/src/github.com/k8s
 $ git clone https://github.com/jojimt/contrib -b contiv
-```
 
-#### Step 3: Clone and build netplugin
-
-```
 $ cd ~/go/src/github.com/k8s
 $ git clone https://github.com/contiv/netplugin
-
-$ cd netplugin
-$ make run-build
 ```
 
-#### Step 4: Set proxies if your network requires http/https proxy.
+#### Step 2: Set proxies if your network requires http/https proxy.
 
 ```
 $ export http_proxy=http://<....>
@@ -45,7 +28,7 @@ $ export https_proxy=http://<....>
 *Note that https_proxy should be set to point to a http:// URL (not https://).
 This is an ansible requirement.*
 
-#### Step 5: Create cluster
+#### Step 3: Create cluster
 
 ```
 $ cd ~/go/src/github.com/k8s/netplugin
@@ -56,7 +39,7 @@ This step will run Vagrant and ansible commands to bring a kubernetes cluster
 with one master and two worker nodes. This will take some time. Please be 
 patient.
 
-When step 5 completes, you should a message like the one below:
+When step 3 completes, you should a message like the one below:
 
 ```
 PLAY RECAP ******************************************************************** 
@@ -72,35 +55,14 @@ If that happens, just re-issue the command (usually, it's caused by a temporary
 unavailability of a repo on the web). If the problem persists, you should open an
 issue on github.*
 
-You should proceed to Step 6 **only if** the previous step completed successfully.
-
-#### Step 6: Load docker images and files used for demo.
+You should proceed to Step 4 **only if** the previous step completed successfully.
 
 This demo utilizes a **busybox** image built to include a full **netcat** utility.
 However, you can try other images as well if you like. *The Dockerfile used for 
 building the nc-busybox is available in the /shared folder of the k8master node
-(you will get to this directory in Step 7).*
+(you will get to this directory in Step 4).*
 
-This step pulls the nc-busybox (i.e. nc + busybox) image into the cluster nodes
-(this is just to speed up the demo process).
-
-```
-$ make k8s-demo
-```
-
-When step 6 completes, you should a message like the one below:
-
-```
-PLAY RECAP ******************************************************************** 
-k8master                   : ok=x    changed=x    unreachable=0    failed=0   
-k8node-01                  : ok=x    changed=x    unreachable=0    failed=0   
-k8node-02                  : ok=x    changed=x    unreachable=0    failed=0   
-```
-
-Again, if you hit an error, just retry the step.
-
-
-#### Step 7: Start the demo and ssh to the kubernetes master
+#### Step 4: Start the demo and ssh to the kubernetes master
 
 This step will start network services and log you into the kubernetes master node.
 
@@ -108,7 +70,7 @@ This step will start network services and log you into the kubernetes master nod
 $ make k8s-demo-start
 ```
 
-When step 7 completes, you will get a shell prompt from the master. Use *sudo su* to
+When step 4 completes, you will get a shell prompt from the master. Use *sudo su* to
 enter sudo mode. Try a few commands.
 
 

--- a/mgmtfn/k8splugin/README.md
+++ b/mgmtfn/k8splugin/README.md
@@ -153,7 +153,8 @@ they can ping each other.
 
 Now let's create Pod with poc-net and poc-epg specified as network and epg
 respectively. Examine pocnet-busybox.yaml. There are two additional labels:
-**network:** *poc-net* and **net-group:** *poc-epg* specified in this pod spec.
+**io.contiv.network:** *poc-net* and **io.contiv.net-group:** *poc-epg* specified
+in this pod spec.
 
 ```
 [root@k8master shared]# kubectl create -f pocnet-busybox.yaml 

--- a/mgmtfn/k8splugin/contivk8s/vagrant/export/noping-busybox.yaml
+++ b/mgmtfn/k8splugin/contivk8s/vagrant/export/noping-busybox.yaml
@@ -4,8 +4,8 @@ metadata:
   name: annoyed-busybox
   labels:
     app: demo
-    net-group: noping-epg
-    network: poc-net
+    io.contiv.net-group: noping-epg
+    io.contiv.network: poc-net
 spec:
   containers:
   - name: bbox

--- a/mgmtfn/k8splugin/contivk8s/vagrant/export/pingme-busybox.yaml
+++ b/mgmtfn/k8splugin/contivk8s/vagrant/export/pingme-busybox.yaml
@@ -4,8 +4,8 @@ metadata:
   name: sportive-busybox
   labels:
     app: demo
-    net-group: poc-epg
-    network: poc-net
+    io.contiv.net-group: poc-epg
+    io.contiv.network: poc-net
 spec:
   containers:
   - name: bbox

--- a/mgmtfn/k8splugin/contivk8s/vagrant/export/pocnet-busybox.yaml
+++ b/mgmtfn/k8splugin/contivk8s/vagrant/export/pocnet-busybox.yaml
@@ -4,8 +4,8 @@ metadata:
   name: busybox-poc-net
   labels:
     app: demo-labels
-    net-group: poc-epg
-    network: poc-net
+    io.contiv.net-group: poc-epg
+    io.contiv.network: poc-net
 spec:
   containers:
   - name: bbox

--- a/mgmtfn/k8splugin/contivk8s/vagrant/restart_cluster.sh
+++ b/mgmtfn/k8splugin/contivk8s/vagrant/restart_cluster.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
 # run ansible
-ansible-playbook -i .contiv_k8s_inventory ../../../../../contrib/ansible/cluster.yml --tags "contiv_restart" -e "networking=contiv"
+ansible-playbook -i .contiv_k8s_inventory ../../../../../contrib/ansible/cluster.yml --tags "contiv_restart" -e "networking=contiv contiv_bin_path=$top_dir/contiv_bin"

--- a/mgmtfn/k8splugin/contivk8s/vagrant/setup_cluster.sh
+++ b/mgmtfn/k8splugin/contivk8s/vagrant/setup_cluster.sh
@@ -1,7 +1,63 @@
 #!/bin/bash
 
+# GetKubernetes fetches k8s binaries from the k8 release repo
+function GetKubernetes {
+
+  # fetch kubernetes released binaries
+  pushd .
+  mkdir -p $top_dir/k8s-$k8sVer
+  if [ -f $top_dir/k8s-$k8sVer/kubernetes.tar.gz ]; then
+    echo "k8s-$k8sVer/kubernetes.tar.gz found, not fetching."
+    rm -rf $top_dir/k8s-$k8sVer/kubernetes
+    rm -rf $top_dir/k8s-$k8sVer/bin
+  else
+    cd $top_dir/k8s-$k8sVer 
+    wget https://github.com/kubernetes/kubernetes/releases/download/$k8sVer/kubernetes.tar.gz
+  fi
+
+  # untar kubernetes released binaries
+  cd $top_dir/k8s-$k8sVer
+  tar xvfz kubernetes.tar.gz kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+  tar xvfz kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+  popd
+
+  if [ ! -f $top_dir/k8s-$k8sVer/kubernetes/server/bin/kubelet ]; then
+    echo "Error kubelet not found after fetch/extraction"
+    exit 1
+  fi
+}
+
+# GetContiv fetches k8s binaries from the contiv release repo
+function GetContiv {
+
+  # fetch contiv binaries
+  pushd .
+  mkdir -p $top_dir/contiv_bin
+  if [ -f $top_dir/contiv_bin/netplugin-$contivVer.tar.bz2 ]; then
+    echo "netplugin-$contivVer.tar.bz2 found, not fetching."
+  else
+    cd $top_dir/contiv_bin
+    wget https://github.com/contiv/netplugin/releases/download/$contivVer/netplugin-$contivVer.tar.bz2
+    tar xvfj netplugin-$contivVer.tar.bz2
+  fi
+  popd
+
+  if [ ! -f $top_dir/contiv_bin/contivk8s ]; then
+    echo "Error contivk8s not found after fetch/extraction"
+    exit 1
+  fi
+}
+
 # kubernetes version to use -- defaults to v1.1.4
 : ${k8sVer:=v1.1.4}
+
+# contiv version
+: ${contivVer:=v0.0.0-01-21-2016.10-26-24.UTC}
+
+top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
+
+GetKubernetes
+GetContiv
 
 # add the vagrant box
 vagrant box list | grep "contiv/k8s-centos" | grep "0.0.6" >& /dev/null
@@ -12,28 +68,6 @@ fi
 # exit on any error
 set -e
 
-# fetch kubernetes released binaries
-pushd .
-top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
-mkdir -p $top_dir/k8s-$k8sVer
-if [ -f $top_dir/k8s-$k8sVer/kubernetes.tar.gz ]; then
-  echo "k8s-$k8sVer/kubernetes.tar.gz found, not fetching."
-  rm -rf $top_dir/k8s-$k8sVer/kubernetes
-  rm -rf $top_dir/k8s-$k8sVer/bin
-else
-  cd $top_dir/k8s-$k8sVer && wget https://github.com/kubernetes/kubernetes/releases/download/$k8sVer/kubernetes.tar.gz
-fi
-
-# untar kubernetes released binaries
-cd $top_dir/k8s-$k8sVer
-tar xvfz kubernetes.tar.gz kubernetes/server/kubernetes-server-linux-amd64.tar.gz
-tar xvfz kubernetes/server/kubernetes-server-linux-amd64.tar.gz
-popd
-
-if [ ! -f $top_dir/k8s-$k8sVer/kubernetes/server/bin/kubelet ]; then
-  echo "Error kubelet not found after fetch/extraction"
-  exit 1
-fi
 
 # bring up vms
 vagrant up
@@ -42,4 +76,4 @@ vagrant up
 vagrant_cluster.py
 
 # run ansible
-ansible-playbook -i .contiv_k8s_inventory ../../../../../contrib/ansible/cluster.yml --skip-tags "contiv_restart,ovs_install" -e "networking=contiv localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin"
+ansible-playbook -i .contiv_k8s_inventory ../../../../../contrib/ansible/cluster.yml --skip-tags "contiv_restart,ovs_install" -e "networking=contiv localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin contiv_bin_path=$top_dir/contiv_bin"

--- a/mgmtfn/k8splugin/contivk8s/vagrant/setup_cluster.sh
+++ b/mgmtfn/k8splugin/contivk8s/vagrant/setup_cluster.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# kubernetes version to use -- defaults to v1.1.4
+: ${k8sVer:=v1.1.4}
+
 # add the vagrant box
 vagrant box list | grep "contiv/k8s-centos" | grep "0.0.6" >& /dev/null
 if [ $? -ne 0 ]; then
@@ -9,6 +12,29 @@ fi
 # exit on any error
 set -e
 
+# fetch kubernetes released binaries
+pushd .
+top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
+mkdir -p $top_dir/k8s-$k8sVer
+if [ -f $top_dir/k8s-$k8sVer/kubernetes.tar.gz ]; then
+  echo "k8s-$k8sVer/kubernetes.tar.gz found, not fetching."
+  rm -rf $top_dir/k8s-$k8sVer/kubernetes
+  rm -rf $top_dir/k8s-$k8sVer/bin
+else
+  cd $top_dir/k8s-$k8sVer && wget https://github.com/kubernetes/kubernetes/releases/download/$k8sVer/kubernetes.tar.gz
+fi
+
+# untar kubernetes released binaries
+cd $top_dir/k8s-$k8sVer
+tar xvfz kubernetes.tar.gz kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+tar xvfz kubernetes/server/kubernetes-server-linux-amd64.tar.gz
+popd
+
+if [ ! -f $top_dir/k8s-$k8sVer/kubernetes/server/bin/kubelet ]; then
+  echo "Error kubelet not found after fetch/extraction"
+  exit 1
+fi
+
 # bring up vms
 vagrant up
 
@@ -16,4 +42,4 @@ vagrant up
 vagrant_cluster.py
 
 # run ansible
-ansible-playbook -i .contiv_k8s_inventory ../../../../../contrib/ansible/cluster.yml --skip-tags "contiv_restart,ovs_install" -e "networking=contiv"
+ansible-playbook -i .contiv_k8s_inventory ../../../../../contrib/ansible/cluster.yml --skip-tags "contiv_restart,ovs_install" -e "networking=contiv localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin"

--- a/mgmtfn/k8splugin/driver.go
+++ b/mgmtfn/k8splugin/driver.go
@@ -279,15 +279,18 @@ func getEPSpec(pInfo *cniapi.CNIPodAttr) (*epSpec, error) {
 	resp := epSpec{}
 
 	// Get labels from the kube api server
-	epg, err := kubeAPIClient.GetPodLabel(pInfo.K8sNameSpace, pInfo.Name, "net-group")
+	epg, err := kubeAPIClient.GetPodLabel(pInfo.K8sNameSpace, pInfo.Name,
+		"io.contiv.net-group")
 	if err != nil {
 		log.Errorf("Error getting epg. Err: %v", err)
 		return &resp, err
 	}
 
 	// Safe to ignore the error return for subsequent invocations of GetPodLabel
-	netw, _ := kubeAPIClient.GetPodLabel(pInfo.K8sNameSpace, pInfo.Name, "network")
-	tenant, _ := kubeAPIClient.GetPodLabel(pInfo.K8sNameSpace, pInfo.Name, "tenant")
+	netw, _ := kubeAPIClient.GetPodLabel(pInfo.K8sNameSpace, pInfo.Name,
+		"io.contiv.network")
+	tenant, _ := kubeAPIClient.GetPodLabel(pInfo.K8sNameSpace, pInfo.Name,
+		"io.contiv.tenant")
 	log.Infof("labels is %s/%s/%s for pod %s\n", tenant, netw, epg, pInfo.Name)
 	resp.Tenant = tenant
 	resp.Network = netw

--- a/mgmtfn/k8splugin/kubeClient.go
+++ b/mgmtfn/k8splugin/kubeClient.go
@@ -86,7 +86,7 @@ func (p *podInfo) setDefaults(ns, name string) {
 	p.name = name
 	p.labels["tenant"] = "default"
 	p.labels["network"] = "default-net"
-	p.labels["net-group"] = "default-epg"
+	p.labels["net-group"] = ""
 }
 
 // fetchPodLabels retrieves the labels from the podspec metadata

--- a/mgmtfn/k8splugin/kubeClient.go
+++ b/mgmtfn/k8splugin/kubeClient.go
@@ -84,9 +84,9 @@ func NewAPIClient(serverURL, caFile, keyFile, certFile string) *APIClient {
 func (p *podInfo) setDefaults(ns, name string) {
 	p.nameSpace = ns
 	p.name = name
-	p.labels["tenant"] = "default"
-	p.labels["network"] = "default-net"
-	p.labels["net-group"] = ""
+	p.labels["io.contiv.tenant"] = "default"
+	p.labels["io.contiv.network"] = "default-net"
+	p.labels["io.contiv.net-group"] = ""
 }
 
 // fetchPodLabels retrieves the labels from the podspec metadata

--- a/netmaster/master/api.go
+++ b/netmaster/master/api.go
@@ -259,6 +259,10 @@ func DeleteEndpointHandler(w http.ResponseWriter, r *http.Request, vars map[stri
 		return nil, err
 	}
 
+	// Take a global lock for address release
+	addrMutex.Lock()
+	defer addrMutex.Unlock()
+
 	// build the endpoint ID
 	netID := epdelReq.NetworkName + "." + epdelReq.TenantName
 	epID := getEpName(netID, &intent.ConfigEP{Container: epdelReq.EndpointID})

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -79,7 +79,7 @@ do
       $GOBIN/godep go tool cover -func=cover.out) || exit 1
   else
       (cd $GOSRC/github.com/contiv/netplugin && \
-      $GOBIN/godep go test ${pkg}) || exit 1
+      $GOBIN/godep go test -v ${pkg}) || exit 1
   fi
 done
 


### PR DESCRIPTION
This PR mainly addresses https://github.com/contiv/netplugin/issues/236. Additional changes are 1) Enable -v option for unit tests in order to be able to debug sporadic failures 2) Add locks in the endpoint delete path 3) Allow AddPod without an epg.