### PR TITLE
vagrant fixes for k8s install

### DIFF
--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -18,7 +18,7 @@ def create_etc_hosts(cluster)
   
   cluster.each do |role, member_list|
     member_list.each do |member_info|
-      etc_file.write("#{member_info['control-ip']}   #{member_info['name']}\n")
+      etc_file.write("#{member_info['contiv_control_ip']}   #{member_info['name']}\n")
     end
   end
 
@@ -43,6 +43,7 @@ Vagrant.configure(2) do |config|
   config.vm.box_version = "0.0.6"
 
   config.ssh.password = 'vagrant'
+
   config.vm.synced_folder "./export", "/shared", disabled: false
   config.vm.synced_folder ".", "/vagrant", disabled: true
  
@@ -55,18 +56,19 @@ Vagrant.configure(2) do |config|
         # Customize VM for better performance
         config.vm.provider "virtualbox" do |v|
           customize_vm(v)
+        end # v
 
         # configure ip address etc
         c.vm.hostname = vm_name
-        c.vm.network :private_network, ip: member_info["control-ip"]
-        c.vm.network :private_network, ip: member_info["contiv-network-ip"]
+        c.vm.network :private_network, ip: member_info["contiv_control_ip"]
+        c.vm.network :private_network, ip: member_info["contiv_network_ip"]
+
         c.vm.provision "shell", inline: <<-EOS
           sudo setenforce 0
           sudo systemctl stop firewalld
           #copy the etc_hosts file we created
           sudo cp /shared/.etc_hosts /etc/hosts
           EOS
-        end # shell
       end # c
     end # member_info
   end #role

--- a/vagrant/k8s/cluster_defs.json
+++ b/vagrant/k8s/cluster_defs.json
@@ -1,5 +1,4 @@
 {"master": [{"name": "k8master", "management_ip": "192.168.2.10", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.10", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.10"}],
  "nodes" : [{"name": "k8node-01", "management_ip": "192.168.2.11", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.11", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.11", "max_pods": "40"},
-            {"name": "k8node-02", "management_ip": "192.168.2.12", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.12", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.12", "max_pods": "40"},
-            {"name": "k8node-03", "management_ip": "192.168.2.13", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.13", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.13", "max_pods": "40"}]
+            {"name": "k8node-02", "management_ip": "192.168.2.12", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.12", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.12", "max_pods": "40"}]
 }

