### PR TITLE
Fix spurious UT failure

### DIFF
--- a/mgmtfn/k8splugin/contivk8s/k8s_cni_test.go
+++ b/mgmtfn/k8splugin/contivk8s/k8s_cni_test.go
@@ -25,9 +25,11 @@ import (
 	"net"
 	"net/http"
 	"os"
+	osexec "os/exec"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -161,6 +163,17 @@ func setupTestServer() {
 		l.Close()
 		logger.Infof("k8s test plugin closing %s", driverPath)
 	}()
+
+	// make sure the listener is ready before returning
+	for count := 0; count < 5; count++ {
+		_, err := osexec.Command("ls", driverPath).CombinedOutput()
+		if err == nil {
+			return
+		}
+		time.Sleep(time.Second)
+	}
+
+	logger.Fatalf("Listener not ready after 5 sec")
 
 }
 

--- a/scripts/unittests
+++ b/scripts/unittests
@@ -58,6 +58,10 @@ if ${run_in_vagrant}; then
     (CONTIV_NODES=1 vagrant ssh netplugin-node1 -c 'sudo -E PATH=$PATH $GOSRC/github.com/contiv/netplugin/'${0})
     ret=$?
     if [ ${ret} -ne 0 ]; then
+        if [ -f /var/log/contivk8s.log ]; then
+	    cat /var/log/contivk8s.log
+        fi
+
         (CONTIV_NODES=1 vagrant destroy -f)
         exit 1
     fi


### PR DESCRIPTION
This fixes https://github.com/contiv/netplugin/issues/249

The failure was caused by a timing issue where the server was not ready by the time posts were issued.