### PR TITLE
Makefile: speed up godep install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ checks:
 run-build: deps checks clean
 	cd ${GOPATH}/src/github.com/contiv/netplugin && version/generate_version ${USE_RELEASE} && \
 	cd $(GOPATH)/src/github.com/contiv/netplugin && \
-	godep go install -v $(TO_BUILD) && \
+	GOGC=1500 godep go install -v $(TO_BUILD) && \
 	sudo cp scripts/contrib/completion/bash/netctl /etc/bash_completion.d/netctl
 
 build:


### PR DESCRIPTION
This PR speeds up `make host-build`.