### PR TITLE
use netmaster service name as default for netctl

### DIFF
--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -16,7 +16,7 @@ import (
 )
 
 // DefaultMaster is the master to use when none is provided.
-const DefaultMaster = "http://localhost:9999"
+const DefaultMaster = "http://netmaster:9999"
 
 func getClient(ctx *cli.Context) *contivClient.ContivClient {
 	cl, err := contivClient.NewContivClient(ctx.GlobalString("netmaster"))

--- a/netmaster/master/consts.go
+++ b/netmaster/master/consts.go
@@ -16,9 +16,6 @@ limitations under the License.
 package master
 
 const (
-	// DaemonURL is default url used by netmaster to listen for http requests
-	DaemonURL = "localhost:9999"
-
 	//DesiredConfigRESTEndpoint is the REST endpoint to post desired configuration
 	DesiredConfigRESTEndpoint = "desired-config"
 	//AddConfigRESTEndpoint is the REST endpoint to post configuration additions


### PR DESCRIPTION
this allows netctl commands to run from any where in cluster setup by contiv ansible.

Also removed one unused variable

/cc @shaleman 