### PR TITLE
Add aci-opflex option to netctl CLI

### DIFF
--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -269,7 +269,7 @@ var Commands = []cli.Command{
 				Flags: []cli.Flag{
 					cli.StringFlag{
 						Name:  "fabric-mode, f",
-						Usage: "Fabric mode (aci or default)",
+						Usage: "Fabric mode (aci, aci-opflex or default)",
 						Value: "default",
 					},
 					cli.StringFlag{

--- a/netmaster/master/netmaster.go
+++ b/netmaster/master/netmaster.go
@@ -111,7 +111,10 @@ func validateTenantConfig(tenant *intent.ConfigTenant) error {
 // CreateGlobal sets the global state
 func CreateGlobal(stateDriver core.StateDriver, gc *intent.ConfigGlobal) error {
 	// check for valid values
-	if gc.NwInfraType != "default" && gc.NwInfraType != "aci" {
+	switch gc.NwInfraType {
+	case "default", "aci", "aci-opflex":
+		// These values are acceptable.
+	default:
 		return errors.New("Invalid fabric mode")
 	}
 	_, err := netutils.ParseTagRanges(gc.VLANs, "vlan")


### PR DESCRIPTION
Add aci-opflex fabric mode option to the netctl CLI. This will be used when opflex is used for ACI communication in the ACI fabric mode.