### PR TITLE
netctl cli to take in router ip 

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel",
-			"Rev": "d65dea21cec76479ef1bf239cf428ffe78b653dc"
+			"Rev": "9c4fa80c5e7b0a4d8583fa9824c0fe799c114c4c"
 		},
 		{
 			"ImportPath": "github.com/contiv/go-etcd/etcd",
@@ -57,7 +57,7 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "3a258615978a694e7ca7aa14f511fc8663bb6bc0"
+			"Rev": "610f0ee65c85153b29477bc5dc911aed7b205127"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/etcdserver/etcdhttp/httptypes",

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModel.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModel.js
@@ -208,7 +208,7 @@ var BgpSummaryView = React.createClass({
 				<ModalTrigger modal={<BgpModalView Bgp={ Bgp }/>}>
 					<tr key={ Bgp.key } className="info">
 						
-						   
+						     
 					</tr>
 				</ModalTrigger>
 			);
@@ -220,7 +220,7 @@ var BgpSummaryView = React.createClass({
 				<thead>
 					<tr>
 					
-					   
+					     
 					</tr>
 				</thead>
 				<tbody>
@@ -240,11 +240,15 @@ var BgpModalView = React.createClass({
 	        <div className='modal-body' style={ {margin: '5%',} }>
 			
 			
-				<Input type='text' label='AS id' ref='AS' defaultValue={obj.AS} placeholder='AS id' />
+				<Input type='text' label='AS id' ref='as' defaultValue={obj.as} placeholder='AS id' />
 			
 				<Input type='text' label='host name' ref='hostname' defaultValue={obj.hostname} placeholder='host name' />
 			
 				<Input type='text' label='Bgp  neighbor' ref='neighbor' defaultValue={obj.neighbor} placeholder='Bgp  neighbor' />
+			
+				<Input type='text' label='AS id' ref='neighbor-as' defaultValue={obj.neighbor-as} placeholder='AS id' />
+			
+				<Input type='text' label='Bgp router intf ip' ref='routerip' defaultValue={obj.routerip} placeholder='Bgp router intf ip' />
 			
 			</div>
 	        <div className='modal-footer'>

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.go
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.go
@@ -202,9 +202,11 @@ type Bgp struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
 
-	AS       string `json:"AS,omitempty"`       // AS id
-	Hostname string `json:"hostname,omitempty"` // host name
-	Neighbor string `json:"neighbor,omitempty"` // Bgp  neighbor
+	As         string `json:"as,omitempty"`          // AS id
+	Hostname   string `json:"hostname,omitempty"`    // host name
+	Neighbor   string `json:"neighbor,omitempty"`    // Bgp  neighbor
+	NeighborAs string `json:"neighbor-as,omitempty"` // AS id
+	Routerip   string `json:"routerip,omitempty"`    // Bgp router intf ip
 
 }
 

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.py
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.py
@@ -178,9 +178,11 @@ class objmodelClient:
 	    postUrl = self.baseUrl + '/api/Bgps/' + obj.hostname  + '/'
 
 	    jdata = json.dumps({ 
-			"AS": obj.AS, 
+			"as": obj.as, 
 			"hostname": obj.hostname, 
 			"neighbor": obj.neighbor, 
+			"neighbor-as": obj.neighbor-as, 
+			"routerip": obj.routerip, 
 	    })
 
 	    # Post the data

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/contivModel.go
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/contivModel.go
@@ -75,9 +75,11 @@ type Bgp struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
 
-	AS       string `json:"AS,omitempty"`       // AS id
-	Hostname string `json:"hostname,omitempty"` // host name
-	Neighbor string `json:"neighbor,omitempty"` // Bgp  neighbor
+	As         string `json:"as,omitempty"`          // AS id
+	Hostname   string `json:"hostname,omitempty"`    // host name
+	Neighbor   string `json:"neighbor,omitempty"`    // Bgp  neighbor
+	NeighborAs string `json:"neighbor-as,omitempty"` // AS id
+	Routerip   string `json:"routerip,omitempty"`    // Bgp router intf ip
 
 }
 
@@ -1573,8 +1575,8 @@ func ValidateBgp(obj *Bgp) error {
 
 	// Validate each field
 
-	if len(obj.AS) > 64 {
-		return errors.New("AS string too long")
+	if len(obj.As) > 64 {
+		return errors.New("as string too long")
 	}
 
 	if len(obj.Hostname) > 256 {
@@ -1583,6 +1585,14 @@ func ValidateBgp(obj *Bgp) error {
 
 	if len(obj.Neighbor) > 15 {
 		return errors.New("neighbor string too long")
+	}
+
+	if len(obj.NeighborAs) > 64 {
+		return errors.New("neighbor-as string too long")
+	}
+
+	if len(obj.Routerip) > 15 {
+		return errors.New("routerip string too long")
 	}
 
 	return nil

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/host.json
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/host.json
@@ -11,7 +11,17 @@
                                              "title": "host name",
                                              "length": 256
                                 },
-                                "AS":       {
+                                "routerip": {
+                                             "type": "string",
+                                             "title": "Bgp router intf ip",
+                                             "length": 15
+                                },
+                                "as":       {
+                                             "type": "string",
+                                             "title": "AS id",
+                                             "length": 64
+                                },
+                                "neighbor-as":       {
                                              "type": "string",
                                              "title": "AS id",
                                              "length": 64
@@ -19,9 +29,8 @@
                                 "neighbor":{
                                         "type": "string",
                                         "title": "Bgp  neighbor",
-                                        "length": 15 
+                                        "length": 15
                                 }
                  }
         }]
 }
-

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/www/dist/bundle.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/www/dist/bundle.js
@@ -334,7 +334,7 @@
 	                        React.createElement("td", null,  network.networkName), 
 	                        React.createElement("td", null,  network.encap), 
 	                        React.createElement("td", null,  network.subnet), 
-	                        React.createElement("td", null,  network.defaultGw)
+	                        React.createElement("td", null,  network.gateway)
 
 						)
 					)
@@ -370,10 +370,8 @@
 	                React.createElement(Input, {type: "text", label: "Tenant Name", ref: "tenantName", defaultValue: obj.tenantName, placeholder: "Tenant Name"}), 
 	                React.createElement(Input, {type: "text", label: "Network name", ref: "networkName", defaultValue: obj.networkName, placeholder: "Network name"}), 
 					React.createElement(Input, {type: "text", label: "Encapsulation", ref: "encap", defaultValue: obj.encap, placeholder: "Encapsulation"}), 
-					React.createElement(Input, {type: "text", label: "Private network", ref: "isPrivate", defaultValue: obj.isPrivate, placeholder: "Private network"}), 
-					React.createElement(Input, {type: "text", label: "Public network", ref: "isPublic", defaultValue: obj.isPublic, placeholder: "Public network"}), 
 					React.createElement(Input, {type: "text", label: "Subnet", ref: "subnet", defaultValue: obj.subnet, placeholder: "Subnet"}), 
-	                React.createElement(Input, {type: "text", label: "Gateway", ref: "defaultGw", defaultValue: obj.defaultGw, placeholder: "Gateway"})
+	                React.createElement(Input, {type: "text", label: "Gateway", ref: "defaultGw", defaultValue: obj.gateway, placeholder: "Gateway"})
 				), 
 		        React.createElement("div", {className: "modal-footer"}, 
 					React.createElement(Button, {onClick: this.props.onRequestHide}, "Close")
@@ -516,19 +514,36 @@
 	            if (rule.action == "deny") {
 	                action = "deny"
 	            }
-				return (
-					React.createElement(ModalTrigger, {modal: React.createElement(RuleModalView, {rule:  rule })}, 
-						React.createElement("tr", {key:  rule.key, className: "info"}, 
-	                        React.createElement("td", null,  rule.ruleId), 
-	                        React.createElement("td", null,  rule.priority), 
-							React.createElement("td", null,  action ), 
-							React.createElement("td", null,  rule.endpointGroup), 
-	                        React.createElement("td", null,  rule.ipAddress), 
-	                        React.createElement("td", null,  rule.protocol), 
-							React.createElement("td", null,  rule.port)
-						)
-					)
-				);
+	            if (self.props.direction == "out") {
+	                return (
+	    				React.createElement(ModalTrigger, {modal: React.createElement(RuleModalView, {rule:  rule })}, 
+	    					React.createElement("tr", {key:  rule.key, className: "info"}, 
+	                            React.createElement("td", null,  rule.ruleId), 
+	                            React.createElement("td", null,  rule.priority), 
+	    						React.createElement("td", null,  action ), 
+	    						React.createElement("td", null,  rule.toEndpointGroup), 
+	                            React.createElement("td", null,  rule.toIpAddress), 
+	                            React.createElement("td", null,  rule.protocol), 
+	    						React.createElement("td", null,  rule.port)
+	    					)
+	    				)
+	    			);
+	            } else {
+	                return (
+	    				React.createElement(ModalTrigger, {modal: React.createElement(RuleModalView, {rule:  rule })}, 
+	    					React.createElement("tr", {key:  rule.key, className: "info"}, 
+	                            React.createElement("td", null,  rule.ruleId), 
+	                            React.createElement("td", null,  rule.priority), 
+	    						React.createElement("td", null,  action ), 
+	    						React.createElement("td", null,  rule.fromEndpointGroup), 
+	                            React.createElement("td", null,  rule.fromIpAddress), 
+	                            React.createElement("td", null,  rule.protocol), 
+	    						React.createElement("td", null,  rule.port)
+	    					)
+	    				)
+	    			);
+	            }
+
 			});
 
 	        // Set appropriate heading based on direction

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/www/network.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/www/network.js
@@ -30,7 +30,7 @@ var NetworkSummaryView = React.createClass({
                         <td>{ network.networkName }</td>
                         <td>{ network.encap }</td>
                         <td>{ network.subnet }</td>
-                        <td>{ network.defaultGw }</td>
+                        <td>{ network.gateway }</td>
 
 					</tr>
 				</ModalTrigger>
@@ -66,10 +66,8 @@ var NetworkModalView = React.createClass({
                 <Input type='text' label='Tenant Name' ref='tenantName' defaultValue={obj.tenantName} placeholder='Tenant Name' />
                 <Input type='text' label='Network name' ref='networkName' defaultValue={obj.networkName} placeholder='Network name' />
 				<Input type='text' label='Encapsulation' ref='encap' defaultValue={obj.encap} placeholder='Encapsulation' />
-				<Input type='text' label='Private network' ref='isPrivate' defaultValue={obj.isPrivate} placeholder='Private network' />
-				<Input type='text' label='Public network' ref='isPublic' defaultValue={obj.isPublic} placeholder='Public network' />
 				<Input type='text' label='Subnet' ref='subnet' defaultValue={obj.subnet} placeholder='Subnet' />
-                <Input type='text' label='Gateway' ref='defaultGw' defaultValue={obj.defaultGw} placeholder='Gateway' />
+                <Input type='text' label='Gateway' ref='defaultGw' defaultValue={obj.gateway} placeholder='Gateway' />
 			</div>
 	        <div className='modal-footer'>
 				<Button onClick={this.props.onRequestHide}>Close</Button>

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/www/package.json
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/www/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jsx-loader": "^0.13.2"
+  }
+}

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/www/policy.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/www/policy.js
@@ -1,0 +1,176 @@
+// policy.js
+// Display Policy information
+
+var contivModel = require("../client/contivModel")
+
+var PolicySummaryView = React.createClass({
+  	render: function() {
+		var self = this
+
+		// Walk thru all objects
+		var policyListView = self.props.policys.map(function(policy){
+			return (
+				<ModalTrigger modal={<PolicyModalView policy={ policy }/>}>
+					<tr key={ policy.key } className="info">
+						<td>{ policy.tenantName }</td>
+                        <td>{ policy.policyName }</td>
+					</tr>
+				</ModalTrigger>
+			);
+		});
+
+		return (
+        <div>
+			<Table hover>
+				<thead>
+					<tr>
+						<th> Tenant Name </th>
+                        <th> Policy Name </th>
+					</tr>
+				</thead>
+				<tbody>
+            		{ policyListView }
+				</tbody>
+			</Table>
+        </div>
+    	);
+	}
+});
+
+var PolicyModalView = React.createClass({
+	render() {
+		var obj = this.props.policy
+
+        // Create incoming rule list
+        var inRules = window.globalRules.filter(function(rule){
+            if ((rule.tenantName == obj.tenantName) && (rule.policyName == obj.policyName) &&
+                rule.direction == "in") {
+                return true
+            }
+
+            return false
+        });
+
+        // create outgoing rule List
+        var outRules = window.globalRules.filter(function(rule){
+            if ((rule.tenantName == obj.tenantName) && (rule.policyName == obj.policyName) &&
+                rule.direction == "out") {
+                return true
+            }
+
+            return false
+        })
+
+	    return (
+	      <Modal {...this.props} bsStyle='primary' bsSize='large' title={obj.policyName} animation={false}>
+	        <div className='modal-body' style={ {margin: '5%',} }>
+				<Input type='text' label='Tenant Name' ref='tenantName' defaultValue={obj.tenantName} placeholder='Tenant Name' />
+                <Input type='text' label='Policy Name' ref='policyName' defaultValue={obj.policyName} placeholder='Policy Name' />
+			</div>
+            <div style={ {margin: '5%',} }>
+                <h3> Incoming Rules </h3>
+                <RuleSummaryView key="ruleSummary" rules={inRules} direction="in" />
+            </div>
+            <div style={ {margin: '5%',} }>
+                <h3> Outgoing Rules </h3>
+                <RuleSummaryView key="ruleSummary" rules={outRules} direction="out" />
+            </div>
+	        <div className='modal-footer'>
+				<Button onClick={this.props.onRequestHide}>Close</Button>
+	        </div>
+	      </Modal>
+	    );
+  	}
+});
+
+var RuleModalView = contivModel.RuleModalView
+var RuleSummaryView = React.createClass({
+  	render: function() {
+		var self = this
+
+		// Walk thru all objects
+		var ruleListView = self.props.rules.map(function(rule){
+            var action = "allow"
+            if (rule.action == "deny") {
+                action = "deny"
+            }
+            if (self.props.direction == "out") {
+                return (
+    				<ModalTrigger modal={<RuleModalView rule={ rule }/>}>
+    					<tr key={ rule.key } className="info">
+                            <td>{ rule.ruleId }</td>
+                            <td>{ rule.priority }</td>
+    						<td>{ action }</td>
+    						<td>{ rule.toEndpointGroup }</td>
+                            <td>{ rule.toIpAddress }</td>
+                            <td>{ rule.protocol }</td>
+    						<td>{ rule.port }</td>
+    					</tr>
+    				</ModalTrigger>
+    			);
+            } else {
+                return (
+    				<ModalTrigger modal={<RuleModalView rule={ rule }/>}>
+    					<tr key={ rule.key } className="info">
+                            <td>{ rule.ruleId }</td>
+                            <td>{ rule.priority }</td>
+    						<td>{ action }</td>
+    						<td>{ rule.fromEndpointGroup }</td>
+                            <td>{ rule.fromIpAddress }</td>
+                            <td>{ rule.protocol }</td>
+    						<td>{ rule.port }</td>
+    					</tr>
+    				</ModalTrigger>
+    			);
+            }
+
+		});
+
+        // Set appropriate heading based on direction
+        var groupHdr = "From Group";
+        var ipHdr = "From IP Address"
+        if (self.props.direction == "out") {
+            groupHdr = "To Group"
+            ipHdr = "To IP Address"
+        }
+
+		return (
+        <div>
+			<Table hover>
+				<thead>
+					<tr>
+                        <th> Rule Id </th>
+                        <th> Priority </th>
+						<th> Action </th>
+						<th> { groupHdr } </th>
+                        <th> { ipHdr } </th>
+                        <th> Protocol </th>
+						<th> To Port </th>
+					</tr>
+				</thead>
+				<tbody>
+            		{ ruleListView }
+				</tbody>
+			</Table>
+        </div>
+    	);
+	}
+});
+var PolicyPane = React.createClass({
+  	render: function() {
+		var self = this
+
+		if (self.props.policies === undefined) {
+			return <div> </div>
+		}
+
+        // var PolicySummaryView = contivModel.PolicySummaryView
+        return (
+            <div style={{margin: '5%',}}>
+                <PolicySummaryView key="policySummary" policys={self.props.policies}/>
+            </div>
+        );
+	}
+});
+
+module.exports = PolicyPane

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/www/volumes.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/www/volumes.js
@@ -1,0 +1,45 @@
+// volumes.js
+// Display Volumes information
+
+var VolumesPane = React.createClass({
+  	render: function() {
+		var self = this
+
+		if (self.props.volumes === undefined) {
+			return <div> </div>
+		}
+
+		// Walk thru all the volumes
+		var volListView = self.props.volumes.map(function(vol){
+			return (
+				<tr key={vol.key} className="info">
+					<td>{vol.tenantName}</td>
+					<td>{vol.volumeName}</td>
+					<td>{vol.poolName}</td>
+					<td>{vol.size}</td>
+				</tr>
+			);
+		});
+
+		// Render the pane
+		return (
+        <div style={{margin: '5%',}}>
+			<Table hover>
+				<thead>
+					<tr>
+						<th>Tenant</th>
+						<th>Volume</th>
+						<th>Pool</th>
+						<th>Size</th>
+					</tr>
+				</thead>
+				<tbody>
+            		{volListView}
+				</tbody>
+			</Table>
+        </div>
+    );
+	}
+});
+
+module.exports = VolumesPane

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/www/webpack.config.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/www/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    entry: "./main.js",
+    output: {
+        path: __dirname + "/dist",
+        filename: "bundle.js"
+    },
+    module: {
+        loaders: [
+            { test: /\.css$/, loader: "style!css" },
+            {
+                //tell webpack to use jsx-loader for all *.jsx files
+                test: /\.js$/,
+                loader: 'jsx-loader?insertPragma=React.DOM&harmony'
+            }
+        ]
+    }
+};

--- a/Godeps/_workspace/src/github.com/contiv/ofnet/ofnet.go
+++ b/Godeps/_workspace/src/github.com/contiv/ofnet/ofnet.go
@@ -73,7 +73,9 @@ type OfnetDatapath interface {
 type OfnetProto interface {
 
 	//Create a protocol server
-	StartProtoServer(routerInfo OfnetProtoRouterInfo) error
+	StartProtoServer(routerInfo *OfnetProtoRouterInfo) error
+
+	StopProtoServer() error
 
 	//Add a Protocol Neighbor
 	AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) error
@@ -144,8 +146,9 @@ type OfnetProtoNeighborInfo struct {
 
 type OfnetProtoRouterInfo struct {
 	ProtocolType string // type of protocol
-	RouterIP     string // ip address of the neighbor
+	RouterIP     string // ip address of the router
 	VlanIntf     string // uplink L2 intf
+	As           string // As for Bgp protocol
 }
 
 type OfnetProtoRouteInfo struct {

--- a/Godeps/_workspace/src/github.com/contiv/ofnet/ofnetBgp.go
+++ b/Godeps/_workspace/src/github.com/contiv/ofnet/ofnetBgp.go
@@ -20,8 +20,9 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"io"
 	"net"
-	"os/exec"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	api "github.com/osrg/gobgp/api"
@@ -36,6 +37,7 @@ import (
 )
 
 type OfnetBgp struct {
+	sync.Mutex
 	routerIP string      // virtual interface ip for bgp
 	vlanIntf string      // uplink port name
 	agent    *OfnetAgent // Pointer back to ofnet agent that owns this
@@ -48,32 +50,29 @@ type OfnetBgp struct {
 
 	myRouterMac net.HardwareAddr //Router mac used for external proxy
 	myBgpPeer   string           // bgp neighbor
+	myBgpAs     uint32
 	cc          *grpc.ClientConn //grpc client connection
-
+	stop        chan bool
+	start       chan bool
+	intfName    string //loopback intf to run bgp
 }
 
 // Create a new vlrouter instance
 func NewOfnetBgp(agent *OfnetAgent, routerInfo []string) *OfnetBgp {
-
 	//Sanity checks
 	if agent == nil || agent.datapath == nil {
 		log.Errorf("Invilid OfnetAgent")
 		return nil
 	}
-
 	ofnetBgp := new(OfnetBgp)
 	// Keep a reference to the agent
 	ofnetBgp.agent = agent
 
-	if len(routerInfo) > 1 {
-		//Ensuring routerInfo is in ip format
-		if ok := net.ParseIP(routerInfo[0]); ok != nil {
-			ofnetBgp.routerIP = routerInfo[0]
-		} else {
-			log.Errorf("Error creating ofnetBgp")
-			return nil
-		}
-		ofnetBgp.vlanIntf = routerInfo[1]
+	if len(routerInfo) > 0 {
+		ofnetBgp.vlanIntf = routerInfo[0]
+	} else {
+		log.Errorf("Error creating ofnetBgp. Missing uplink port")
+		return nil
 	}
 
 	ofnetBgp.bgpServer, ofnetBgp.grpcServer = createBgpServer()
@@ -82,14 +81,9 @@ func NewOfnetBgp(agent *OfnetAgent, routerInfo []string) *OfnetBgp {
 		log.Errorf("Error instantiating Bgp server")
 		return nil
 	}
-	//go routine to start gobgp server
-	go func() {
-		rInfo := OfnetProtoRouterInfo{ProtocolType: "bgp", RouterIP: ofnetBgp.routerIP}
-		err := ofnetBgp.StartProtoServer(rInfo)
-		if err != nil {
-			log.Errorf("protocol server finished with err: %s", err)
-		}
-	}()
+	ofnetBgp.stop = make(chan bool, 1)
+	ofnetBgp.intfName = "inb01"
+	ofnetBgp.start = make(chan bool, 1)
 	return ofnetBgp
 }
 
@@ -99,9 +93,14 @@ Bgp serve routine does the following:
 2) Add MyBgp endpoint
 3) Kicks off routines to monitor route updates and peer state
 */
-func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
-	time.Sleep(5 * time.Second)
-	self.agent.WaitForSwitchConnection()
+func (self *OfnetBgp) StartProtoServer(routerInfo *OfnetProtoRouterInfo) error {
+	log.Infof("Starting the Bgp Server with %v", routerInfo)
+	//go routine to start gobgp server
+	var len uint
+	var err error
+	self.routerIP, len, err = ParseCIDR(routerInfo.RouterIP)
+	as, _ := strconv.Atoi(routerInfo.As)
+	self.myBgpAs = uint32(as)
 
 	self.modRibCh = make(chan *api.Path, 16)
 	self.advPathCh = make(chan *api.Path, 16)
@@ -123,36 +122,44 @@ func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
 		Pattrs: make([][]byte, 0),
 	}
 
-	if len(routerInfo.RouterIP) == 0 {
-		log.Errorf("Invalid router IP. Bgp service aborted")
-		return errors.New("Invalid router IP")
-	}
-	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(32), routerInfo.RouterIP).Serialize()
+	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(32), self.routerIP).Serialize()
 	n, _ := bgp.NewPathAttributeNextHop("0.0.0.0").Serialize()
 	path.Pattrs = append(path.Pattrs, n)
 	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_INCOMPLETE).Serialize()
 	path.Pattrs = append(path.Pattrs, origin)
 
-	err = self.agent.ovsDriver.CreatePort("inb01", "internal", 1)
+	log.Debugf("Creating the loopback port ")
+	err = self.agent.ovsDriver.CreatePort(self.intfName, "internal", 1)
 	if err != nil {
 		log.Errorf("Error creating the port", err)
 	}
 
-	cmd := exec.Command("ifconfig", "inb01", routerInfo.RouterIP+"/24")
-	cmd.Run()
+	intfIP := fmt.Sprintf("%s/%d", self.routerIP, len)
+	log.Debugf("Creating inb01 with ", intfIP)
+	ofPortno, _ := self.agent.ovsDriver.GetOfpPortNo(self.intfName)
 
-	intf, _ := net.InterfaceByName("inb01")
-	ofPortno, _ := self.agent.ovsDriver.GetOfpPortNo("inb01")
+	link, err := netlink.LinkByName(self.intfName)
+	if err != nil {
+		log.Errorf("error finding link by name %v", self.intfName)
+		return err
+	}
+	linkIP, err := netlink.ParseAddr(intfIP)
+	if err != nil {
+		log.Errorf("invalid ip ", intfIP)
+	}
+	netlink.AddrAdd(link, linkIP)
 
-	if intf == nil || ofPortno == 0 {
-		log.Errorf("Error fetching inb01 information", intf, ofPortno)
+	if link == nil || ofPortno == 0 {
+		log.Errorf("Error fetching %v information", self.intfName, link, ofPortno)
 		return errors.New("Unable to fetch inb01 info")
 	}
 
+	intf, _ := net.InterfaceByName(self.intfName)
+
 	epreg := &OfnetEndpoint{
-		EndpointID:   routerInfo.RouterIP,
+		EndpointID:   self.routerIP,
 		EndpointType: "internal-bgp",
-		IpAddr:       net.ParseIP(routerInfo.RouterIP),
+		IpAddr:       net.ParseIP(self.routerIP),
 		IpMask:       net.ParseIP("255.255.255.255"),
 		VrfId:        0,                          // FIXME set VRF correctly
 		MacAddrStr:   intf.HardwareAddr.String(), //link.Attrs().HardwareAddr.String(),
@@ -160,8 +167,9 @@ func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
 		PortNo:       ofPortno,
 		Timestamp:    time.Now(),
 	}
+
 	// Add the endpoint to local routing table
-	self.agent.endpointDb[routerInfo.RouterIP] = epreg
+	self.agent.endpointDb[self.routerIP] = epreg
 	self.agent.localEndpointDb[epreg.PortNo] = epreg
 	fmt.Println(epreg)
 	err = self.agent.datapath.AddLocalEndpoint(*epreg)
@@ -169,8 +177,8 @@ func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
 	//Add bgp router id as well
 	bgpGlobalCfg := &bgpconf.Global{}
 	setDefaultGlobalConfigValues(bgpGlobalCfg)
-	bgpGlobalCfg.GlobalConfig.RouterId = net.ParseIP(routerInfo.RouterIP)
-	bgpGlobalCfg.GlobalConfig.As = 65002
+	bgpGlobalCfg.GlobalConfig.RouterId = net.ParseIP(self.routerIP)
+	bgpGlobalCfg.GlobalConfig.As = self.myBgpAs
 	self.bgpServer.SetGlobalType(*bgpGlobalCfg)
 
 	self.advPathCh <- path
@@ -179,7 +187,7 @@ func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
 	go self.monitorBest()
 	//monitor peer state
 	go self.monitorPeer()
-
+	self.start <- true
 	for {
 		select {
 		case p := <-self.modRibCh:
@@ -187,8 +195,32 @@ func (self *OfnetBgp) StartProtoServer(routerInfo OfnetProtoRouterInfo) error {
 			if err != nil {
 				log.Error("failed to mod rib: ", err)
 			}
+		case <-self.stop:
+			return nil
 		}
 	}
+	return nil
+}
+func (self *OfnetBgp) StopProtoServer() error {
+
+	log.Info("Received stop bgp server")
+	err := self.agent.ovsDriver.DeletePort(self.intfName)
+	if err != nil {
+		log.Errorf("Error deleting the port", err)
+		return err
+	}
+
+	// Delete the endpoint from local routing table
+	epreg := self.agent.getEndpointByIp(net.ParseIP(self.routerIP))
+	if epreg != nil {
+		delete(self.agent.endpointDb, self.routerIP)
+		delete(self.agent.localEndpointDb, epreg.PortNo)
+		err = self.agent.datapath.RemoveLocalEndpoint(*epreg)
+	}
+	self.routerIP = ""
+	self.myBgpAs = 0
+	self.stop <- true
+	return nil
 }
 
 //DeleteProtoNeighbor deletes bgp neighbor for the host
@@ -256,6 +288,8 @@ func (self *OfnetBgp) DeleteProtoNeighbor() error {
 //AddProtoNeighbor adds bgp neighbor
 func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) error {
 
+	<-self.start
+
 	log.Infof("Received AddProtoNeighbor to Add bgp neighbor %v", neighborInfo.NeighborIP)
 
 	var policyConfig bgpconf.RoutingPolicy
@@ -274,15 +308,7 @@ func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) err
 	})
 
 	self.bgpServer.PeerAdd(*p)
-	//	if policyConfig == nil {
-	//policyConfig = &newConfig.Policy
 	self.bgpServer.SetPolicy(policyConfig)
-	//	} else {
-	//if bgpconf.CheckPolicyDifference(policyConfig, &newConfig.Policy) {
-	//	log.Info("Policy config is updated")
-	//	bgpServer.UpdatePolicy(newConfig.Policy)
-	//}
-	//	}
 
 	log.Infof("Peer %v is added", p.NeighborConfig.NeighborAddress)
 
@@ -308,6 +334,15 @@ func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) err
 	self.myBgpPeer = neighborInfo.NeighborIP
 	go self.sendArp()
 
