### PR TITLE
return error while deleting network with active EPs. fixes#270

### DIFF
--- a/netmaster/docknet/docknet.go
+++ b/netmaster/docknet/docknet.go
@@ -201,8 +201,7 @@ func DeleteDockNet(tenantName, networkName, serviceName string) error {
 	err = docker.RemoveNetwork(docknetName)
 	if err != nil {
 		log.Errorf("Error deleting network %s. Err: %v", docknetName, err)
-		// FIXME: Ignore errors till we fully move to docker 1.9
-		return nil
+		return err
 	}
 
 	// Get the state driver

--- a/netmaster/master/endpoint.go
+++ b/netmaster/master/endpoint.go
@@ -142,8 +142,6 @@ func CreateEndpoints(stateDriver core.StateDriver, tenant *intent.ConfigTenant) 
 				log.Errorf("Error creating endpoint %+v. Err: %v", ep, err)
 				return err
 			}
-
-			nwCfg.EpCount++
 		}
 
 		err = nwCfg.Write()

--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -486,6 +486,7 @@ func (ac *APIController) NetworkDelete(network *contivModel.Network) error {
 	err = master.DeleteNetworkID(stateDriver, networkID)
 	if err != nil {
 		log.Errorf("Error deleting network %s. Err: %v", network.NetworkName, err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
The error returned by DeleteDockNet needs to be passed back to make sure the overall operation fail.