### PR TITLE
svcplugin and other bugfixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/contiv/netplugin",
 	"GoVersion": "go1.5.1",
-	"GodepVersion": "v62",
+	"GodepVersion": "v68",
 	"Packages": [
 		"./..."
 	],
@@ -70,23 +70,23 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "bc37eaef88c241864b9782f356a43305535cf3c0"
+			"Rev": "43df083da25e1af2b67586376629908ac836ee63"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ofctrl",
-			"Rev": "bc37eaef88c241864b9782f356a43305535cf3c0"
+			"Rev": "43df083da25e1af2b67586376629908ac836ee63"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ovsdbDriver",
-			"Rev": "bc37eaef88c241864b9782f356a43305535cf3c0"
+			"Rev": "43df083da25e1af2b67586376629908ac836ee63"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/pqueue",
-			"Rev": "bc37eaef88c241864b9782f356a43305535cf3c0"
+			"Rev": "43df083da25e1af2b67586376629908ac836ee63"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/rpcHub",
-			"Rev": "bc37eaef88c241864b9782f356a43305535cf3c0"
+			"Rev": "43df083da25e1af2b67586376629908ac836ee63"
 		},
 		{
 			"ImportPath": "github.com/contiv/systemtests-utils",
@@ -337,6 +337,21 @@
 		{
 			"ImportPath": "gopkg.in/tomb.v2",
 			"Rev": "14b3d72120e8d10ea6e6b7f87f7175734b1faab8"
+		},
+		{
+			"ImportPath": "github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2",
+			"Comment": "v0.1-2-g58cf012",
+			"Rev": "58cf01279880d621a67c5f929af9ed59ab409373"
+		},
+		{
+			"ImportPath": "github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc",
+			"Comment": "v0.1-2-g58cf012",
+			"Rev": "58cf01279880d621a67c5f929af9ed59ab409373"
+		},
+		{
+			"ImportPath": "github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub",
+			"Comment": "v0.1-2-g58cf012",
+			"Rev": "58cf01279880d621a67c5f929af9ed59ab409373"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/contiv/ofnet/ofnetMaster.go
+++ b/Godeps/_workspace/src/github.com/contiv/ofnet/ofnetMaster.go
@@ -126,6 +126,7 @@ func (self *OfnetMaster) RegisterNode(hostInfo *OfnetNode, ret *bool) error {
 			err := client.Call("OfnetAgent.EndpointAdd", endpoint, &resp)
 			if err != nil {
 				log.Errorf("Error adding endpoint to %s. Err: %v", node.HostAddr, err)
+				// continue sending other endpoints
 			}
 		}
 	}
@@ -140,7 +141,7 @@ func (self *OfnetMaster) RegisterNode(hostInfo *OfnetNode, ret *bool) error {
 		err := client.Call("PolicyAgent.AddRule", rule, &resp)
 		if err != nil {
 			log.Errorf("Error adding rule to %s. Err: %v", node.HostAddr, err)
-			return err
+			// continue sending other rules
 		}
 	}
 
@@ -174,7 +175,7 @@ func (self *OfnetMaster) EndpointAdd(ep *OfnetEndpoint, ret *bool) error {
 			err := client.Call("OfnetAgent.EndpointAdd", ep, &resp)
 			if err != nil {
 				log.Errorf("Error adding endpoint to %s. Err: %v", node.HostAddr, err)
-				return err
+				// Continue sending the message to other nodes
 			}
 		}
 	}
@@ -211,7 +212,7 @@ func (self *OfnetMaster) EndpointDel(ep *OfnetEndpoint, ret *bool) error {
 			err := client.Call("OfnetAgent.EndpointDel", ep, &resp)
 			if err != nil {
 				log.Errorf("Error sending DELERE endpoint to %s. Err: %v", node.HostAddr, err)
-				return err
+				// Continue sending the message to other nodes
 			}
 		}
 	}
@@ -240,7 +241,7 @@ func (self *OfnetMaster) AddRule(rule *OfnetPolicyRule) error {
 		err := client.Call("PolicyAgent.AddRule", rule, &resp)
 		if err != nil {
 			log.Errorf("Error adding rule to %s. Err: %v", node.HostAddr, err)
-			return err
+			// Continue sending the message to other nodes
 		}
 	}
 
@@ -267,7 +268,7 @@ func (self *OfnetMaster) DelRule(rule *OfnetPolicyRule) error {
 		err := client.Call("PolicyAgent.DelRule", rule, &resp)
 		if err != nil {
 			log.Errorf("Error adding rule to %s. Err: %v", node.HostAddr, err)
-			return err
+			// Continue sending the message to other nodes
 		}
 	}
 