--- a/vagrant/k8s/cluster_defs.json
+++ b/vagrant/k8s/cluster_defs.json
@@ -1,4 +1,5 @@
-{"master": [{"name": "k8master", "control-ip": "10.6.3.100", "contiv-network-ip": "11.7.4.100"}],
- "nodes" : [{"name": "k8node-01", "control-ip": "10.6.3.101", "contiv-network-ip": "11.7.4.101"},
-            {"name": "k8node-02", "control-ip": "10.6.3.102", "contiv-network-ip": "11.7.4.102"}]
+{"master": [{"name": "k8master", "management_ip": "192.168.2.10", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.10", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.10"}],
+ "nodes" : [{"name": "k8node-01", "management_ip": "192.168.2.11", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.11", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.11", "max_pods": "40"},
+            {"name": "k8node-02", "management_ip": "192.168.2.12", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.12", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.12", "max_pods": "40"},
+            {"name": "k8node-03", "management_ip": "192.168.2.13", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.13", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.13", "max_pods": "40"}]
 }

--- a/vagrant/k8s/copy_demo.sh
+++ b/vagrant/k8s/copy_demo.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # run ansible
-ansible-playbook -i .contiv_k8s_inventory ../../../contrib/ansible/cluster.yml --tags "contiv_demo" -e "networking=contiv"
+ansible-playbook -i .contiv_k8s_inventory ../../../contrib/ansible/cluster.yml --tags "contiv_demo" -e "networking=contiv contiv_fabric_mode=default"

--- a/vagrant/k8s/restart_cluster.sh
+++ b/vagrant/k8s/restart_cluster.sh
@@ -2,4 +2,4 @@
 
 top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
 # run ansible
-ansible-playbook -i .contiv_k8s_inventory ../../../contrib/ansible/cluster.yml --tags "contiv_restart" -e "networking=contiv contiv_bin_path=$top_dir/contiv_bin"
+ansible-playbook -i .contiv_k8s_inventory ../../../contrib/ansible/cluster.yml --tags "contiv_restart" -e "networking=contiv contiv_fabric_mode=default contiv_bin_path=$top_dir/contiv_bin"

--- a/vagrant/k8s/setup_cluster.sh
+++ b/vagrant/k8s/setup_cluster.sh
@@ -76,4 +76,4 @@ vagrant up
 ./vagrant_cluster.py
 
 # run ansible
-ansible-playbook -i .contiv_k8s_inventory ../../../contrib/ansible/cluster.yml --skip-tags "contiv_restart,ovs_install" -e "networking=contiv localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin contiv_bin_path=$top_dir/contiv_bin"
+ansible-playbook -i .contiv_k8s_inventory ../../../contrib/ansible/cluster.yml --skip-tags "contiv_restart,ovs_install,addons" -e "networking=contiv contiv_fabric_mode=default localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin contiv_bin_path=$top_dir/contiv_bin"

--- a/vagrant/k8s/setup_cluster.sh
+++ b/vagrant/k8s/setup_cluster.sh
@@ -48,11 +48,11 @@ function GetContiv {
   fi
 }
 
-# kubernetes version to use -- defaults to v1.1.4
-: ${k8sVer:=v1.1.4}
+# kubernetes version to use -- defaults to v1.2.3
+: ${k8sVer:=v1.2.3}
 
 # contiv version
-: ${contivVer:=v0.1-01-28-2016.03-55-05.UTC}
+: ${contivVer:=v0.1-05-05-2016.18-38-56.UTC}
 
 top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
 

--- a/vagrant/k8s/vagrant_cluster.py
+++ b/vagrant/k8s/vagrant_cluster.py
@@ -56,7 +56,7 @@ def writeHostLine(outFd, hostInfo, hConfig, comVars):
     for attr in hostAttr:
         outFd.write(" {}={}".format(attr, info[attr]))
 
-    outFd.write(" contiv_control_ip={}".format(hConfig['control-ip']))
+    outFd.write(" contiv_control_ip={}".format(hConfig['contiv_control_ip']))
     outFd.write(" contiv_network_if=enp0s9") # might need to change if box changes
     outFd.write(comVars)
     outFd.write("\n")
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # Make sure all hosts are reported
     for mInfo in clusterConf['master']:
         validateHostInfo(hostInfo, mInfo['name'])
-        service_ip = mInfo['control-ip']
+        service_ip = mInfo['contiv_control_ip']
 
     for nInfo in clusterConf['nodes']:
         validateHostInfo(hostInfo, nInfo['name'])

--- a/vagrant/k8s/vagrant_cluster.py
+++ b/vagrant/k8s/vagrant_cluster.py
@@ -57,7 +57,7 @@ def writeHostLine(outFd, hostInfo, hConfig, comVars):
         outFd.write(" {}={}".format(attr, info[attr]))
 
     outFd.write(" contiv_control_ip={}".format(hConfig['contiv_control_ip']))
-    outFd.write(" contiv_network_if=enp0s9") # might need to change if box changes
+    outFd.write(" contiv_control_ip={}".format(hConfig['contiv_network_if']))
     outFd.write(comVars)
     outFd.write("\n")
 

--- a/vagrant/k8s/vagrant_cluster.py
+++ b/vagrant/k8s/vagrant_cluster.py
@@ -57,7 +57,7 @@ def writeHostLine(outFd, hostInfo, hConfig, comVars):
         outFd.write(" {}={}".format(attr, info[attr]))
 
     outFd.write(" contiv_control_ip={}".format(hConfig['contiv_control_ip']))
-    outFd.write(" contiv_control_ip={}".format(hConfig['contiv_network_if']))
+    outFd.write(" contiv_network_if={}".format(hConfig['contiv_network_if']))
     outFd.write(comVars)
     outFd.write("\n")
 


### PR DESCRIPTION
Added below changes:
a) Typo error in Vagrantfile to fix vagrant nodes startup
b) cluster_defs.json to use same format as in demo/k8s folder
c) Use latest version of kubernetes and contiv by default