### PR TITLE
Fix DNS attach error message

### DIFF
--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -301,7 +301,9 @@ func attachServiceContainer(tenantName, networkName string, stateDriver core.Sta
 	if err != nil {
 		log.Errorf("Could not attach container(%s) to network %s. Error: %s",
 			contName, dnetName, err)
-		return err
+		return fmt.Errorf("Could not attach container(%s) to network %s."+
+			"Please make sure %s container is up.",
+			contName, dnetName, contName)
 	}
 
 	// inspect the container


### PR DESCRIPTION
This fixes the error message thrown when attaching DNS to network fails and makes it more intuitive to users on what is failing.