+	//Walk through all the localEndpointDb and them to protocol rib
+	for _, endpoint := range self.agent.localEndpointDb {
+		path := &OfnetProtoRouteInfo{
+			ProtocolType: "bgp",
+			localEpIP:    endpoint.IpAddr.String(),
+			nextHopIP:    self.routerIP,
+		}
+		self.AddLocalProtoRoute(path)
+	}
 	return nil
 }
 
@@ -324,6 +359,12 @@ func (self *OfnetBgp) GetRouterInfo() *OfnetProtoRouterInfo {
 //AddLocalProtoRoute is used to add local endpoint to the protocol RIB
 func (self *OfnetBgp) AddLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error {
 
+	if self.routerIP == "" {
+		//ignoring populating to the bgp rib because
+		//Bgp is not configured.
+		return nil
+	}
+
 	log.Infof("Received AddLocalProtoRoute to add local endpoint to protocol RIB: %v", pathInfo)
 
 	path := &api.Path{
@@ -335,7 +376,7 @@ func (self *OfnetBgp) AddLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error {
 	path.Nlri, _ = nlri.Serialize()
 	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_EGP).Serialize()
 	path.Pattrs = append(path.Pattrs, origin)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65002})}
+	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{self.myBgpAs})}
 	aspath, _ := bgp.NewPathAttributeAsPath(aspathParam).Serialize()
 	path.Pattrs = append(path.Pattrs, aspath)
 	n, _ := bgp.NewPathAttributeNextHop(pathInfo.nextHopIP).Serialize()
