### PR TITLE
fix for netplugin panic while vtep deletion. fixes #274

### DIFF
--- a/drivers/ovsdbDriver.go
+++ b/drivers/ovsdbDriver.go
@@ -574,7 +574,7 @@ func (d *OvsdbDriver) GetOfpPortNo(intfName string) (uint32, error) {
 	for {
 		row, err := d.ovs.Transact(ovsDataBase, selectOp)
 
-		if err == nil {
+		if err == nil && len(row) > 0 && len(row[0].Rows) > 0 {
 			value := row[0].Rows[0]["ofport"]
 			if reflect.TypeOf(value).Kind() == reflect.Float64 {
 				//retry few more time. Due to asynchronous call between

--- a/netplugin/cluster/cluster.go
+++ b/netplugin/cluster/cluster.go
@@ -185,14 +185,6 @@ func peerDiscoveryLoop(netplugin *plugin.NetPlugin, objdbClient objdb.API, local
 				if err != nil {
 					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)
 				}
-				// add the node
-				err = netplugin.AddPeerHost(core.ServiceInfo{
-					HostAddr: nodeInfo.HostAddr,
-					Port:     ofnet.OFNET_AGENT_VLAN_PORT,
-				})
-				if err != nil {
-					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)
-				}
 
 			} else if srvEvent.EventType == objdb.WatchServiceEventDel {
 				log.Infof("Node delete event for {%+v}", nodeInfo)
@@ -201,14 +193,6 @@ func peerDiscoveryLoop(netplugin *plugin.NetPlugin, objdbClient objdb.API, local
 				err := netplugin.DeletePeerHost(core.ServiceInfo{
 					HostAddr: nodeInfo.HostAddr,
 					Port:     ofnet.OFNET_AGENT_VXLAN_PORT,
-				})
-				if err != nil {
-					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)
-				}
-				// remove the node
-				err = netplugin.DeletePeerHost(core.ServiceInfo{
-					HostAddr: nodeInfo.HostAddr,
-					Port:     ofnet.OFNET_AGENT_VLAN_PORT,
 				})
 				if err != nil {
 					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)


### PR DESCRIPTION
(1) removing the duplicate add/delete Peer Host calls. 
We were doing a AddPeerHost twice, once for OFNET_AGENT_VLAN_PORT and then for OFNET_AGENT_VXLAN_PORT. Similarly, the DeletePeerHost was also getting done twice.
But the AddPeerHost/DeletePeerHost methods, do not use the port at all. They use only the IP, this was causing a double deletion and hence the panic.

(2) added guarding checks for array length.