### PR TITLE
vlan network support in k8s vagrant

### DIFF
--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -11,6 +11,18 @@ def customize_vm(v)
   v.customize ["modifyvm", :id, "--cpus", cpus]
 end
 
+# method to set up network attributes
+def customize_vm_network(v)
+  # make all nics 'virtio' to take benefit of builtin vlan tag
+  # support, which otherwise needs to be enabled in Intel drivers,
+  # which are used by default by virtualbox
+  v.customize ['modifyvm', :id, '--nictype1', 'virtio']
+  v.customize ['modifyvm', :id, '--nictype2', 'virtio']
+  v.customize ['modifyvm', :id, '--nictype3', 'virtio']
+  v.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
+  v.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
+end
+
 # method to create an etc_hosts file based on the cluster info
 def create_etc_hosts(cluster)
   etc_file = open("./export/.etc_hosts", "w")
@@ -60,8 +72,13 @@ Vagrant.configure(2) do |config|
 
         # configure ip address etc
         c.vm.hostname = vm_name
-        c.vm.network :private_network, ip: member_info["contiv_control_ip"]
-        c.vm.network :private_network, ip: member_info["contiv_network_ip"]
+        c.vm.network :private_network, ip: member_info["contiv_control_ip"], virtualbox__intnet: "true"
+        c.vm.network :private_network, ip: "0.0.0.0", virtualbox__intnet: "true"
+
+        # Customize VM network settings
+        config.vm.provider "virtualbox" do |v|
+          customize_vm_network(v)
+        end # v
 
         c.vm.provision "shell", inline: <<-EOS
           sudo setenforce 0

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(2) do |config|
 
         # configure ip address etc
         c.vm.hostname = vm_name
-        c.vm.network :private_network, ip: member_info["contiv_control_ip"], virtualbox__intnet: "true"
+        c.vm.network :private_network, ip: member_info["contiv_control_ip"]
         c.vm.network :private_network, ip: "0.0.0.0", virtualbox__intnet: "true"
 
         # Customize VM network settings

--- a/vagrant/k8s/cluster_defs.json
+++ b/vagrant/k8s/cluster_defs.json
@@ -1,4 +1,4 @@
-{"master": [{"name": "k8master", "management_ip": "192.168.2.10", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.10", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.10"}],
- "nodes" : [{"name": "k8node-01", "management_ip": "192.168.2.11", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.11", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.11", "max_pods": "40"},
-            {"name": "k8node-02", "management_ip": "192.168.2.12", "contiv_control_if": "enp0s8", "contiv_control_ip": "192.168.2.12", "contiv_network_if": "enp0s9", "contiv_network_ip": "10.1.1.12", "max_pods": "40"}]
+{"master": [{"name": "k8master", "management_ip": "192.168.2.10", "contiv_control_if": "eth1", "contiv_control_ip": "192.168.2.10", "contiv_network_if": "eth2", "contiv_network_ip": "10.1.1.10"}],
+ "nodes" : [{"name": "k8node-01", "management_ip": "192.168.2.11", "contiv_control_if": "eth1", "contiv_control_ip": "192.168.2.11", "contiv_network_if": "eth2", "contiv_network_ip": "10.1.1.11", "max_pods": "40"},
+            {"name": "k8node-02", "management_ip": "192.168.2.12", "contiv_control_if": "eth1", "contiv_control_ip": "192.168.2.12", "contiv_network_if": "eth2", "contiv_network_ip": "10.1.1.12", "max_pods": "40"}]
 }


### PR DESCRIPTION
Changed vagrant file to add support for vlan network with k8s VM: 
Ethernet interface used as contivVlanBridge uplink should have ip 0, and have promisc/virtio settings enabled.