@@ -287,7 +288,7 @@ func (self *OfnetMaster) MakeDummyRpcCall() error {
 		err := client.Call("OfnetAgent.DummyRpc", &dummyArg, &resp)
 		if err != nil {
 			log.Errorf("Error making dummy rpc call to %+v. Err: %v", node, err)
-			return err
+			// Continue sending the message to other nodes
 		}
 	}
 

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/.gitignore
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/.travis.yml
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go: 1.2
+

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/LICENSE
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/README.md
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/README.md
@@ -1,0 +1,5 @@
+hub
+===
+
+[![GoDoc](https://godoc.org/github.com/cenkalti/hub?status.png)](https://godoc.org/github.com/cenkalti/hub)
+[![Build Status](https://travis-ci.org/cenkalti/hub.png)](https://travis-ci.org/cenkalti/hub)

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/hub.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/hub/hub.go
@@ -1,0 +1,79 @@
+// Package hub provides a simple event dispatcher for publish/subscribe pattern.
+package hub
+
+import "sync"
+
+// Event is an interface for published events.
+type Event interface {
+	Kind() int
+}
+
+// Hub is an event dispatcher, publishes events to the subscribers
+// which are subscribed for a specific event type.
+// Optimized for publish calls.
+// The handlers may be called in order different than they are registered.
+type Hub struct {
+	subscribers map[int][]handler
+	m           sync.RWMutex
+	seq         uint64
+}
+
+type handler struct {
+	f  func(Event)
+	id uint64
+}
+
+// Subscribe registers f for the event of a specific kind.
+func (h *Hub) Subscribe(kind int, f func(Event)) (cancel func()) {
+	var cancelled bool
+	h.m.Lock()
+	h.seq++
+	id := h.seq
+	if h.subscribers == nil {
+		h.subscribers = make(map[int][]handler)
+	}
+	h.subscribers[kind] = append(h.subscribers[kind], handler{id: id, f: f})
+	h.m.Unlock()
+	return func() {
+		h.m.Lock()
+		if cancelled {
+			panic("subscription is already cancelled")
+		}
+		cancelled = true
+		a := h.subscribers[kind]
+		for i, h := range a {
+			if h.id == id {
+				a[i], a = a[len(a)-1], a[:len(a)-1]
+				break
+			}
+		}
+		if len(a) == 0 {
+			delete(h.subscribers, kind)
+		}
+		h.m.Unlock()
+	}
+}
+
+// Publish an event to the subscribers.
+func (h *Hub) Publish(e Event) {
+	h.m.RLock()
+	if handlers, ok := h.subscribers[e.Kind()]; ok {
+		for _, h := range handlers {
+			h.f(e)
+		}
+	}
+	h.m.RUnlock()
+}
+
+// DefaultHub is the default Hub used by Publish and Subscribe.
+var DefaultHub Hub
+
+// Subscribe registers f for the event of a specific kind in the DefaultHub.
+func Subscribe(kind int, f func(Event)) (cancel func()) {
+	return DefaultHub.Subscribe(kind, f)
+}
+
+// Publish an event to the subscribers in DefaultHub.
+func Publish(e Event) {
+	DefaultHub.Publish(e)
+}

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/.gitignore
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/.travis.yml
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/.travis.yml
@@ -1,0 +1,3 @@
+language: go
+go: 1.2
+

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/LICENSE
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/README.md
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/README.md
@@ -1,0 +1,59 @@
+rpc2
+====
+
+[![GoDoc](https://godoc.org/github.com/cenkalti/rpc2?status.png)](https://godoc.org/github.com/cenkalti/rpc2)
+[![Build Status](https://travis-ci.org/cenkalti/rpc2.png)](https://travis-ci.org/cenkalti/rpc2)
+
+rpc2 is a fork of net/rpc package in the standard library.
+The main goal is to add bi-directional support to calls.
+That means server can call the methods of client.
+This is not possible with net/rpc package.
+In order to do this it adds a `*Client` argument to method signatures.
+
+Install
+--------
+
+    go get github.com/cenkalti/rpc2
+
+Example server
+---------------
+
+```go
+type Args struct{ A, B int }
+type Reply int
+
+srv := rpc2.NewServer()
+srv.Handle("add", func(client *rpc2.Client, args *Args, reply *Reply) error {
+        // Reversed call (server to client)
+        var rep Reply
+        client.Call("mult", Args{2, 3}, &rep)
+        fmt.Println("mult result:", rep)
+
+        *reply = Reply(args.A + args.B)
+        return nil
+})
+
+lis, _ := net.Listen("tcp", "127.0.0.1:5000")
+srv.Accept(lis)
+```
+
+Example Client
+---------------
+
+```go
+type Args struct{ A, B int }
+type Reply int
+
+conn, _ := net.Dial("tcp", "127.0.0.1:5000")
+
+clt := rpc2.NewClient(conn)
+clt.Handle("mult", func(client *rpc2.Client, args *Args, reply *Reply) error {
+        *reply = Reply(args.A * args.B)
+        return nil
+})
+go clt.Run()
+
+var rep Reply
+clt.Call("add", Args{1, 2}, &rep)
+fmt.Println("add result:", rep)
+```

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/client.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/client.go
@@ -1,0 +1,330 @@
+// Package rpc2 provides bi-directional RPC client and server similar to net/rpc.
+package rpc2
+
+import (
+	"errors"
+	"io"
+	"log"
+	"reflect"
+	"sync"
+)
+
+// Client represents an RPC Client.
+// There may be multiple outstanding Calls associated
+// with a single Client, and a Client may be used by
+// multiple goroutines simultaneously.
+type Client struct {
+	mutex      sync.Mutex // protects pending, seq, request
+	sending    sync.Mutex
+	request    Request // temp area used in send()
+	seq        uint64
+	pending    map[uint64]*Call
+	closing    bool
+	shutdown   bool
+	server     bool
+	codec      Codec
+	handlers   map[string]*handler
+	disconnect chan struct{}
+}
+
+// NewClient returns a new Client to handle requests to the
+// set of services at the other end of the connection.
+// It adds a buffer to the write side of the connection so
+// the header and payload are sent as a unit.
+func NewClient(conn io.ReadWriteCloser) *Client {
+	return NewClientWithCodec(newGobCodec(conn))
+}
+
+// NewClientWithCodec is like NewClient but uses the specified
+// codec to encode requests and decode responses.
+func NewClientWithCodec(codec Codec) *Client {
+	return &Client{
+		codec:      codec,
+		pending:    make(map[uint64]*Call),
+		handlers:   make(map[string]*handler),
+		disconnect: make(chan struct{}),
+		seq:        1, // 0 means notification.
+	}
+}
+
+// Run the client's read loop.
+// You must run this method before calling any methods on the server.
+func (c *Client) Run() {
+	c.readLoop()
+}
+
+// DisconnectNotify returns a channel that is closed
+// when the client connection has gone away.
+func (c *Client) DisconnectNotify() chan struct{} {
+	return c.disconnect
+}
+
+// Handle registers the handler function for the given method. If a handler already exists for method, Handle panics.
+func (c *Client) Handle(method string, handlerFunc interface{}) {
+	addHandler(c.handlers, method, handlerFunc)
+}
+
+// readLoop reads messages from codec.
+// It reads a reqeust or a response to the previous request.
+// If the message is request, calls the handler function.
+// If the message is response, sends the reply to the associated call.
+func (c *Client) readLoop() {
+	var err error
+	var req Request
+	var resp Response
+	for err == nil {
+		req = Request{}
+		resp = Response{}
+		if err = c.codec.ReadHeader(&req, &resp); err != nil {
+			break
+		}
+
+		if req.Method != "" {
+			// request comes to server
+			if err = c.readRequest(&req); err != nil {
+				log.Println("rpc2: error reading request:", err.Error())
+			}
+		} else {
+			// response comes to client
+			if err = c.readResponse(&resp); err != nil {
+				log.Println("rpc2: error reading response:", err.Error())
+			}
+		}
+	}
+	// Terminate pending calls.
+	c.sending.Lock()
+	c.mutex.Lock()
+	c.shutdown = true
+	closing := c.closing
+	if err == io.EOF {
+		if closing {
+			err = ErrShutdown
+		} else {
+			err = io.ErrUnexpectedEOF
+		}
+	}
+	for _, call := range c.pending {
+		call.Error = err
+		call.done()
+	}
+	c.mutex.Unlock()
+	c.sending.Unlock()
+	if err != io.EOF && !closing && !c.server {
+		log.Println("rpc2: client protocol error:", err)
+	}
+	close(c.disconnect)
+}
+
+func (c *Client) readRequest(req *Request) error {
+	method, ok := c.handlers[req.Method]
+	if !ok {
+		resp := &Response{
+			Seq:   req.Seq,
+			Error: "rpc2: can't find method " + req.Method,
+		}
+		return c.codec.WriteResponse(resp, resp)
+	}
+
+	// Decode the argument value.
+	var argv reflect.Value
+	argIsValue := false // if true, need to indirect before calling.
+	if method.argType.Kind() == reflect.Ptr {
+		argv = reflect.New(method.argType.Elem())
+	} else {
+		argv = reflect.New(method.argType)
+		argIsValue = true
+	}
+	// argv guaranteed to be a pointer now.
+	if err := c.codec.ReadRequestBody(argv.Interface()); err != nil {
+		return err
+	}
+	if argIsValue {
+		argv = argv.Elem()
+	}
+
+	// Invoke the method, providing a new value for the reply.
+	replyv := reflect.New(method.replyType.Elem())
+
+	// Call handler function.
+	go func(req Request) {
+		returnValues := method.fn.Call([]reflect.Value{reflect.ValueOf(c), argv, replyv})
+
+		// Do not send response if request is a notification.
+		if req.Seq == 0 {
+			return
+		}
+
+		// The return value for the method is an error.
+		errInter := returnValues[0].Interface()
+		errmsg := ""
+		if errInter != nil {
+			errmsg = errInter.(error).Error()
+		}
+		resp := &Response{
+			Seq:   req.Seq,
+			Error: errmsg,
+		}
+		c.codec.WriteResponse(resp, replyv.Interface())
+	}(*req)
+
+	return nil
+}
+
+func (c *Client) readResponse(resp *Response) error {
+	seq := resp.Seq
+	c.mutex.Lock()
+	call := c.pending[seq]
+	delete(c.pending, seq)
+	c.mutex.Unlock()
+
+	var err error
+	switch {
+	case call == nil:
+		// We've got no pending call. That usually means that
+		// WriteRequest partially failed, and call was already
+		// removed; response is a server telling us about an
+		// error reading request body. We should still attempt
+		// to read error body, but there's no one to give it to.
+		err = c.codec.ReadResponseBody(nil)
+		if err != nil {
+			err = errors.New("reading error body: " + err.Error())
+		}
+	case resp.Error != "":
+		// We've got an error response. Give this to the request;
+		// any subsequent requests will get the ReadResponseBody
+		// error if there is one.
+		call.Error = ServerError(resp.Error)
+		err = c.codec.ReadResponseBody(nil)
+		if err != nil {
+			err = errors.New("reading error body: " + err.Error())
+		}
+		call.done()
+	default:
+		err = c.codec.ReadResponseBody(call.Reply)
+		if err != nil {
+			call.Error = errors.New("reading body " + err.Error())
+		}
+		call.done()
+	}
+
+	return nil
+}
+
+// Close waits for active calls to finish and closes the codec.
+func (c *Client) Close() error {
+	c.mutex.Lock()
+	if c.shutdown || c.closing {
+		c.mutex.Unlock()
+		return ErrShutdown
+	}
+	c.closing = true
+	c.mutex.Unlock()
+	return c.codec.Close()
+}
+
+// Go invokes the function asynchronously.  It returns the Call structure representing
+// the invocation.  The done channel will signal when the call is complete by returning
+// the same Call object.  If done is nil, Go will allocate a new channel.
+// If non-nil, done must be buffered or Go will deliberately crash.
+func (c *Client) Go(method string, args interface{}, reply interface{}, done chan *Call) *Call {
+	call := new(Call)
+	call.Method = method
+	call.Args = args
+	call.Reply = reply
+	if done == nil {
+		done = make(chan *Call, 10) // buffered.
+	} else {
+		// If caller passes done != nil, it must arrange that
+		// done has enough buffer for the number of simultaneous
+		// RPCs that will be using that channel.  If the channel
+		// is totally unbuffered, it's best not to run at all.
+		if cap(done) == 0 {
+			log.Panic("rpc2: done channel is unbuffered")
+		}
+	}
+	call.Done = done
+	c.send(call)
+	return call
+}
+
+// Call invokes the named function, waits for it to complete, and returns its error status.
+func (c *Client) Call(method string, args interface{}, reply interface{}) error {
+	call := <-c.Go(method, args, reply, make(chan *Call, 1)).Done
+	return call.Error
+}
+
+func (call *Call) done() {
+	select {
+	case call.Done <- call:
+		// ok
+	default:
+		// We don't want to block here.  It is the caller's responsibility to make
+		// sure the channel has enough buffer space. See comment in Go().
+		log.Println("rpc2: discarding Call reply due to insufficient Done chan capacity")
+	}
+}
+
+// ServerError represents an error that has been returned from
+// the remote side of the RPC connection.
+type ServerError string
+
+func (e ServerError) Error() string {
+	return string(e)
+}
+
+var ErrShutdown = errors.New("connection is shut down")
+
+// Call represents an active RPC.
+type Call struct {
+	Method string      // The name of the service and method to call.
+	Args   interface{} // The argument to the function (*struct).
+	Reply  interface{} // The reply from the function (*struct).
+	Error  error       // After completion, the error status.
+	Done   chan *Call  // Strobes when call is complete.
+}
+
+func (c *Client) send(call *Call) {
+	c.sending.Lock()
+	defer c.sending.Unlock()
+
+	// Register this call.
+	c.mutex.Lock()
+	if c.shutdown || c.closing {
+		call.Error = ErrShutdown
+		c.mutex.Unlock()
+		call.done()
+		return
+	}
+	seq := c.seq
+	c.seq++
+	c.pending[seq] = call
+	c.mutex.Unlock()
+
+	// Encode and send the request.
+	c.request.Seq = seq
+	c.request.Method = call.Method
+	err := c.codec.WriteRequest(&c.request, call.Args)
+	if err != nil {
+		c.mutex.Lock()
+		call = c.pending[seq]
+		delete(c.pending, seq)
+		c.mutex.Unlock()
+		if call != nil {
+			call.Error = err
+			call.done()
+		}
+	}
+}
+
+func (c *Client) Notify(method string, args interface{}) error {
+	c.sending.Lock()
+	defer c.sending.Unlock()
+
+	if c.shutdown || c.closing {
+		return ErrShutdown
+	}
+
+	c.request.Seq = 0
+	c.request.Method = method
+	return c.codec.WriteRequest(&c.request, args)
+}

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/codec.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/codec.go
@@ -1,0 +1,124 @@
+package rpc2
+
+import (
+	"bufio"
+	"encoding/gob"
+	"io"
+	"sync"
+)
+
+// A Codec implements reading and writing of RPC requests and responses.
+// The client calls ReadHeader to read a message header.
+// The implementation must populate either Request or Response argument.
+// Depending on which argument is populated, ReadRequestBody or
+// ReadResponseBody is called right after ReadHeader.
+// ReadRequestBody and ReadResponseBody may be called with a nil
+// argument to force the body to be read and then discarded.
+type Codec interface {
+	// ReadHeader must read a message and populate either the request
+	// or the response by inspecting the incoming message.
+	ReadHeader(*Request, *Response) error
+
+	// ReadRequestBody into args argument of handler function.
+	ReadRequestBody(interface{}) error
+
+	// ReadResponseBody into reply argument of handler function.
+	ReadResponseBody(interface{}) error
+
+	// WriteRequest must be safe for concurrent use by multiple goroutines.
+	WriteRequest(*Request, interface{}) error
+
+	// WriteResponse must be safe for concurrent use by multiple goroutines.
+	WriteResponse(*Response, interface{}) error
+
+	// Close is called when client/server finished with the connection.
+	Close() error
+}
+
+// Request is a header written before every RPC call.
+type Request struct {
+	Seq    uint64 // sequence number chosen by client
+	Method string
+}
+
+// Response is a header written before every RPC return.
+type Response struct {
+	Seq   uint64 // echoes that of the request
+	Error string // error, if any.
+}
+
+type gobCodec struct {
+	rwc    io.ReadWriteCloser
+	dec    *gob.Decoder
+	enc    *gob.Encoder
+	encBuf *bufio.Writer
+	mutex  sync.Mutex
+}
+
+type message struct {
+	Seq    uint64
+	Method string
+	Error  string
+}
+
+func newGobCodec(conn io.ReadWriteCloser) *gobCodec {
+	buf := bufio.NewWriter(conn)
+	return &gobCodec{
+		rwc:    conn,
+		dec:    gob.NewDecoder(conn),
+		enc:    gob.NewEncoder(buf),
+		encBuf: buf,
+	}
+}
+
+func (c *gobCodec) ReadHeader(req *Request, resp *Response) error {
+	var msg message
+	if err := c.dec.Decode(&msg); err != nil {
+		return err
+	}
+
+	if msg.Method != "" {
+		req.Seq = msg.Seq
+		req.Method = msg.Method
+	} else {
+		resp.Seq = msg.Seq
+		resp.Error = msg.Error
+	}
+	return nil
+}
+
+func (c *gobCodec) ReadRequestBody(body interface{}) error {
+	return c.dec.Decode(body)
+}
+
+func (c *gobCodec) ReadResponseBody(body interface{}) error {
+	return c.dec.Decode(body)
+}
+
+func (c *gobCodec) WriteRequest(r *Request, body interface{}) (err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if err = c.enc.Encode(r); err != nil {
+		return
+	}
+	if err = c.enc.Encode(body); err != nil {
+		return
+	}
+	return c.encBuf.Flush()
+}
+
+func (c *gobCodec) WriteResponse(r *Response, body interface{}) (err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if err = c.enc.Encode(r); err != nil {
+		return
+	}
+	if err = c.enc.Encode(body); err != nil {
+		return
+	}
+	return c.encBuf.Flush()
+}
+
+func (c *gobCodec) Close() error {
+	return c.rwc.Close()
+}

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/jsonrpc/jsonrpc.go
@@ -1,0 +1,214 @@
+// Package jsonrpc implements a JSON-RPC ClientCodec and ServerCodec for the rpc2 package.
+//
+// Beside struct types, JSONCodec allows using positional arguments.
+// Use []interface{} as the type of argument when sending and receiving methods.
+//
+// Positional arguments example:
+// 	server.Handle("add", func(client *rpc2.Client, args []interface{}, result *float64) error {
+// 		*result = args[0].(float64) + args[1].(float64)
+// 		return nil
+// 	})
+//
+//	var result float64
+// 	client.Call("add", []interface{}{1, 2}, &result)
+//
+package jsonrpc
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/cenkalti/rpc2"
+)
+
+type jsonCodec struct {
+	dec *json.Decoder // for reading JSON values
+	enc *json.Encoder // for writing JSON values
+	c   io.Closer
+
+	// temporary work space
+	msg            message
+	serverRequest  serverRequest
+	clientResponse clientResponse
+
+	// JSON-RPC clients can use arbitrary json values as request IDs.
+	// Package rpc expects uint64 request IDs.
+	// We assign uint64 sequence numbers to incoming requests
+	// but save the original request ID in the pending map.
+	// When rpc responds, we use the sequence number in
+	// the response to find the original request ID.
+	mutex   sync.Mutex // protects seq, pending
+	pending map[uint64]*json.RawMessage
+	seq     uint64
+}
+
+// NewJSONCodec returns a new rpc2.Codec using JSON-RPC on conn.
+func NewJSONCodec(conn io.ReadWriteCloser) rpc2.Codec {
+	return &jsonCodec{
+		dec:     json.NewDecoder(conn),
+		enc:     json.NewEncoder(conn),
+		c:       conn,
+		pending: make(map[uint64]*json.RawMessage),
+	}
+}
+
+// serverRequest and clientResponse combined
+type message struct {
+	Method string           `json:"method"`
+	Params *json.RawMessage `json:"params"`
+	Id     *json.RawMessage `json:"id"`
+	Result *json.RawMessage `json:"result"`
+	Error  interface{}      `json:"error"`
+}
+
+// Unmarshal to
+type serverRequest struct {
+	Method string           `json:"method"`
+	Params *json.RawMessage `json:"params"`
+	Id     *json.RawMessage `json:"id"`
+}
+type clientResponse struct {
+	Id     uint64           `json:"id"`
+	Result *json.RawMessage `json:"result"`
+	Error  interface{}      `json:"error"`
+}
+
+// to Marshal
+type serverResponse struct {
+	Id     *json.RawMessage `json:"id"`
+	Result interface{}      `json:"result"`
+	Error  interface{}      `json:"error"`
+}
+type clientRequest struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+	Id     *uint64       `json:"id"`
+}
+
+func (c *jsonCodec) ReadHeader(req *rpc2.Request, resp *rpc2.Response) error {
+	c.msg = message{}
+	if err := c.dec.Decode(&c.msg); err != nil {
+		return err
+	}
+
+	if c.msg.Method != "" {
+		// request comes to server
+		c.serverRequest.Id = c.msg.Id
+		c.serverRequest.Method = c.msg.Method
+		c.serverRequest.Params = c.msg.Params
+
+		req.Method = c.serverRequest.Method
+
+		// JSON request id can be any JSON value;
+		// RPC package expects uint64.  Translate to
+		// internal uint64 and save JSON on the side.
+		if c.serverRequest.Id == nil {
+			// Notification
+		} else {
+			c.mutex.Lock()
+			c.seq++
+			c.pending[c.seq] = c.serverRequest.Id
+			c.serverRequest.Id = nil
+			req.Seq = c.seq
+			c.mutex.Unlock()
+		}
+	} else {
+		// response comes to client
+		err := json.Unmarshal(*c.msg.Id, &c.clientResponse.Id)
+		if err != nil {
+			return err
+		}
+		c.clientResponse.Result = c.msg.Result
+		c.clientResponse.Error = c.msg.Error
+
+		resp.Error = ""
+		resp.Seq = c.clientResponse.Id
+		if c.clientResponse.Error != nil || c.clientResponse.Result == nil {
+			x, ok := c.clientResponse.Error.(string)
+			if !ok {
+				return fmt.Errorf("invalid error %v", c.clientResponse.Error)
+			}
+			if x == "" {
+				x = "unspecified error"
+			}
+			resp.Error = x
+		}
+	}
+	return nil
+}
+
+var errMissingParams = errors.New("jsonrpc: request body missing params")
+
+func (c *jsonCodec) ReadRequestBody(x interface{}) error {
+	if x == nil {
+		return nil
+	}
+	if c.serverRequest.Params == nil {
+		return errMissingParams
+	}
+	var params *[]interface{}
+	switch x := x.(type) {
+	case *[]interface{}:
+		params = x
+	default:
+		params = &[]interface{}{x}
+	}
+	return json.Unmarshal(*c.serverRequest.Params, params)
+}
+
+func (c *jsonCodec) ReadResponseBody(x interface{}) error {
+	if x == nil {
+		return nil
+	}
+	return json.Unmarshal(*c.clientResponse.Result, x)
+}
+
+func (c *jsonCodec) WriteRequest(r *rpc2.Request, param interface{}) error {
+	req := &clientRequest{Method: r.Method}
+	switch param := param.(type) {
+	case []interface{}:
+		req.Params = param
+	default:
+		req.Params = []interface{}{param}
+	}
+	if r.Seq == 0 {
+		// Notification
+		req.Id = nil
+	} else {
+		seq := r.Seq
+		req.Id = &seq
+	}
+	return c.enc.Encode(req)
+}
+
+var null = json.RawMessage([]byte("null"))
+
+func (c *jsonCodec) WriteResponse(r *rpc2.Response, x interface{}) error {
+	c.mutex.Lock()
+	b, ok := c.pending[r.Seq]
+	if !ok {
+		c.mutex.Unlock()
+		return errors.New("invalid sequence number in response")
+	}
+	delete(c.pending, r.Seq)
+	c.mutex.Unlock()
+
+	if b == nil {
+		// Invalid request so no id.  Use JSON null.
+		b = &null
+	}
+	resp := serverResponse{Id: b}
+	if r.Error == "" {
+		resp.Result = x
+	} else {
+		resp.Error = r.Error
+	}
+	return c.enc.Encode(resp)
+}
+
+func (c *jsonCodec) Close() error {
+	return c.c.Close()
+}

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/server.go
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/Godeps/_workspace/src/github.com/cenkalti/rpc2/server.go
@@ -1,0 +1,171 @@
+package rpc2
+
+import (
+	"io"
+	"log"
+	"net"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/cenkalti/hub"
+)
+
+// Precompute the reflect type for error.  Can't use error directly
+// because Typeof takes an empty interface value.  This is annoying.
+var typeOfError = reflect.TypeOf((*error)(nil)).Elem()
+var typeOfClient = reflect.TypeOf((*Client)(nil))
+
+const (
+	clientConnected = iota
+	clientDisconnected
+)
+
+type Server struct {
+	handlers map[string]*handler
+	eventHub *hub.Hub
+}
+
+type handler struct {
+	fn        reflect.Value
+	argType   reflect.Type
+	replyType reflect.Type
+}
+
+type connectionEvent struct {
+	Client *Client
+}
+
+type disconnectionEvent struct {
+	Client *Client
+}
+
+func (connectionEvent) Kind() int    { return clientConnected }
+func (disconnectionEvent) Kind() int { return clientDisconnected }
+
+func NewServer() *Server {
+	return &Server{
+		handlers: make(map[string]*handler),
+		eventHub: &hub.Hub{},
+	}
+}
+
+// Handle registers the handler function for the given method. If a handler already exists for method, Handle panics.
+func (s *Server) Handle(method string, handlerFunc interface{}) {
+	addHandler(s.handlers, method, handlerFunc)
+}
+
+func addHandler(handlers map[string]*handler, mname string, handlerFunc interface{}) {
+	if _, ok := handlers[mname]; ok {
+		panic("rpc2: multiple registrations for " + mname)
+	}
+
+	method := reflect.ValueOf(handlerFunc)
+	mtype := method.Type()
+	// Method needs three ins: *client, *args, *reply.
+	if mtype.NumIn() != 3 {
+		log.Panicln("method", mname, "has wrong number of ins:", mtype.NumIn())
+	}
+	// First arg must be a pointer to rpc2.Client.
+	clientType := mtype.In(0)
+	if clientType.Kind() != reflect.Ptr {
+		log.Panicln("method", mname, "client type not a pointer:", clientType)
+	}
+	if clientType != typeOfClient {
+		log.Panicln("method", mname, "first argument", clientType.String(), "not *rpc2.Client")
+	}
+	// Second arg need not be a pointer.
+	argType := mtype.In(1)
+	if !isExportedOrBuiltinType(argType) {
+		log.Panicln(mname, "argument type not exported:", argType)
+	}
+	// Third arg must be a pointer.
+	replyType := mtype.In(2)
+	if replyType.Kind() != reflect.Ptr {
+		log.Panicln("method", mname, "reply type not a pointer:", replyType)
+	}
+	// Reply type must be exported.
+	if !isExportedOrBuiltinType(replyType) {
+		log.Panicln("method", mname, "reply type not exported:", replyType)
+	}
+	// Method needs one out.
+	if mtype.NumOut() != 1 {
+		log.Panicln("method", mname, "has wrong number of outs:", mtype.NumOut())
+	}
+	// The return type of the method must be error.
+	if returnType := mtype.Out(0); returnType != typeOfError {
+		log.Panicln("method", mname, "returns", returnType.String(), "not error")
+	}
+	handlers[mname] = &handler{
+		fn:        method,
+		argType:   argType,
+		replyType: replyType,
+	}
+}
+
+// Is this type exported or a builtin?
+func isExportedOrBuiltinType(t reflect.Type) bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	// PkgPath will be non-empty even for an exported type,
+	// so we need to check the type name as well.
+	return isExported(t.Name()) || t.PkgPath() == ""
+}
+
+// Is this an exported - upper case - name?
+func isExported(name string) bool {
+	rune, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(rune)
+}
+
+// OnConnect registers a function to run when a client connects.
+func (s *Server) OnConnect(f func(*Client)) {
+	s.eventHub.Subscribe(clientConnected, func(e hub.Event) {
+		go f(e.(connectionEvent).Client)
+	})
+}
+
+// OnDisconnect registers a function to run when a client disconnects.
+func (s *Server) OnDisconnect(f func(*Client)) {
+	s.eventHub.Subscribe(clientDisconnected, func(e hub.Event) {
+		go f(e.(disconnectionEvent).Client)
+	})
+}
+
+// Accept accepts connections on the listener and serves requests
+// for each incoming connection.  Accept blocks; the caller typically
+// invokes it in a go statement.
+func (s *Server) Accept(lis net.Listener) {
+	for {
+		conn, err := lis.Accept()
+		if err != nil {
+			log.Fatal("rpc.Serve: accept:", err.Error())
+		}
+		go s.ServeConn(conn)
+	}
+}
+
+// ServeConn runs the server on a single connection.
+// ServeConn blocks, serving the connection until the client hangs up.
+// The caller typically invokes ServeConn in a go statement.
+// ServeConn uses the gob wire format (see package gob) on the
+// connection.  To use an alternate codec, use ServeCodec.
+func (s *Server) ServeConn(conn io.ReadWriteCloser) {
+	s.ServeCodec(newGobCodec(conn))
+}
+
+// ServeCodec is like ServeConn but uses the specified codec to
+// decode requests and encode responses.
+func (s *Server) ServeCodec(codec Codec) {
+	defer codec.Close()
+
+	// Client also handles the incoming connections.
+	c := NewClientWithCodec(codec)
+	c.server = true
+	c.handlers = s.handlers
+
+	s.eventHub.Publish(connectionEvent{c})
+	c.Run()
+	s.eventHub.Publish(disconnectionEvent{c})
+}

--- a/Godeps/_workspace/src/github.com/socketplane/libovsdb/LICENSE
+++ b/Godeps/_workspace/src/github.com/socketplane/libovsdb/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,11 +61,14 @@ docker load --input #{gopath_folder}/src/github.com/contiv/netplugin/scripts/dns
 # Drop cache to workaround vboxsf problem
 echo 3 > /proc/sys/vm/drop_caches
 
+# Change ownership for gopath folder
+chown vagrant #{gopath_folder}
+
 SCRIPT
 
 provision_gobgp = <<SCRIPT
 #Get gobgp binary
-wget https://cisco.box.com/shared/static/5leqlo84kjh0thty91ouotilm4ish3nz -q -O #{gopath_folder}/bin/gobgp && chmod +x #{gopath_folder}/bin/gobgp 
+wget https://cisco.box.com/shared/static/5leqlo84kjh0thty91ouotilm4ish3nz -q -O #{gopath_folder}/bin/gobgp && chmod +x #{gopath_folder}/bin/gobgp
 SCRIPT
 
 provision_bird = <<SCRIPT
@@ -218,6 +221,7 @@ set -x
  --listen-peer-urls http://#{node_addr}:2380 \
  --initial-cluster #{node_peers.join(",")} --initial-cluster-state new \
   0<&- &>/tmp/etcd.log &) || exit 1
+
 ## start consul
 (nohup consul agent -server #{consul_join_flag} #{consul_bootstrap_flag} \
  -bind=#{node_addr} -data-dir /opt/consul 0<&- &>/tmp/consul.log &) || exit 1

--- a/drivers/ovsSwitch.go
+++ b/drivers/ovsSwitch.go
@@ -265,6 +265,17 @@ func (sw *OvsSwitch) CreatePort(intfName string, cfgEp *mastercfg.CfgEndpointSta
 		ovsIntfType = "internal"
 	}
 
+	// If the port already exists in OVS, remove it first
+	if sw.ovsdbDriver.IsPortNamePresent(ovsPortName) {
+		log.Debugf("Removing existing interface entry %s from OVS", ovsPortName)
+
+		// Delete it from ovsdb
+		err := sw.ovsdbDriver.DeletePort(ovsPortName)
+		if err != nil {
+			log.Errorf("Error deleting port %s from OVS. Err: %v", ovsPortName, err)
+		}
+	}
+
 	// Ask OVSDB driver to add the port
 	err := sw.ovsdbDriver.CreatePort(ovsPortName, ovsIntfType, cfgEp.ID, pktTag)
 	if err != nil {

--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -88,10 +88,13 @@ func (d *OvsDriver) getIntfName() (string, error) {
 		// Pick next port number
 		d.oper.CurrPortNum++
 		intfName := fmt.Sprintf("vport%d", d.oper.CurrPortNum)
+		ovsIntfName := getOvsPortName(intfName, false)
 
 		// check if the port name is already in use
 		_, err := netlink.LinkByName(intfName)
-		if err != nil && strings.Contains(err.Error(), "not found") {
+		_, err2 := netlink.LinkByName(ovsIntfName)
+		if err != nil && strings.Contains(err.Error(), "not found") &&
+			err2 != nil && strings.Contains(err2.Error(), "not found") {
 			// save the new state
 			err = d.oper.Write()
 			if err != nil {

--- a/mgmtfn/dockplugin/dockplugin.go
+++ b/mgmtfn/dockplugin/dockplugin.go
@@ -30,7 +30,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/netplugin/netplugin/plugin"
 	"github.com/contiv/netplugin/svcplugin"
-	"github.com/contiv/netplugin/svcplugin/bridge"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	"github.com/gorilla/mux"
@@ -40,11 +39,15 @@ const pluginPath = "/run/docker/plugins"
 const driverName = "netplugin"
 
 var netPlugin *plugin.NetPlugin
-var dnsBridge = &bridge.Bridge{}
+var svcPlugin svcplugin.SvcregPlugin
 
 // InitDockPlugin initializes the docker plugin
-func InitDockPlugin(netplugin *plugin.NetPlugin) error {
-	netPlugin = netplugin
+func InitDockPlugin(np *plugin.NetPlugin, sp svcplugin.SvcregPlugin) error {
+	// Save state
+	netPlugin = np
+	svcPlugin = sp
+
+	// Get local hostname
 	hostname, err := os.Hostname()
 	if err != nil {
 		log.Fatalf("Could not retrieve hostname: %v", err)
@@ -98,12 +101,6 @@ func InitDockPlugin(netplugin *plugin.NetPlugin) error {
 		l.Close()
 		log.Infof("docker plugin closing %s", driverPath)
 	}()
-
-	// Adding bridge Config temporarily to check service refresh
-	bConfig := bridge.DefaultBridgeConfig()
-	bConfig.RefreshTTL = 15
-	bConfig.RefreshInterval = 10
-	dnsBridge, err = svcplugin.InitServicePlugin("skydns2:", bConfig)
 
 	return nil
 }

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -151,7 +151,7 @@ func deleteEndpoint(hostname string) func(http.ResponseWriter, *http.Request) {
 		// Remove the DNS entry for the service
 		if serviceName != "" {
 			log.Infof("Calling RemoveService with: ID: %s, Name: %s, Network: %s, Tenant: %s, IP: %s", delreq.EndpointID[len(delreq.EndpointID)-12:], serviceName, netName, tenantName, ep.IPAddress)
-			dnsBridge.RemoveService(delreq.EndpointID[len(delreq.EndpointID)-12:], serviceName, netName, tenantName, ep.IPAddress)
+			svcPlugin.RemoveService(delreq.EndpointID[len(delreq.EndpointID)-12:], serviceName, netName, tenantName, ep.IPAddress)
 		}
 
 		// delete the endpoint
@@ -246,7 +246,7 @@ func createEndpoint(hostname string) func(http.ResponseWriter, *http.Request) {
 		// Add the service information using Service plugin
 		if serviceName != "" {
 			log.Infof("Calling AddService with: ID: %s, Name: %s, Network: %s, Tenant: %s, IP: %s", cereq.EndpointID[len(cereq.EndpointID)-12:], serviceName, netName, tenantName, ep.IPAddress)
-			dnsBridge.AddService(cereq.EndpointID[len(cereq.EndpointID)-12:], serviceName, netName, tenantName, ep.IPAddress)
+			svcPlugin.AddService(cereq.EndpointID[len(cereq.EndpointID)-12:], serviceName, netName, tenantName, ep.IPAddress)
 		}
 
 		log.Infof("Sending CreateEndpointResponse: {%+v}, IP Addr: %v", epResponse, ep.IPAddress)

--- a/netmaster/daemon.go
+++ b/netmaster/daemon.go
@@ -188,9 +188,6 @@ func (d *daemon) registerRoutes(router *mux.Router) {
 	s.HandleFunc(fmt.Sprintf("/%s", master.GetNetworksRESTEndpoint),
 		get(true, d.networks))
 	s.HandleFunc(fmt.Sprintf("/%s", master.GetVersionRESTEndpoint), getVersion)
-
-	// See if we need to create the default tenant
-	go objApi.CreateDefaultTenant()
 }
 
 // XXX: This function should be returning logical state instead of driver state

--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -17,7 +17,6 @@ package objApi
 
 import (
 	"errors"
-	"time"
 
 	"github.com/contiv/contivmodel"
 	"github.com/contiv/netplugin/core"
@@ -78,14 +77,6 @@ func NewAPIController(router *mux.Router, storeURL string) *APIController {
 		}
 	}
 
-	return ctrler
-}
-
-// CreateDefaultTenant creates the default tenant
-func CreateDefaultTenant() {
-	// Wait for netmaster to start listening to port 9999
-	time.Sleep(time.Second)
-
 	// Add default tenant if it doesnt exist
 	tenant := contivModel.FindTenant("default")
 	if tenant == nil {
@@ -98,6 +89,8 @@ func CreateDefaultTenant() {
 			log.Fatalf("Error creating default tenant. Err: %v", err)
 		}
 	}
+
+	return ctrler
 }
 
 // Utility function to check if string exists in a slice

--- a/netmaster/objApi/objapi_test.go
+++ b/netmaster/objApi/objapi_test.go
@@ -93,38 +93,11 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Error creating contiv client. Err: %v", err)
 	}
 
-	// Create default tenant
-	createDefaultTenant()
-
 	exitCode := m.Run()
 	if exitCode == 0 {
 		cleanupState()
 	}
 	os.Exit(exitCode)
-}
-
-// createDefaultTenant creates the default tenant
-func createDefaultTenant() {
-	// tenant params
-	tenant := client.Tenant{
-		TenantName: "default",
-	}
-
-	// create a tenant
-	err := contivClient.TenantPost(&tenant)
-	if err != nil {
-		log.Fatalf("Error creating default tenant. Err: %v", err)
-	}
-
-	// Get the tenant and verify it exists
-	gotTenant, err := contivClient.TenantGet("default")
-	if err != nil {
-		log.Fatalf("Error getting default tenant. Err: %v", err)
-	}
-
-	if gotTenant.TenantName != tenant.TenantName {
-		log.Fatalf("Got invalid tenant name. expecting %s. Got %s", tenant.TenantName, gotTenant.TenantName)
-	}
 }
 
 // cleanupState cleans up default tenant and other global state

--- a/scripts/python/policyScale.py
+++ b/scripts/python/policyScale.py
@@ -53,7 +53,7 @@ def testConnections(testbed, numContainer):
 # Cleanup all policies
 def cleanupPolicies(numPolicy, numRulesPerPolicy):
 	tenant = api.objmodel.tenant('default')
-	network = tenant.network('private')
+	network = tenant.newNetwork('private', pktTag=10, subnet="20.1.0.0/16", gateway="20.1.1.254", encap="vlan")
 	for pid in range(numPolicy):
 		pname = 'policy' + str(pid + 1)
 		policy = tenant.newPolicy(pname)

--- a/systemtests/basic_test.go
+++ b/systemtests/basic_test.go
@@ -1,18 +1,14 @@
 package systemtests
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
 	"github.com/contiv/contivmodel/client"
 	. "gopkg.in/check.v1"
 )
-
-var privateNetwork = &client.Network{
-	PktTag:      1001,
-	NetworkName: "private",
-	Subnet:      "10.1.0.0/16",
-	Gateway:     "10.1.1.254",
-	Encap:       "vxlan",
-	TenantName:  "default",
-}
 
 func (s *systemtestSuite) TestBasicStartRemoveContainerVXLAN(c *C) {
 	s.testBasicStartRemoveContainer(c, "vxlan")
@@ -39,10 +35,12 @@ func (s *systemtestSuite) testBasicStartRemoveContainer(c *C, encap string) {
 
 	for i := 0; i < s.iterations; i++ {
 		containers, err := s.runContainers(s.containers, false, "private", nil)
+		c.Assert(err, IsNil)
+
 		if s.fwdMode == "routing" && encap == "vlan" {
 			s.CheckBgpRouteDistribution(c, s.vagrant.GetNode("quagga1"), containers)
 		}
-		c.Assert(err, IsNil)
+
 		c.Assert(s.pingTest(containers), IsNil)
 		c.Assert(s.removeContainers(containers), IsNil)
 	}
@@ -105,5 +103,72 @@ func (s *systemtestSuite) testBasicStartStopContainer(c *C, encap string) {
 	}
 
 	c.Assert(s.removeContainers(containers), IsNil)
+	c.Assert(s.cli.NetworkDelete("default", "private"), IsNil)
+}
+
+func (s *systemtestSuite) TestBasicSvcDiscoveryVXLAN(c *C) {
+	s.testBasicSvcDiscovery(c, "vxlan")
+}
+
+func (s *systemtestSuite) TestBasicSvcDiscoveryVLAN(c *C) {
+	s.testBasicSvcDiscovery(c, "vlan")
+}
+
+func (s *systemtestSuite) testBasicSvcDiscovery(c *C, encap string) {
+	if !strings.Contains(s.clusterStore, "etcd") || !s.enableDNS {
+		c.Skip("Skipping test")
+	}
+
+	if s.fwdMode == "routing" && encap == "vlan" {
+		s.SetupBgp(c, false)
+		s.CheckBgpConnection(c)
+	}
+	c.Assert(s.cli.NetworkPost(&client.Network{
+		PktTag:      1001,
+		NetworkName: "private",
+		Subnet:      "10.1.0.0/16",
+		Gateway:     "10.1.1.254",
+		Encap:       encap,
+		TenantName:  "default",
+	}), IsNil)
+
+	for i := 0; i < s.iterations; i++ {
+		group1 := &client.EndpointGroup{
+			GroupName:   fmt.Sprintf("svc1%d", i),
+			NetworkName: "private",
+			Policies:    []string{},
+			TenantName:  "default",
+		}
+		group2 := &client.EndpointGroup{
+			GroupName:   fmt.Sprintf("svc2%d", i),
+			NetworkName: "private",
+			Policies:    []string{},
+			TenantName:  "default",
+		}
+		logrus.Infof("Creating epg: %s", group1.GroupName)
+		c.Assert(s.cli.EndpointGroupPost(group1), IsNil)
+		logrus.Infof("Creating epg: %s", group2.GroupName)
+		c.Assert(s.cli.EndpointGroupPost(group2), IsNil)
+
+		containers1, err := s.runContainersWithDNS(s.containers, "default", "private", fmt.Sprintf("svc1%d", i))
+		c.Assert(err, IsNil)
+		containers2, err := s.runContainersWithDNS(s.containers, "default", "private", fmt.Sprintf("svc2%d", i))
+		c.Assert(err, IsNil)
+
+		containers := append(containers1, containers2...)
+		if s.fwdMode == "routing" && encap == "vlan" {
+			time.Sleep(5 * time.Second)
+		}
+
+		// Check name resolution
+		c.Assert(s.pingTestByName(containers, fmt.Sprintf("svc1%d.private.default", i)), IsNil)
+		c.Assert(s.pingTestByName(containers, fmt.Sprintf("svc2%d.private.default", i)), IsNil)
+
+		// cleanup
+		c.Assert(s.removeContainers(containers), IsNil)
+		c.Assert(s.cli.EndpointGroupDelete(group1.TenantName, group1.NetworkName, group1.GroupName), IsNil)
+		c.Assert(s.cli.EndpointGroupDelete(group2.TenantName, group2.NetworkName, group2.GroupName), IsNil)
+	}
+
 	c.Assert(s.cli.NetworkDelete("default", "private"), IsNil)
 }

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -47,7 +47,7 @@ func TestMain(m *M) {
 	flag.StringVar(&sts.binpath, "binpath", "/opt/gopath/bin", "netplugin/netmaster binary path")
 	flag.IntVar(&sts.containers, "containers", 3, "Number of containers to use")
 	flag.BoolVar(&sts.short, "short", false, "Do a quick validation run instead of the full test suite")
-	flag.BoolVar(&sts.enableDNS, "dns-enable", true, "Enable DNS service discovery")
+	flag.BoolVar(&sts.enableDNS, "dns-enable", false, "Enable DNS service discovery")
 	if os.Getenv("CONTIV_CLUSTER_STORE") == "" {
 		flag.StringVar(&sts.clusterStore, "cluster-store", "etcd://localhost:2379", "cluster store URL")
 	} else {
@@ -177,9 +177,10 @@ func (s *systemtestSuite) TearDownSuite(c *C) {
 
 	// Print all errors and fatal messages
 	for _, node := range s.nodes {
+		logrus.Infof("Checking for errors on %v", node.Name())
 		out, _ := node.runCommand(`for i in /tmp/_net*; do grep "error\|fatal" $i; done`)
 		if out != "" {
-			logrus.Errorf("Errors in logfiles on %s: \n%v\n==========================\n\n", node.Name(), out)
+			logrus.Errorf("Errors in logfiles on %s: \n%s\n==========================\n\n", node.Name(), out)
 		}
 	}
 

--- a/systemtests/node_test.go
+++ b/systemtests/node_test.go
@@ -17,6 +17,7 @@ type containerSpec struct {
 	networkName string
 	serviceName string
 	name        string
+	dnsServer   string
 }
 
 type node struct {
@@ -79,7 +80,11 @@ func (n *node) stopNetmaster() error {
 
 func (n *node) startNetmaster() error {
 	logrus.Infof("Starting netmaster on %s", n.Name())
-	return n.tbnode.RunCommandBackground(n.suite.binpath + "/netmaster -dns-enable=false" + " --cluster-store " + n.suite.clusterStore + " &> /tmp/netmaster.log")
+	dnsOpt := " --dns-enable=false "
+	if n.suite.enableDNS {
+		dnsOpt = " --dns-enable=true "
+	}
+	return n.tbnode.RunCommandBackground(n.suite.binpath + "/netmaster" + dnsOpt + " --cluster-store " + n.suite.clusterStore + " &> /tmp/netmaster.log")
 }
 
 func (n *node) cleanupDockerNetwork() error {
@@ -132,7 +137,7 @@ func (n *node) runCommand(cmd string) (string, error) {
 }
 
 func (n *node) runContainer(spec containerSpec) (*container, error) {
-	var namestr, netstr string
+	var namestr, netstr, dnsStr string
 
 	if spec.networkName != "" {
 		netstr = spec.networkName
@@ -156,9 +161,14 @@ func (n *node) runContainer(spec containerSpec) (*container, error) {
 		namestr = "--name=" + spec.name
 	}
 
+	if spec.dnsServer != "" {
+		dnsStr = "--dns=" + spec.dnsServer
+	}
 	logrus.Infof("Starting a container running %q on %s", spec.commandName, n.Name())
 
-	cmd := fmt.Sprintf("docker run -itd %s %s %s %s", namestr, netstr, spec.imageName, spec.commandName)
+	cmd := fmt.Sprintf("docker run -itd %s %s %s %s %s", namestr, netstr, dnsStr, spec.imageName, spec.commandName)
+
+	logrus.Infof("Starting container on %s with: %s", n.Name(), cmd)
 
 	out, err := n.tbnode.RunCommandWithOutput(cmd)
 	if err != nil {
@@ -186,7 +196,8 @@ func (n *node) runContainer(spec containerSpec) (*container, error) {
 func (n *node) checkForNetpluginErrors() error {
 	out, _ := n.tbnode.RunCommandWithOutput(`for i in /tmp/net*; do grep "error|fatal" $i; done`)
 	if out != "" {
-		return fmt.Errorf("error output in netplugin logs: %q", out)
+		logrus.Errorf("error output in netplugin logs on %s: \n%v\n", n.Name(), out)
+		return fmt.Errorf("error output in netplugin logs")
 	}
 
 	return nil

--- a/systemtests/node_test.go
+++ b/systemtests/node_test.go
@@ -196,7 +196,7 @@ func (n *node) runContainer(spec containerSpec) (*container, error) {
 func (n *node) checkForNetpluginErrors() error {
 	out, _ := n.tbnode.RunCommandWithOutput(`for i in /tmp/net*; do grep "error|fatal" $i; done`)
 	if out != "" {
-		logrus.Errorf("error output in netplugin logs on %s: \n%v\n", n.Name(), out)
+		logrus.Errorf("error output in netplugin logs on %s: \n%s\n", n.Name(), out)
 		return fmt.Errorf("error output in netplugin logs")
 	}
 

--- a/systemtests/trigger_test.go
+++ b/systemtests/trigger_test.go
@@ -214,9 +214,14 @@ func (s *systemtestSuite) TestTriggers(c *C) {
 			logrus.Info("Triggering netmaster restart")
 			for _, node := range s.nodes {
 				c.Assert(node.stopNetmaster(), IsNil)
-				time.Sleep(1 * time.Second)
 				c.Assert(node.rotateLog("netmaster"), IsNil)
+			}
+
+			time.Sleep(15 * time.Second)
+
+			for _, node := range s.nodes {
 				c.Assert(node.startNetmaster(), IsNil)
+				time.Sleep(1 * time.Second)
 				c.Assert(node.runCommandUntilNoError("pgrep netmaster"), IsNil)
 			}
 			time.Sleep(30 * time.Second)

--- a/systemtests/trigger_test.go
+++ b/systemtests/trigger_test.go
@@ -215,11 +215,9 @@ func (s *systemtestSuite) TestTriggers(c *C) {
 			for _, node := range s.nodes {
 				c.Assert(node.stopNetmaster(), IsNil)
 				c.Assert(node.rotateLog("netmaster"), IsNil)
-			}
 
-			time.Sleep(15 * time.Second)
+				time.Sleep(1 * time.Second)
 
-			for _, node := range s.nodes {
 				c.Assert(node.startNetmaster(), IsNil)
 				time.Sleep(1 * time.Second)
 				c.Assert(node.runCommandUntilNoError("pgrep netmaster"), IsNil)


### PR DESCRIPTION
- Fix #345 and #344 seen at a customer. Adds tests for both scenarios.
- Vagrantfile changes to run a cluster in etcd or consul modes so that we can run consul tests without etcd in the system
- Add checks to see Veth interfaces and OVS configuration already exists
- Rearrange svcplugin code to make it work in consul cluster.
-  Move to svcplugin to new etcd client
- Remove the delay in creating default tenant
- Now that CI is stable, re-enables skydns in CI runs
- Adds a system test to verify skydns service discovery works
- Print out all netplugin errors logs at the end of the system-test so that we can debug CI failures