### PR TITLE
Skydns refactor

### DIFF
--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -39,6 +39,7 @@ type cliOpts struct {
 	storeURL    string
 	listenURL   string
 	clusterMode string
+	dnsEnabled  bool
 	version     bool
 }
 
@@ -107,6 +108,10 @@ func parseOpts(opts *cliOpts) error {
 		"cluster-mode",
 		"docker",
 		"{docker, kubernetes}")
+	flagSet.BoolVar(&opts.dnsEnabled,
+		"dns-enable",
+		true,
+		"Turn on DNS {true, false}")
 	flagSet.BoolVar(&opts.version,
 		"version",
 		false,
@@ -140,6 +145,10 @@ func execOpts(opts *cliOpts) core.StateDriver {
 
 	if err := master.SetClusterMode(opts.clusterMode); err != nil {
 		log.Fatalf("Failed to set cluster-mode. Error: %s", err)
+	}
+
+	if err := master.SetDNSEnabled(opts.dnsEnabled); err != nil {
+		log.Fatalf("Failed to set dns-enable. Error: %s", err)
 	}
 
 	sd, err := initStateDriver(opts)

--- a/netmaster/master/netmaster.go
+++ b/netmaster/master/netmaster.go
@@ -264,6 +264,7 @@ func startServiceContainer(tenantName string) error {
 	containerID, err := docker.CreateContainer(containerConfig, getDNSName(tenantName), nil)
 	if err != nil {
 		log.Errorf("Error creating DNS container for tenant: %s. Error: %s", tenantName, err)
+		return err
 	}
 
 	hostConfig := &dockerclient.HostConfig{

--- a/netmaster/master/netmaster.go
+++ b/netmaster/master/netmaster.go
@@ -54,7 +54,6 @@ func SetClusterMode(cm string) error {
 	}
 
 	masterRTCfg.clusterMode = cm
-	SetDNSEnabled(false)
 	return nil
 }
 
@@ -305,17 +304,15 @@ func stopAndRemoveServiceContainer(tenantName string) error {
 
 // DeleteTenantID deletes a tenant from the state store, by ID.
 func DeleteTenantID(stateDriver core.StateDriver, tenantID string) error {
-	var err error
-
 	if IsDNSEnabled() {
-		err = stopAndRemoveServiceContainer(tenantID)
+		err := stopAndRemoveServiceContainer(tenantID)
 		if err != nil {
 			log.Errorf("Error in stopping service container for tenant: %+v", tenantID)
 			return err
 		}
 	}
 
-	return err
+	return nil
 }
 
 // DeleteTenant deletes a tenant from the state store based on its ConfigTenant.

--- a/netmaster/master/netmaster.go
+++ b/netmaster/master/netmaster.go
@@ -248,8 +248,11 @@ func startServiceContainer(tenantName string) error {
 		log.Errorf("Error creating DNS container for tenant: %s. Error: %s", tenantName, err)
 	}
 
+	hostConfig := &dockerclient.HostConfig{
+		RestartPolicy: dockerclient.RestartPolicy{Name: "always"}}
+
 	// Start the container
-	err = docker.StartContainer(containerID, nil)
+	err = docker.StartContainer(containerID, hostConfig)
 	if err != nil {
 		log.Errorf("Error starting DNS container for tenant: %s. Error: %s", tenantName, err)
 	}


### PR DESCRIPTION
- Including an option in netmaster to deploy DNS container (default is enabled)
- Added additional checks during tenant create and network create to deal with failure cases
- To ensure HA for DNS containers, introduced a restart policy so that it is always restarted 

**Explanation of changes with output**
- When started with -dns-enable=false, creation of tenant does not start skydns container
```
vagrant@netplugin-node1:~$ netctl tenant list
Name
------
tenant1
default

vagrant@netplugin-node1:~$ docker ps
CONTAINER ID        IMAGE                          COMMAND             CREATED             STATUS              PORTS               NAMES
```
- Starting netmaster without any options, starts off skydns containers per tenant by default
```
vagrant@netplugin-node1:~$ netctl tenant list
Name
------
tenant1
default

vagrant@netplugin-node1:~$ docker ps
CONTAINER ID        IMAGE                          COMMAND             CREATED             STATUS              PORTS               NAMES
ff729f5a4130        skynetservices/skydns:latest   "/skydns"           9 minutes ago       Up 9 minutes        53/tcp, 53/udp      defaultdns
2afb234c7f92        skynetservices/skydns:latest   "/skydns"           8 minutes ago       Up 8 minutes        53/tcp, 53/udp      tenant1dns
```
- During network attach:
   - If the tenant-dns is missing
     - DNS container is started off and the attach is tried again 
       - If this fails, the network creation continues after a warning is issued
   - If the tenant-dns is in stopped state
     - A restart of the dns container is attempted
       - If this fails, network creation continues after a warning is issued
   
- When starting a skydns container:
   - If the skydns image is missing on the node 
     - A pull of skydns image is attempted
       - If the skydns pull fails, a warning is issued and tenant creation proceeds
     
- To ensure that the HA of DNS provider, the skydns container is started off with "always" restart-policy. With this policy, docker tries to bring back the skydns container whenever it fails/docker restarts.