@@ -358,10 +399,9 @@ func (self *OfnetBgp) AddLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error {
 
 	stream, err := client.ModPath(context.Background())
 	if err != nil {
-		log.Errorf("Fail to enforce Modpathi", err)
+		log.Errorf("Fail to enforce Modpath", err)
 		return err
 	}
-
 	err = stream.Send(arg)
 	if err != nil {
 		log.Errorf("Failed to send strean", err)
@@ -393,7 +433,7 @@ func (self *OfnetBgp) DeleteLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error
 	path.Nlri, _ = nlri.Serialize()
 	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_EGP).Serialize()
 	path.Pattrs = append(path.Pattrs, origin)
-	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{65002})}
+	aspathParam := []bgp.AsPathParamInterface{bgp.NewAs4PathParam(2, []uint32{self.myBgpAs})}
 	aspath, _ := bgp.NewPathAttributeAsPath(aspathParam).Serialize()
 	path.Pattrs = append(path.Pattrs, aspath)
 	n, _ := bgp.NewPathAttributeNextHop(pathInfo.nextHopIP).Serialize()
@@ -415,22 +455,24 @@ func (self *OfnetBgp) DeleteLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error
 	}
 
 	stream, err := client.ModPath(context.Background())
-	log.Infof("The stream is ", stream)
 	if err != nil {
 		log.Errorf("Fail to enforce Modpathi", err)
 		return err
 	}
