### PR TITLE
Fixing Proxy ARP for ACI-gw

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -70,23 +70,23 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "6383dd4bb5acc4140bf6fea1eefafeefe3fde64e"
+			"Rev": "5ec464bca5a171d1a8fbee1b147bd468c07649cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ofctrl",
-			"Rev": "6383dd4bb5acc4140bf6fea1eefafeefe3fde64e"
+			"Rev": "5ec464bca5a171d1a8fbee1b147bd468c07649cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ovsdbDriver",
-			"Rev": "6383dd4bb5acc4140bf6fea1eefafeefe3fde64e"
+			"Rev": "5ec464bca5a171d1a8fbee1b147bd468c07649cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/pqueue",
-			"Rev": "6383dd4bb5acc4140bf6fea1eefafeefe3fde64e"
+			"Rev": "5ec464bca5a171d1a8fbee1b147bd468c07649cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/rpcHub",
-			"Rev": "6383dd4bb5acc4140bf6fea1eefafeefe3fde64e"
+			"Rev": "5ec464bca5a171d1a8fbee1b147bd468c07649cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/systemtests-utils",

--- a/Godeps/_workspace/src/github.com/contiv/ofnet/ofnet.go
+++ b/Godeps/_workspace/src/github.com/contiv/ofnet/ofnet.go
@@ -118,18 +118,19 @@ type OfnetNode struct {
 
 // OfnetEndpoint has info about an endpoint
 type OfnetEndpoint struct {
-	EndpointID    string    // Unique identifier for the endpoint
-	EndpointType  string    // Type of the endpoint "internal", "external" or "externalRoute"
-	EndpointGroup int       // Endpoint group identifier for policies.
-	IpAddr        net.IP    // IP address of the end point
-	IpMask        net.IP    // IP mask for the end point
-	Vrf           string    // IP address namespace
-	MacAddrStr    string    // Mac address of the end point(in string format)
-	Vlan          uint16    // Vlan Id for the endpoint
-	Vni           uint32    // Vxlan VNI
-	OriginatorIp  net.IP    // Originating switch
-	PortNo        uint32    // Port number on originating switch
-	Timestamp     time.Time // Timestamp of the last event
+	EndpointID        string    // Unique identifier for the endpoint
+	EndpointType      string    // Type of the endpoint "internal", "external" or "externalRoute"
+	EndpointGroup     int       // Endpoint group identifier for policies.
+	IpAddr            net.IP    // IP address of the end point
+	IpMask            net.IP    // IP mask for the end point
+	Vrf               string    // IP address namespace
+	MacAddrStr        string    // Mac address of the end point(in string format)
+	Vlan              uint16    // Vlan Id for the endpoint
+	Vni               uint32    // Vxlan VNI
+	OriginatorIp      net.IP    // Originating switch
+	PortNo            uint32    // Port number on originating switch
+	Timestamp         time.Time // Timestamp of the last event
+	EndpointGroupVlan uint16    // EnpointGroup Vlan, needed in non-Standalone mode of netplugin
 }
 
 // OfnetPolicyRule has security rule to be installed

--- a/Godeps/_workspace/src/github.com/contiv/ofnet/ofnetAgent.go
+++ b/Godeps/_workspace/src/github.com/contiv/ofnet/ofnetAgent.go
@@ -81,12 +81,13 @@ type OfnetAgent struct {
 
 // local End point information
 type EndpointInfo struct {
-	PortNo        uint32
-	EndpointGroup int
-	MacAddr       net.HardwareAddr
-	Vlan          uint16
-	IpAddr        net.IP
-	Vrf           string
+	PortNo            uint32
+	EndpointGroup     int
+	MacAddr           net.HardwareAddr
+	Vlan              uint16
+	IpAddr            net.IP
+	Vrf               string
+	EndpointGroupVlan uint16
 }
 
 const FLOW_MATCH_PRIORITY = 100        // Priority for all match flows
@@ -384,18 +385,19 @@ func (self *OfnetAgent) AddLocalEndpoint(endpoint EndpointInfo) error {
 	}
 	// Build endpoint registry info
 	epreg := &OfnetEndpoint{
-		EndpointID:    epId,
-		EndpointType:  "internal",
-		EndpointGroup: endpoint.EndpointGroup,
-		IpAddr:        endpoint.IpAddr,
-		IpMask:        net.ParseIP("255.255.255.255"),
-		Vrf:           *vrf,
-		MacAddrStr:    endpoint.MacAddr.String(),
-		Vlan:          endpoint.Vlan,
-		Vni:           *vni,
-		OriginatorIp:  self.localIp,
-		PortNo:        endpoint.PortNo,
-		Timestamp:     time.Now(),
+		EndpointID:        epId,
+		EndpointType:      "internal",
+		EndpointGroup:     endpoint.EndpointGroup,
+		IpAddr:            endpoint.IpAddr,
+		IpMask:            net.ParseIP("255.255.255.255"),
+		Vrf:               *vrf,
+		MacAddrStr:        endpoint.MacAddr.String(),
+		Vlan:              endpoint.Vlan,
+		Vni:               *vni,
+		OriginatorIp:      self.localIp,
+		PortNo:            endpoint.PortNo,
+		Timestamp:         time.Now(),
+		EndpointGroupVlan: endpoint.EndpointGroupVlan,
 	}
 
 	// Call the datapath

--- a/Godeps/_workspace/src/github.com/contiv/ofnet/vlanBridge.go
+++ b/Godeps/_workspace/src/github.com/contiv/ofnet/vlanBridge.go
@@ -462,7 +462,7 @@ func (vl *VlanBridge) processArp(pkt protocol.Ethernet, inPort uint32) {
 				// ARP request from local container to unknown IP
 				// Reinject ARP to uplinks
 				ethPkt := protocol.NewEthernet()
-				ethPkt.VLANID.VID = srcEp.Vlan
+				ethPkt.VLANID.VID = srcEp.EndpointGroupVlan
 				ethPkt.HWDst = pkt.HWDst
 				ethPkt.HWSrc = pkt.HWSrc
 				ethPkt.Ethertype = 0x0806

--- a/drivers/ovsSwitch.go
+++ b/drivers/ovsSwitch.go
@@ -306,11 +306,12 @@ func (sw *OvsSwitch) CreatePort(intfName string, cfgEp *mastercfg.CfgEndpointSta
 
 	// Build the endpoint info
 	endpoint := ofnet.EndpointInfo{
-		PortNo:        ofpPort,
-		MacAddr:       macAddr,
-		Vlan:          uint16(nwPktTag),
-		IpAddr:        net.ParseIP(cfgEp.IPAddress),
-		EndpointGroup: cfgEp.EndpointGroupID,
+		PortNo:            ofpPort,
+		MacAddr:           macAddr,
+		Vlan:              uint16(nwPktTag),
+		IpAddr:            net.ParseIP(cfgEp.IPAddress),
+		EndpointGroup:     cfgEp.EndpointGroupID,
+		EndpointGroupVlan: uint16(pktTag),
 	}
 
 	log.Infof("Adding local endpoint: {%+v}", endpoint)


### PR DESCRIPTION
For a version : v0.1-04-11-2016.17-31-22.UTC , proxy ARP was broken for ACI-gw. We were not able to ping default gateway because of this. With this fix, issue has been resolved and we are now able to ping gateway.