### PR TITLE
fix interop issue with docker 1.11

### DIFF
--- a/mgmtfn/dockplugin/ipamDriver.go
+++ b/mgmtfn/dockplugin/ipamDriver.go
@@ -31,7 +31,7 @@ import (
 func getIpamCapability(w http.ResponseWriter, r *http.Request) {
 	logEvent("getIpamCapability")
 
-	content, err := json.Marshal(api.GetCapabilityResponse{RequiresMACAddress: true})
+	content, err := json.Marshal(api.GetCapabilityResponse{})
 	if err != nil {
 		httpError(w, "Could not generate getCapability response", err)
 		return

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -240,7 +240,9 @@ func createEndpoint(hostname string) func(http.ResponseWriter, *http.Request) {
 		log.Debug(ep)
 
 		epResponse := api.CreateEndpointResponse{
-			Interface: &api.EndpointInterface{},
+			Interface: &api.EndpointInterface{
+				MacAddress: mresp.EndpointConfig.MacAddress,
+			},
 		}
 
 		// Add the service information using Service plugin


### PR DESCRIPTION
With docker 1.11, if IPAM driver sets "RequiresMACAddress" capability, it overwrites container interface Macaddress with a random mac. This change stops advertising the RequiresMACAddress capability.

fixes #372 