+
 	err = stream.Send(arg)
 	if err != nil {
 		log.Errorf("Failed to send strean", err)
 		return err
 	}
 	stream.CloseSend()
+
 	res, e := stream.CloseAndRecv()
 	if e != nil {
 		log.Errorf("Falied toclose stream ")
 		return e
 	}
+
 	if res.Code != api.Error_SUCCESS {
 		return fmt.Errorf("error: code: %d, msg: %s", res.Code, res.Msg)
 	}
@@ -438,12 +480,12 @@ func (self *OfnetBgp) DeleteLocalProtoRoute(pathInfo *OfnetProtoRouteInfo) error
 }
 
 //monitorBest monitors for route updates/changes form peer
-func (self *OfnetBgp) monitorBest() error {
+func (self *OfnetBgp) monitorBest() {
 
 	client := api.NewGobgpApiClient(self.cc)
 	if client == nil {
 		log.Errorf("Invalid Gobgpapi client")
-		return errors.New("Error creating Gobgpapiclient")
+		return
 	}
 	arg := &api.Arguments{
 		Resource: api.Resource_GLOBAL,
@@ -452,7 +494,7 @@ func (self *OfnetBgp) monitorBest() error {
 
 	stream, err := client.MonitorBestChanged(context.Background(), arg)
 	if err != nil {
-		return err
+		return
 	}
 
 	for {
@@ -460,37 +502,37 @@ func (self *OfnetBgp) monitorBest() error {
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return err
+			log.Infof("monitorBest stream ended")
+			return
 		}
-
 		self.modRibCh <- dst.Paths[0]
 	}
-	return nil
+	return
 }
 
 // monitorPeer is used to monitor the bgp peer state
-func (self *OfnetBgp) monitorPeer() error {
+func (self *OfnetBgp) monitorPeer() {
 
 	var oldAdminState, oldState string
 
 	client := api.NewGobgpApiClient(self.cc)
 	if client == nil {
 		log.Errorf("Invalid Gobgpapi client")
-		return errors.New("Error creating Gobgpapiclient")
+		return
 	}
 	arg := &api.Arguments{}
 
 	stream, err := client.MonitorPeerState(context.Background(), arg)
 	if err != nil {
 		log.Errorf("MonitorPeerState failed ", err)
-		return err
+		return
 	}
 	for {
 		s, err := stream.Recv()
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			log.Errorf("MonitorPeerState stream failed :", err)
+			log.Warnf("MonitorPeerState stream ended :")
 			break
 		}
 		fmt.Printf("[NEIGH] %s fsm: %s admin: %s\n", s.Conf.NeighborAddress,
@@ -526,7 +568,7 @@ func (self *OfnetBgp) monitorPeer() error {
 		oldState = s.Info.BgpState
 		oldAdminState = s.Info.AdminState
 	}
-	return nil
+	return
 }
 
 //modrib receives route updates from BGP server and adds the endpoint
@@ -616,8 +658,10 @@ func (self *OfnetBgp) modRib(path *api.Path) error {
 	} else {
 		log.Info("Received route withdraw from BGP for ", endpointIPNet)
 		endpoint := self.agent.getEndpointByIp(endpointIPNet.IP)
-		self.agent.datapath.RemoveEndpoint(endpoint)
-		delete(self.agent.endpointDb, endpoint.EndpointID)
+		if endpoint != nil {
+			self.agent.datapath.RemoveEndpoint(endpoint)
+			delete(self.agent.endpointDb, endpoint.EndpointID)
+		}
 	}
 	return nil
 }
@@ -728,4 +772,20 @@ func (self *OfnetBgp) sendArp() {
 
 func (self *OfnetBgp) ModifyProtoRib(path interface{}) {
 	self.modRibCh <- path.(*api.Path)
+}
+
+// ParseCIDR parses a CIDR string into a gateway IP and length.
+func ParseCIDR(cidrStr string) (string, uint, error) {
+	strs := strings.Split(cidrStr, "/")
+	if len(strs) != 2 {
+		return "", 0, errors.New("invalid cidr format")
+	}
+
+	subnetStr := strs[0]
+	subnetLen, err := strconv.Atoi(strs[1])
+	if subnetLen > 32 || err != nil {
+		return "", 0, errors.New("invalid mask in gateway/mask specification ")
+	}
+
+	return subnetStr, uint(subnetLen), nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -99,8 +99,8 @@ type NetworkDriver interface {
 	DeletePeerHost(node ServiceInfo) error
 	AddMaster(node ServiceInfo) error
 	DeleteMaster(node ServiceInfo) error
-	AddBgpNeighbors(id string) error
-	DeleteBgpNeighbors(id string) error
+	AddBgp(id string) error
+	DeleteBgp(id string) error
 }
 
 // WatchState is used to provide a difference between core.State structs by

--- a/drivers/fakenetepdriver.go
+++ b/drivers/fakenetepdriver.go
@@ -60,12 +60,12 @@ func (d *FakeNetEpDriver) DeleteMaster(node core.ServiceInfo) error {
 	return core.Errorf("Not implemented")
 }
 
-// AddBgpNeighbors is not implemented.
-func (d *FakeNetEpDriver) AddBgpNeighbors(id string) (err error) {
+// AddBgp is not implemented.
+func (d *FakeNetEpDriver) AddBgp(id string) (err error) {
 	return core.Errorf("Not implemented")
 }
 
-// DeleteBgpNeighbors is not implemented.
-func (d *FakeNetEpDriver) DeleteBgpNeighbors(id string) (err error) {
+// DeleteBgp is not implemented.
+func (d *FakeNetEpDriver) DeleteBgp(id string) (err error) {
 	return core.Errorf("Not implemented")
 }

--- a/drivers/ovsSwitch.go
+++ b/drivers/ovsSwitch.go
@@ -74,7 +74,7 @@ func NewOvsSwitch(bridgeName, netType, localIP string, fwdMode string,
 		case "routing":
 			datapath = "vrouter"
 		default:
-			fmt.Errorf("Invalid datapath mode")
+			log.Errorf("Invalid datapath mode")
 			return nil, errors.New("Invalid forwarding mode. Expects 'bridge' or 'routing'")
 		}
 	} else if netType == "vlan" {
@@ -86,13 +86,13 @@ func NewOvsSwitch(bridgeName, netType, localIP string, fwdMode string,
 		case "routing":
 			datapath = "vlrouter"
 		default:
-			fmt.Errorf("Invalid datapath mode")
+			log.Errorf("Invalid datapath mode")
 			return nil, errors.New("Invalid forwarding mode. Expects 'bridge' or 'routing'")
 		}
 	}
 
 	// Create an ofnet agent
-	sw.ofnetAgent, err = ofnet.NewOfnetAgent(datapath, net.ParseIP(localIP),
+	sw.ofnetAgent, err = ofnet.NewOfnetAgent(bridgeName, datapath, net.ParseIP(localIP),
 		ofnetPort, ctrlrPort, routerInfo...)
 
 	if err != nil {
@@ -569,11 +569,11 @@ func (sw *OvsSwitch) DeleteMaster(node core.ServiceInfo) error {
 	return nil
 }
 
-// AddBgpadds a bgp config to host
-func (sw *OvsSwitch) AddBgp(hostname string, routerIp string,
+// AddBgp adds a bgp config to host
+func (sw *OvsSwitch) AddBgp(hostname string, routerIP string,
 	As string, neighborAs, neighbor string) error {
 	if sw.netType == "vlan" && sw.ofnetAgent != nil {
-		err := sw.ofnetAgent.AddBgp(routerIp, As, neighborAs, neighbor)
+		err := sw.ofnetAgent.AddBgp(routerIP, As, neighborAs, neighbor)
 		if err != nil {
 			log.Errorf("Error adding BGP server")
 			return err

--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -145,7 +145,7 @@ func (d *OvsDriver) Init(config *core.Config, info *core.InstanceInfo) error {
 	}
 	// Create Vlan switch
 	d.switchDb["vlan"], err = NewOvsSwitch(vlanBridgeName, "vlan", info.VtepIP,
-		info.FwdMode, info.RouterIP, info.VlanIntf)
+		info.FwdMode, info.VlanIntf)
 	if err != nil {
 		log.Fatalf("Error creating vlan switch. Err: %v", err)
 	}
@@ -433,7 +433,7 @@ func (d *OvsDriver) DeleteMaster(node core.ServiceInfo) error {
 }
 
 // AddBgpNeighbors adds bgp neighbor by named identifier
-func (d *OvsDriver) AddBgpNeighbors(id string) error {
+func (d *OvsDriver) AddBgp(id string) error {
 	var sw *OvsSwitch
 
 	cfg := mastercfg.CfgBgpState{}
@@ -449,17 +449,17 @@ func (d *OvsDriver) AddBgpNeighbors(id string) error {
 	// Find the switch based on network type
 	sw = d.switchDb["vlan"]
 
-	return sw.AddBgpNeighbors(cfg.Hostname, cfg.As, cfg.Neighbor)
+	return sw.AddBgp(cfg.Hostname, cfg.RouterIP, cfg.As, cfg.NeighborAs, cfg.Neighbor)
 }
 
 // DeleteBgpNeighbors deletes a bgp neighbor by named identifier
-func (d *OvsDriver) DeleteBgpNeighbors(id string) error {
+func (d *OvsDriver) DeleteBgp(id string) error {
 	log.Infof("delete Bgp Neighbor %s \n", id)
 	//FixME: We are not maintaining oper state for Bgp
 	//Need to Revisit again
 	// Find the switch based on network type
 	var sw *OvsSwitch
 	sw = d.switchDb["vlan"]
-	return sw.DeleteBgpNeighbors()
+	return sw.DeleteBgp()
 
 }

--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -432,7 +432,7 @@ func (d *OvsDriver) DeleteMaster(node core.ServiceInfo) error {
 	return nil
 }
 
-// AddBgpNeighbors adds bgp neighbor by named identifier
+// AddBgp adds bgp config by named identifier
 func (d *OvsDriver) AddBgp(id string) error {
 	var sw *OvsSwitch
 
@@ -452,7 +452,7 @@ func (d *OvsDriver) AddBgp(id string) error {
 	return sw.AddBgp(cfg.Hostname, cfg.RouterIP, cfg.As, cfg.NeighborAs, cfg.Neighbor)
 }
 
-// DeleteBgpNeighbors deletes a bgp neighbor by named identifier
+// DeleteBgp deletes bgp config by named identifier
 func (d *OvsDriver) DeleteBgp(id string) error {
 	log.Infof("delete Bgp Neighbor %s \n", id)
 	//FixME: We are not maintaining oper state for Bgp

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -292,21 +292,25 @@ var Commands = []cli.Command{
 		Usage: "router capability configuration",
 		Subcommands: []cli.Command{
 			{
-				Name:      "delete",
-				Usage:     "Delete Bgp Config",
-				ArgsUsage: "",
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "hostname",
-						Usage: "host name",
-					},
-				},
-				Action: deleteBgp,
+				Name:      "ls",
+				Aliases:   []string{"list"},
+				Usage:     "List BGP configuration",
+				ArgsUsage: "[hostname]",
+				Flags:     []cli.Flag{jsonFlag, quietFlag},
+				Action:    listBgp,
 			},
 			{
-				Name:      "add",
-				Usage:     "Add router capability configuration.",
-				ArgsUsage: " ",
+				Name:      "rm",
+				Aliases:   []string{"delete"},
+				Usage:     "Delete BGP configuration",
+				ArgsUsage: "[hostname]",
+				Flags:     []cli.Flag{},
+				Action:    deleteBgp,
+			},
+			{
+				Name:      "create",
+				Usage:     "Add BGP configuration.",
+				ArgsUsage: "[hostname]",
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "hostname",
@@ -314,19 +318,19 @@ var Commands = []cli.Command{
 					},
 					cli.StringFlag{
 						Name:  "router-ip",
-						Usage: "Bgp my router ip ",
+						Usage: "BGP my-router ip ",
 					},
 					cli.StringFlag{
 						Name:  "as",
-						Usage: "self AS id",
+						Usage: "Self AS id",
 					},
 					cli.StringFlag{
 						Name:  "neighbor-as",
-						Usage: "bgp neighbor AS id",
+						Usage: "BGP neighbor AS id",
 					},
 					cli.StringFlag{
 						Name:  "neighbor",
-						Usage: "Bgp neighbor to be added",
+						Usage: "BGP neighbor to be added",
 					},
 				},
 				Action: addBgp,

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -293,16 +293,12 @@ var Commands = []cli.Command{
 		Subcommands: []cli.Command{
 			{
 				Name:      "delete",
-				Usage:     "Delete Bgp neighbor",
-				ArgsUsage: "[router]",
+				Usage:     "Delete Bgp Config",
+				ArgsUsage: "",
 				Flags: []cli.Flag{
 					cli.StringFlag{
-						Name:  "host",
+						Name:  "hostname",
 						Usage: "host name",
-					},
-					cli.StringFlag{
-						Name:  "neighbors",
-						Usage: "Bgp neighbor to be deleted",
 					},
 				},
 				Action: deleteBgpNeighbors,
@@ -313,12 +309,20 @@ var Commands = []cli.Command{
 				ArgsUsage: " ",
 				Flags: []cli.Flag{
 					cli.StringFlag{
-						Name:  "host",
+						Name:  "hostname",
 						Usage: "host name",
 					},
 					cli.StringFlag{
+						Name:  "router-ip",
+						Usage: "Bgp my router ip ",
+					},
+					cli.StringFlag{
 						Name:  "as",
-						Usage: "AS id",
+						Usage: "self AS id",
+					},
+					cli.StringFlag{
+						Name:  "neighbor-as",
+						Usage: "bgp neighbor AS id",
 					},
 					cli.StringFlag{
 						Name:  "neighbor",

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -301,7 +301,7 @@ var Commands = []cli.Command{
 						Usage: "host name",
 					},
 				},
-				Action: deleteBgpNeighbors,
+				Action: deleteBgp,
 			},
 			{
 				Name:      "add",
@@ -329,7 +329,7 @@ var Commands = []cli.Command{
 						Usage: "Bgp neighbor to be added",
 					},
 				},
-				Action: addBgpNeighbors,
+				Action: addBgp,
 			},
 		},
 	},

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -521,10 +521,11 @@ func listBgpNeighbors(ctx *cli.Context) {
 		writer.Write([]byte("HostName\tNeighbor\tAS\n"))
 		writer.Write([]byte("---------\t--------\t-------\n"))
 		for _, group := range filtered {
-			fmt.Println(group)
 			writer.Write(
-				[]byte(fmt.Sprintf("%v\t%v\t%v\t\n",
-					group["host"],
+				[]byte(fmt.Sprintf("%v\t%v\t%v\t%v\t%v\n",
+					group["hostname"],
+					group["routerip"],
+					group["as"],
 					group["neighbor"],
 					group["neighbor-as"],
 				)))

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -465,15 +465,22 @@ func listEndpointGroups(ctx *cli.Context) {
 func addBgpNeighbors(ctx *cli.Context) {
 	argCheck(0, ctx)
 
-	hostname := ctx.String("host")
+	hostname := ctx.String("hostname")
+	routerip := ctx.String("router-ip")
 	asid := ctx.String("as")
+	neighboras := ctx.String("neighbor-as")
 	neighbor := ctx.String("neighbor")
 
-	errCheck(ctx, getClient(ctx).BgpPost(&contivClient.Bgp{
-		Hostname: hostname,
-		AS:       asid,
-		Neighbor: neighbor,
-	}))
+	url := fmt.Sprintf("%s%s/", bgpURL(ctx), hostname)
+
+	out := map[string]interface{}{
+		"Hostname":    hostname,
+		"routerip":    routerip,
+		"as":          asid,
+		"neighbor-as": neighboras,
+		"neighbor":    neighbor,
+	}
+	postMap(ctx, url, out)
 }
 
 //deleteBgpNeighbors is a netctl interface routine to delete
@@ -481,8 +488,8 @@ func addBgpNeighbors(ctx *cli.Context) {
 func deleteBgpNeighbors(ctx *cli.Context) {
 	argCheck(0, ctx)
 
-	hostname := ctx.String("host")
-	logrus.Infof("Deleting router config %s:%s", hostname)
+	hostname := ctx.String("hostname")
+	logrus.Infof("Deleting Bgp router config %s:%s", hostname)
 
 	errCheck(ctx, getClient(ctx).BgpDelete(hostname))
 }
@@ -492,7 +499,7 @@ func deleteBgpNeighbors(ctx *cli.Context) {
 func listBgpNeighbors(ctx *cli.Context) {
 	argCheck(0, ctx)
 
-	hostname := ctx.String("host")
+	hostname := ctx.String("hostname")
 
 	bgpList, err := getClient(ctx).BgpList()
 	errCheck(ctx, err)
@@ -517,9 +524,9 @@ func listBgpNeighbors(ctx *cli.Context) {
 			fmt.Println(group)
 			writer.Write(
 				[]byte(fmt.Sprintf("%v\t%v\t%v\t\n",
-					group.Hostname,
-					group.Neighbor,
-					group.AS,
+					group["host"],
+					group["neighbor"],
+					group["neighbor-as"],
 				)))
 		}
 	}

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -460,9 +460,9 @@ func listEndpointGroups(ctx *cli.Context) {
 	}
 }
 
-//addBgpNeighbors is a netctl interface routine to add
-//bgp neighbor
-func addBgpNeighbors(ctx *cli.Context) {
+//addBgp is a netctl interface routine to add
+//bgp config
+func addBgp(ctx *cli.Context) {
 	argCheck(0, ctx)
 
 	hostname := ctx.String("hostname")
@@ -483,9 +483,9 @@ func addBgpNeighbors(ctx *cli.Context) {
 	postMap(ctx, url, out)
 }
 
-//deleteBgpNeighbors is a netctl interface routine to delete
-//bgp neighbor
-func deleteBgpNeighbors(ctx *cli.Context) {
+//deleteBgp is a netctl interface routine to delete
+//bgp config
+func deleteBgp(ctx *cli.Context) {
 	argCheck(0, ctx)
 
 	hostname := ctx.String("hostname")

--- a/netmaster/intent/config.go
+++ b/netmaster/intent/config.go
@@ -59,9 +59,11 @@ type ConfigTenant struct {
 
 //ConfigBgp keeps bgp specific configs
 type ConfigBgp struct {
-	Hostname string
-	As       string
-	Neighbor string
+	Hostname   string
+	RouterIP   string
+	As         string
+	NeighborAs string
+	Neighbor   string
 }
 
 // Config is the top level configuration

--- a/netmaster/master/bgp.go
+++ b/netmaster/master/bgp.go
@@ -22,13 +22,15 @@ import (
 	"github.com/contiv/netplugin/netmaster/mastercfg"
 )
 
-//AddBgpNeighbors adds to the etcd state
-func AddBgpNeighbors(stateDriver core.StateDriver, bgpCfg *intent.ConfigBgp) error {
+//AddBgp adds to the etcd state
+func AddBgp(stateDriver core.StateDriver, bgpCfg *intent.ConfigBgp) error {
 
 	log.Infof("Adding bgp neighbor {%v}", bgpCfg)
 	bgpState := &mastercfg.CfgBgpState{}
 	bgpState.Hostname = bgpCfg.Hostname
+	bgpState.RouterIP = bgpCfg.RouterIP
 	bgpState.As = bgpCfg.As
+	bgpState.NeighborAs = bgpCfg.NeighborAs
 	bgpState.Neighbor = bgpCfg.Neighbor
 	bgpState.StateDriver = stateDriver
 	bgpState.ID = bgpCfg.Hostname
@@ -40,8 +42,8 @@ func AddBgpNeighbors(stateDriver core.StateDriver, bgpCfg *intent.ConfigBgp) err
 	return nil
 }
 
-//DeleteBgpNeighbors deletes from etcd state
-func DeleteBgpNeighbors(stateDriver core.StateDriver, hostname string) error {
+//DeleteBgp deletes from etcd state
+func DeleteBgp(stateDriver core.StateDriver, hostname string) error {
 	log.Infof("Deleting bgp neighbor for {%v}", hostname)
 	bgpState := &mastercfg.CfgBgpState{}
 	bgpState.StateDriver = stateDriver

--- a/netmaster/mastercfg/bgpState.go
+++ b/netmaster/mastercfg/bgpState.go
@@ -29,9 +29,11 @@ const (
 // CfgBgpState is the router Bgp configuration for the host
 type CfgBgpState struct {
 	core.CommonState
-	Hostname string `json:"hostname"`
-	As       string `json:"as"`
-	Neighbor string `json:"neighbor"`
+	Hostname   string `json:"hostname"`
+	RouterIP   string `json:"router-ip"`
+	As         string `json:"as"`
+	NeighborAs string `json:"neighbor-as"`
+	Neighbor   string `json:"neighbor"`
 }
 
 // Write the state

--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -832,10 +832,10 @@ func (ac *APIController) TenantDelete(tenant *contivModel.Tenant) error {
 }
 
 //BgpCreate add bgp neighbor
-func (ac *APIController) BgpCreate(bgpNeighborCfg *contivModel.Bgp) error {
-	log.Infof("Received BgpCreate: %+v", bgpNeighborCfg)
+func (ac *APIController) BgpCreate(bgpCfg *contivModel.Bgp) error {
+	log.Infof("Received BgpCreate: %+v", bgpCfg)
 
-	if bgpNeighborCfg.Hostname == "" {
+	if bgpCfg.Hostname == "" {
 		return core.Errorf("Invalid host name")
 	}
 
@@ -846,32 +846,34 @@ func (ac *APIController) BgpCreate(bgpNeighborCfg *contivModel.Bgp) error {
 	}
 
 	// Build bgp config
-	bgpCfg := intent.ConfigBgp{
-		Hostname: bgpNeighborCfg.Hostname,
-		As:       bgpNeighborCfg.AS,
-		Neighbor: bgpNeighborCfg.Neighbor,
+	bgpIntentCfg := intent.ConfigBgp{
+		Hostname:   bgpCfg.Hostname,
+		RouterIP:   bgpCfg.Routerip,
+		As:         bgpCfg.As,
+		NeighborAs: bgpCfg.NeighborAs,
+		Neighbor:   bgpCfg.Neighbor,
 	}
 
 	// Add the Bgp neighbor
-	err = master.AddBgpNeighbors(stateDriver, &bgpCfg)
+	err = master.AddBgp(stateDriver, &bgpIntentCfg)
 	if err != nil {
-		log.Errorf("Error creating Bgp neighbor {%+v}. Err: %v", bgpNeighborCfg.Neighbor, err)
+		log.Errorf("Error creating Bgp neighbor {%+v}. Err: %v", bgpCfg.Neighbor, err)
 		return err
 	}
 	return nil
 }
 
 //BgpDelete deletes bgp neighbor
-func (ac *APIController) BgpDelete(bgpNeighborCfg *contivModel.Bgp) error {
+func (ac *APIController) BgpDelete(bgpCfg *contivModel.Bgp) error {
 
-	log.Infof("Received delete for Bgp config on {%+v} ", bgpNeighborCfg.Hostname)
+	log.Infof("Received delete for Bgp config on {%+v} ", bgpCfg.Hostname)
 	// Get the state driver
 	stateDriver, err := utils.GetStateDriver()
 	if err != nil {
 		return err
 	}
 
-	err = master.DeleteBgpNeighbors(stateDriver, bgpNeighborCfg.Hostname)
+	err = master.DeleteBgp(stateDriver, bgpCfg.Hostname)
 	if err != nil {
 		log.Errorf("Error Deleting Bgp neighbor. Err: %v", err)
 		return err
@@ -880,6 +882,6 @@ func (ac *APIController) BgpDelete(bgpNeighborCfg *contivModel.Bgp) error {
 }
 
 //BgpUpdate updates bgp config
-func (ac *APIController) BgpUpdate(oldbgpNeighborCfg *contivModel.Bgp, NewbgpNeighborCfg *contivModel.Bgp) error {
+func (ac *APIController) BgpUpdate(oldbgpCfg *contivModel.Bgp, NewbgpCfg *contivModel.Bgp) error {
 	return nil
 }

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -480,7 +480,7 @@ func processBgpEvent(netPlugin *plugin.NetPlugin, opts cliOpts, hostID string,
 	isDelete bool) (err error) {
 
 	if opts.hostLabel != hostID {
-		log.Errorf("Skipping deleting neighbor on this host")
+		log.Errorf("Ignoring Bgp Event on this host")
 		return
 	}
 	netPlugin.Lock()

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -488,10 +488,10 @@ func processBgpEvent(netPlugin *plugin.NetPlugin, opts cliOpts, hostID string,
 
 	operStr := ""
 	if isDelete {
-		err = netPlugin.DeleteBgpNeighbors(hostID)
+		err = netPlugin.DeleteBgp(hostID)
 		operStr = "delete"
 	} else {
-		err = netPlugin.AddBgpNeighbors(hostID)
+		err = netPlugin.AddBgp(hostID)
 		operStr = "create"
 	}
 	if err != nil {

--- a/netplugin/plugin/netplugin.go
+++ b/netplugin/plugin/netplugin.go
@@ -148,12 +148,12 @@ func (p *NetPlugin) DeleteMaster(node core.ServiceInfo) error {
 	return p.NetworkDriver.DeleteMaster(node)
 }
 
-//AddBgpNeighbors adds bgp neigbor
-func (p *NetPlugin) AddBgpNeighbors(id string) error {
-	return p.NetworkDriver.AddBgpNeighbors(id)
+//AddBgp adds bgp configs
+func (p *NetPlugin) AddBgp(id string) error {
+	return p.NetworkDriver.AddBgp(id)
 }
 
-//DeleteBgpNeighbors deletes bgp neigbor
-func (p *NetPlugin) DeleteBgpNeighbors(id string) error {
-	return p.NetworkDriver.DeleteBgpNeighbors(id)
+//DeleteBgp deletes bgp configs
+func (p *NetPlugin) DeleteBgp(id string) error {
+	return p.NetworkDriver.DeleteBgp(id)
 }


### PR DESCRIPTION
The changes contain:
1) Changes to netctl cli to take in router ip and as as additional parameters
2) This would mean there is only 1 bgp config cli to be used to configure L3 mode.
3) decoupled bgp server start from netplugin start and tied it to the cli.
4) This wil ensure bgp config can be changed dynamically even after containers come up . 

new cli  netctl bgp create <hostname> -router-ip=<> -as=<> -neighbor-ip=<> neighbor-as=<>
 
