### PR TITLE
Makefile,Vagrantfile: make centos the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@ TAR_FILENAME := $(NAME)-$(VERSION).$(TAR_EXT)
 TAR_LOC := .
 TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 
-all: build unit-test system-test centos-tests
+all: build unit-test system-test ubuntu-tests
 
 # 'all-CI' target is used by the scripts/CI.sh that passes appropriate set of
 # ENV variables (from the jenkins job) to run OS (centos, ubuntu etc) and
 # sandbox specific(vagrant, docker-in-docker)
 all-CI: build unit-test system-test
 
-test: build unit-test system-test centos-tests
+test: build unit-test system-test ubuntu-tests
 
 default: build
 
@@ -80,8 +80,8 @@ mesos-docker-destroy:
 	cd vagrant/mesos-docker && vagrant destroy -f
 
 
-demo-centos:
-	CONTIV_NODE_OS=centos make demo
+demo-ubuntu:
+	CONTIV_NODE_OS=ubuntu make demo
 
 stop:
 	CONTIV_NODES=$${CONTIV_NODES:-2} vagrant destroy -f
@@ -97,8 +97,8 @@ ssh:
 unit-test: stop clean build
 	./scripts/unittests -vagrant
 
-centos-tests:
-	CONTIV_NODE_OS=centos make clean build unit-test system-test stop
+ubuntu-tests:
+	CONTIV_NODE_OS=ubuntu make clean build unit-test system-test stop
 
 system-test:start
 	godep go test -v -timeout 240m ./systemtests -check.v 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,10 +69,10 @@ SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "centos" then
-        config.vm.box = "contiv/centos71-netplugin"
-    else
+    if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "ubuntu" then
         config.vm.box = "contiv/ubuntu1504-netplugin"
+    else
+        config.vm.box = "contiv/centos71-netplugin"
     end
     config.vm.provider 'virtualbox' do |v|
         v.linked_clone = true if Vagrant::VERSION =~ /^1.8/


### PR DESCRIPTION
This PR makes centos the default when no OS is specified. This is the first step towards improving development and testing parity.