### PR TITLE
correct return error for docker-1.11 compatibility

### DIFF
--- a/mgmtfn/dockplugin/dockplugin.go
+++ b/mgmtfn/dockplugin/dockplugin.go
@@ -149,7 +149,7 @@ func unknownAction(w http.ResponseWriter, r *http.Request) {
 	log.Infof("Unknown networkdriver action at %q", r.URL.Path)
 	content, _ := ioutil.ReadAll(r.Body)
 	log.Infof("Body content: %s", string(content))
-	w.WriteHeader(503)
+	http.NotFound(w, r)
 }
 
 // deactivate the plugin


### PR DESCRIPTION
Seeing following error when running docker container in Docker version 1.11-rc3, with netplugin as remote driver:

root@ip-10-10-128-130:~# docker run -itd --net=busybox:latest.test busybox
25b95b93da52aa2ef32630a0c4e9a5473561d3b0ce3ca520830b45d34469b10c
docker: Error response from daemon: driver failed programming external connectivity on endpoint amazing_lumiere 

Fix includes correct response error from netplugin.