### PR TITLE
add endpoint oper object

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -54,11 +54,11 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel",
-			"Rev": "846d0879b7d854e5b692227a3a4cf0a99b59166c"
+			"Rev": "a9279c43e839341bc4cd06e43ba2bd58f62d6a07"
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel/client",
-			"Rev": "846d0879b7d854e5b692227a3a4cf0a99b59166c"
+			"Rev": "a9279c43e839341bc4cd06e43ba2bd58f62d6a07"
 		},
 		{
 			"ImportPath": "github.com/contiv/libovsdb",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -54,11 +54,11 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel",
-			"Rev": "25b340263ede344507fbb05a81856afaeb6d967e"
+			"Rev": "846d0879b7d854e5b692227a3a4cf0a99b59166c"
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel/client",
-			"Rev": "25b340263ede344507fbb05a81856afaeb6d967e"
+			"Rev": "846d0879b7d854e5b692227a3a4cf0a99b59166c"
 		},
 		{
 			"ImportPath": "github.com/contiv/libovsdb",

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModel.js
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModel.js
@@ -124,6 +124,59 @@ var BgpModalView = React.createClass({
 
 module.exports.BgpSummaryView = BgpSummaryView
 module.exports.BgpModalView = BgpModalView
+var EndpointSummaryView = React.createClass({
+  	render: function() {
+		var self = this
+
+		// Walk thru all objects
+		var endpointListView = self.props.endpoints.map(function(endpoint){
+			return (
+				<ModalTrigger modal={<EndpointModalView endpoint={ endpoint }/>}>
+					<tr key={ endpoint.key } className="info">
+						
+						
+					</tr>
+				</ModalTrigger>
+			);
+		});
+
+		return (
+        <div>
+			<Table hover>
+				<thead>
+					<tr>
+					
+					
+					</tr>
+				</thead>
+				<tbody>
+            		{ endpointListView }
+				</tbody>
+			</Table>
+        </div>
+    	);
+	}
+});
+
+var EndpointModalView = React.createClass({
+	render() {
+		var obj = this.props.endpoint
+	    return (
+	      <Modal {...this.props} bsStyle='primary' bsSize='large' title='Endpoint' animation={false}>
+	        <div className='modal-body' style={ {margin: '5%',} }>
+			
+			
+			</div>
+	        <div className='modal-footer'>
+				<Button onClick={this.props.onRequestHide}>Close</Button>
+	        </div>
+	      </Modal>
+	    );
+  	}
+});
+
+module.exports.EndpointSummaryView = EndpointSummaryView
+module.exports.EndpointModalView = EndpointModalView
 var EndpointGroupSummaryView = React.createClass({
   	render: function() {
 		var self = this

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.go
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.go
@@ -187,6 +187,27 @@ type BgpInspect struct {
 	Config Bgp
 }
 
+type EndpointOper struct {
+	AttachUUID       string   `json:"attachUUID,omitempty"`       //
+	ContainerID      string   `json:"containerID,omitempty"`      //
+	EndpointGroupID  int      `json:"endpointGroupId,omitempty"`  //
+	EndpointGroupKey string   `json:"endpointGroupKey,omitempty"` //
+	HomingHost       string   `json:"homingHost,omitempty"`       //
+	IntfName         string   `json:"intfName,omitempty"`         //
+	IpAddress        []string `json:"ipAddress,omitempty"`
+	Labels           string   `json:"labels,omitempty"`      //
+	MacAddress       string   `json:"macAddress,omitempty"`  //
+	Name             string   `json:"name,omitempty"`        //
+	Network          string   `json:"network,omitempty"`     //
+	ServiceName      string   `json:"serviceName,omitempty"` //
+	VtepIP           string   `json:"vtepIP,omitempty"`      //
+
+}
+
+type EndpointInspect struct {
+	Oper EndpointOper
+}
+
 type EndpointGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -519,6 +540,22 @@ func (c *ContivClient) AppProfileGet(tenantName string, appProfileName string) (
 	return &obj, nil
 }
 
+// AppProfileDelete deletes the appProfile object
+func (c *ContivClient) AppProfileDelete(tenantName string, appProfileName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + appProfileName
+	url := c.baseURL + "/api/v1/appProfiles/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting appProfile %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // AppProfileInspect gets the appProfileInspect object
 func (c *ContivClient) AppProfileInspect(tenantName string, appProfileName string) (*AppProfileInspect, error) {
 	// build key and URL
@@ -534,22 +571,6 @@ func (c *ContivClient) AppProfileInspect(tenantName string, appProfileName strin
 	}
 
 	return &obj, nil
-}
-
-// AppProfileDelete deletes the appProfile object
-func (c *ContivClient) AppProfileDelete(tenantName string, appProfileName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + appProfileName
-	url := c.baseURL + "/api/v1/appProfiles/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting appProfile %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // BgpPost posts the Bgp object
@@ -601,6 +622,22 @@ func (c *ContivClient) BgpGet(hostname string) (*Bgp, error) {
 	return &obj, nil
 }
 
+// BgpDelete deletes the Bgp object
+func (c *ContivClient) BgpDelete(hostname string) error {
+	// build key and URL
+	keyStr := hostname
+	url := c.baseURL + "/api/v1/Bgps/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting Bgp %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // BgpInspect gets the BgpInspect object
 func (c *ContivClient) BgpInspect(hostname string) (*BgpInspect, error) {
 	// build key and URL
@@ -618,20 +655,21 @@ func (c *ContivClient) BgpInspect(hostname string) (*BgpInspect, error) {
 	return &obj, nil
 }
 
-// BgpDelete deletes the Bgp object
-func (c *ContivClient) BgpDelete(hostname string) error {
+// EndpointInspect gets the endpointInspect object
+func (c *ContivClient) EndpointInspect(name string) (*EndpointInspect, error) {
 	// build key and URL
-	keyStr := hostname
-	url := c.baseURL + "/api/v1/Bgps/" + keyStr + "/"
+	keyStr := name
+	url := c.baseURL + "/api/v1/inspect/endpoints/" + keyStr + "/"
 
 	// http get the object
-	err := httpDelete(url)
+	var obj EndpointInspect
+	err := httpGet(url, &obj)
 	if err != nil {
-		log.Debugf("Error deleting Bgp %s. Err: %v", keyStr, err)
-		return err
+		log.Debugf("Error getting endpoint %+v. Err: %v", keyStr, err)
+		return nil, err
 	}
 
-	return nil
+	return &obj, nil
 }
 
 // EndpointGroupPost posts the endpointGroup object
@@ -683,6 +721,22 @@ func (c *ContivClient) EndpointGroupGet(tenantName string, groupName string) (*E
 	return &obj, nil
 }
 
+// EndpointGroupDelete deletes the endpointGroup object
+func (c *ContivClient) EndpointGroupDelete(tenantName string, groupName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + groupName
+	url := c.baseURL + "/api/v1/endpointGroups/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting endpointGroup %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // EndpointGroupInspect gets the endpointGroupInspect object
 func (c *ContivClient) EndpointGroupInspect(tenantName string, groupName string) (*EndpointGroupInspect, error) {
 	// build key and URL
@@ -698,22 +752,6 @@ func (c *ContivClient) EndpointGroupInspect(tenantName string, groupName string)
 	}
 
 	return &obj, nil
-}
-
-// EndpointGroupDelete deletes the endpointGroup object
-func (c *ContivClient) EndpointGroupDelete(tenantName string, groupName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + groupName
-	url := c.baseURL + "/api/v1/endpointGroups/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting endpointGroup %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // ExtContractsGroupPost posts the extContractsGroup object
@@ -765,6 +803,22 @@ func (c *ContivClient) ExtContractsGroupGet(tenantName string, contractsGroupNam
 	return &obj, nil
 }
 
+// ExtContractsGroupDelete deletes the extContractsGroup object
+func (c *ContivClient) ExtContractsGroupDelete(tenantName string, contractsGroupName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + contractsGroupName
+	url := c.baseURL + "/api/v1/extContractsGroups/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting extContractsGroup %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // ExtContractsGroupInspect gets the extContractsGroupInspect object
 func (c *ContivClient) ExtContractsGroupInspect(tenantName string, contractsGroupName string) (*ExtContractsGroupInspect, error) {
 	// build key and URL
@@ -780,22 +834,6 @@ func (c *ContivClient) ExtContractsGroupInspect(tenantName string, contractsGrou
 	}
 
 	return &obj, nil
-}
-
-// ExtContractsGroupDelete deletes the extContractsGroup object
-func (c *ContivClient) ExtContractsGroupDelete(tenantName string, contractsGroupName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + contractsGroupName
-	url := c.baseURL + "/api/v1/extContractsGroups/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting extContractsGroup %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // GlobalPost posts the global object
@@ -847,6 +885,22 @@ func (c *ContivClient) GlobalGet(name string) (*Global, error) {
 	return &obj, nil
 }
 
+// GlobalDelete deletes the global object
+func (c *ContivClient) GlobalDelete(name string) error {
+	// build key and URL
+	keyStr := name
+	url := c.baseURL + "/api/v1/globals/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting global %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // GlobalInspect gets the globalInspect object
 func (c *ContivClient) GlobalInspect(name string) (*GlobalInspect, error) {
 	// build key and URL
@@ -862,22 +916,6 @@ func (c *ContivClient) GlobalInspect(name string) (*GlobalInspect, error) {
 	}
 
 	return &obj, nil
-}
-
-// GlobalDelete deletes the global object
-func (c *ContivClient) GlobalDelete(name string) error {
-	// build key and URL
-	keyStr := name
-	url := c.baseURL + "/api/v1/globals/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting global %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // NetworkPost posts the network object
@@ -929,6 +967,22 @@ func (c *ContivClient) NetworkGet(tenantName string, networkName string) (*Netwo
 	return &obj, nil
 }
 
+// NetworkDelete deletes the network object
+func (c *ContivClient) NetworkDelete(tenantName string, networkName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + networkName
+	url := c.baseURL + "/api/v1/networks/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting network %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // NetworkInspect gets the networkInspect object
 func (c *ContivClient) NetworkInspect(tenantName string, networkName string) (*NetworkInspect, error) {
 	// build key and URL
@@ -944,22 +998,6 @@ func (c *ContivClient) NetworkInspect(tenantName string, networkName string) (*N
 	}
 
 	return &obj, nil
-}
-
-// NetworkDelete deletes the network object
-func (c *ContivClient) NetworkDelete(tenantName string, networkName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + networkName
-	url := c.baseURL + "/api/v1/networks/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting network %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // PolicyPost posts the policy object
@@ -1011,6 +1049,22 @@ func (c *ContivClient) PolicyGet(tenantName string, policyName string) (*Policy,
 	return &obj, nil
 }
 
+// PolicyDelete deletes the policy object
+func (c *ContivClient) PolicyDelete(tenantName string, policyName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + policyName
+	url := c.baseURL + "/api/v1/policys/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting policy %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // PolicyInspect gets the policyInspect object
 func (c *ContivClient) PolicyInspect(tenantName string, policyName string) (*PolicyInspect, error) {
 	// build key and URL
@@ -1026,22 +1080,6 @@ func (c *ContivClient) PolicyInspect(tenantName string, policyName string) (*Pol
 	}
 
 	return &obj, nil
-}
-
-// PolicyDelete deletes the policy object
-func (c *ContivClient) PolicyDelete(tenantName string, policyName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + policyName
-	url := c.baseURL + "/api/v1/policys/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting policy %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // RulePost posts the rule object
@@ -1093,6 +1131,22 @@ func (c *ContivClient) RuleGet(tenantName string, policyName string, ruleId stri
 	return &obj, nil
 }
 
+// RuleDelete deletes the rule object
+func (c *ContivClient) RuleDelete(tenantName string, policyName string, ruleId string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + policyName + ":" + ruleId
+	url := c.baseURL + "/api/v1/rules/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting rule %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // RuleInspect gets the ruleInspect object
 func (c *ContivClient) RuleInspect(tenantName string, policyName string, ruleId string) (*RuleInspect, error) {
 	// build key and URL
@@ -1108,22 +1162,6 @@ func (c *ContivClient) RuleInspect(tenantName string, policyName string, ruleId 
 	}
 
 	return &obj, nil
-}
-
-// RuleDelete deletes the rule object
-func (c *ContivClient) RuleDelete(tenantName string, policyName string, ruleId string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + policyName + ":" + ruleId
-	url := c.baseURL + "/api/v1/rules/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting rule %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // ServiceLBPost posts the serviceLB object
@@ -1175,6 +1213,22 @@ func (c *ContivClient) ServiceLBGet(tenantName string, serviceName string) (*Ser
 	return &obj, nil
 }
 
+// ServiceLBDelete deletes the serviceLB object
+func (c *ContivClient) ServiceLBDelete(tenantName string, serviceName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + serviceName
+	url := c.baseURL + "/api/v1/serviceLBs/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting serviceLB %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // ServiceLBInspect gets the serviceLBInspect object
 func (c *ContivClient) ServiceLBInspect(tenantName string, serviceName string) (*ServiceLBInspect, error) {
 	// build key and URL
@@ -1190,22 +1244,6 @@ func (c *ContivClient) ServiceLBInspect(tenantName string, serviceName string) (
 	}
 
 	return &obj, nil
-}
-
-// ServiceLBDelete deletes the serviceLB object
-func (c *ContivClient) ServiceLBDelete(tenantName string, serviceName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + serviceName
-	url := c.baseURL + "/api/v1/serviceLBs/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting serviceLB %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // TenantPost posts the tenant object
@@ -1257,6 +1295,22 @@ func (c *ContivClient) TenantGet(tenantName string) (*Tenant, error) {
 	return &obj, nil
 }
 
+// TenantDelete deletes the tenant object
+func (c *ContivClient) TenantDelete(tenantName string) error {
+	// build key and URL
+	keyStr := tenantName
+	url := c.baseURL + "/api/v1/tenants/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting tenant %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // TenantInspect gets the tenantInspect object
 func (c *ContivClient) TenantInspect(tenantName string) (*TenantInspect, error) {
 	// build key and URL
@@ -1272,22 +1326,6 @@ func (c *ContivClient) TenantInspect(tenantName string) (*TenantInspect, error) 
 	}
 
 	return &obj, nil
-}
-
-// TenantDelete deletes the tenant object
-func (c *ContivClient) TenantDelete(tenantName string) error {
-	// build key and URL
-	keyStr := tenantName
-	url := c.baseURL + "/api/v1/tenants/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting tenant %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // VolumePost posts the volume object
@@ -1339,6 +1377,22 @@ func (c *ContivClient) VolumeGet(tenantName string, volumeName string) (*Volume,
 	return &obj, nil
 }
 
+// VolumeDelete deletes the volume object
+func (c *ContivClient) VolumeDelete(tenantName string, volumeName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + volumeName
+	url := c.baseURL + "/api/v1/volumes/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting volume %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // VolumeInspect gets the volumeInspect object
 func (c *ContivClient) VolumeInspect(tenantName string, volumeName string) (*VolumeInspect, error) {
 	// build key and URL
@@ -1354,22 +1408,6 @@ func (c *ContivClient) VolumeInspect(tenantName string, volumeName string) (*Vol
 	}
 
 	return &obj, nil
-}
-
-// VolumeDelete deletes the volume object
-func (c *ContivClient) VolumeDelete(tenantName string, volumeName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + volumeName
-	url := c.baseURL + "/api/v1/volumes/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting volume %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }
 
 // VolumeProfilePost posts the volumeProfile object
@@ -1421,6 +1459,22 @@ func (c *ContivClient) VolumeProfileGet(tenantName string, volumeProfileName str
 	return &obj, nil
 }
 
+// VolumeProfileDelete deletes the volumeProfile object
+func (c *ContivClient) VolumeProfileDelete(tenantName string, volumeProfileName string) error {
+	// build key and URL
+	keyStr := tenantName + ":" + volumeProfileName
+	url := c.baseURL + "/api/v1/volumeProfiles/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting volumeProfile %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
 // VolumeProfileInspect gets the volumeProfileInspect object
 func (c *ContivClient) VolumeProfileInspect(tenantName string, volumeProfileName string) (*VolumeProfileInspect, error) {
 	// build key and URL
@@ -1436,20 +1490,4 @@ func (c *ContivClient) VolumeProfileInspect(tenantName string, volumeProfileName
 	}
 
 	return &obj, nil
-}
-
-// VolumeProfileDelete deletes the volumeProfile object
-func (c *ContivClient) VolumeProfileDelete(tenantName string, volumeProfileName string) error {
-	// build key and URL
-	keyStr := tenantName + ":" + volumeProfileName
-	url := c.baseURL + "/api/v1/volumeProfiles/" + keyStr + "/"
-
-	// http get the object
-	err := httpDelete(url)
-	if err != nil {
-		log.Debugf("Error deleting volumeProfile %s. Err: %v", keyStr, err)
-		return err
-	}
-
-	return nil
 }

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.py
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/client/contivModelClient.py
@@ -72,6 +72,7 @@ def httpGet(url):
 class objmodelClient:
 	def __init__(self, baseUrl):
 		self.baseUrl = baseUrl
+
 	# Create appProfile
 	def createAppProfile(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/appProfiles/' + obj.tenantName + ":" + obj.appProfileName  + '/'
@@ -105,6 +106,10 @@ class objmodelClient:
 	        errorExit("list AppProfile failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create Bgp
 	def createBgp(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/Bgps/' + obj.hostname  + '/'
@@ -140,6 +145,23 @@ class objmodelClient:
 	        errorExit("list Bgp failed")
 
 	    return json.loads(retData)
+
+
+
+
+
+
+	# Inspect endpoint
+	def createEndpoint(self, obj):
+	    postUrl = self.baseUrl + '/api/v1/inspect/endpoint/' + obj.name  + '/'
+
+	    retDate = urllib2.urlopen(postUrl)
+	    if retData == "Error":
+	        errorExit("list Endpoint failed")
+
+	    return json.loads(retData)
+
+
 	# Create endpointGroup
 	def createEndpointGroup(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/endpointGroups/' + obj.tenantName + ":" + obj.groupName  + '/'
@@ -175,6 +197,10 @@ class objmodelClient:
 	        errorExit("list EndpointGroup failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create extContractsGroup
 	def createExtContractsGroup(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/extContractsGroups/' + obj.tenantName + ":" + obj.contractsGroupName  + '/'
@@ -209,6 +235,10 @@ class objmodelClient:
 	        errorExit("list ExtContractsGroup failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create global
 	def createGlobal(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/globals/' + obj.name  + '/'
@@ -243,6 +273,20 @@ class objmodelClient:
 	        errorExit("list Global failed")
 
 	    return json.loads(retData)
+
+
+
+	# Inspect global
+	def createGlobal(self, obj):
+	    postUrl = self.baseUrl + '/api/v1/inspect/global/' + obj.name  + '/'
+
+	    retDate = urllib2.urlopen(postUrl)
+	    if retData == "Error":
+	        errorExit("list Global failed")
+
+	    return json.loads(retData)
+
+
 	# Create network
 	def createNetwork(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/networks/' + obj.tenantName + ":" + obj.networkName  + '/'
@@ -282,6 +326,20 @@ class objmodelClient:
 	        errorExit("list Network failed")
 
 	    return json.loads(retData)
+
+
+
+	# Inspect network
+	def createNetwork(self, obj):
+	    postUrl = self.baseUrl + '/api/v1/inspect/network/' + obj.tenantName + ":" + obj.networkName  + '/'
+
+	    retDate = urllib2.urlopen(postUrl)
+	    if retData == "Error":
+	        errorExit("list Network failed")
+
+	    return json.loads(retData)
+
+
 	# Create policy
 	def createPolicy(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/policys/' + obj.tenantName + ":" + obj.policyName  + '/'
@@ -314,6 +372,10 @@ class objmodelClient:
 	        errorExit("list Policy failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create rule
 	def createRule(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/rules/' + obj.tenantName + ":" + obj.policyName + ":" + obj.ruleId  + '/'
@@ -358,6 +420,10 @@ class objmodelClient:
 	        errorExit("list Rule failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create serviceLB
 	def createServiceLB(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/serviceLBs/' + obj.tenantName + ":" + obj.serviceName  + '/'
@@ -394,6 +460,10 @@ class objmodelClient:
 	        errorExit("list ServiceLB failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create tenant
 	def createTenant(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/tenants/' + obj.tenantName  + '/'
@@ -426,6 +496,10 @@ class objmodelClient:
 	        errorExit("list Tenant failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create volume
 	def createVolume(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/volumes/' + obj.tenantName + ":" + obj.volumeName  + '/'
@@ -462,6 +536,10 @@ class objmodelClient:
 	        errorExit("list Volume failed")
 
 	    return json.loads(retData)
+
+
+
+
 	# Create volumeProfile
 	def createVolumeProfile(self, obj):
 	    postUrl = self.baseUrl + '/api/v1/volumeProfiles/' + obj.tenantName + ":" + obj.volumeProfileName  + '/'
@@ -498,3 +576,5 @@ class objmodelClient:
 	        errorExit("list VolumeProfile failed")
 
 	    return json.loads(retData)
+
+

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/contivModel.go
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/contivModel.go
@@ -15,6 +15,7 @@ import (
 )
 
 type HttpApiFunc func(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error)
+
 type AppProfile struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -39,6 +40,7 @@ type AppProfileLinks struct {
 type AppProfileInspect struct {
 	Config AppProfile
 }
+
 type Bgp struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -54,6 +56,32 @@ type Bgp struct {
 type BgpInspect struct {
 	Config Bgp
 }
+
+type EndpointOper struct {
+
+	// oper object key (present for oper only objects)
+	Key string `json:"key,omitempty"`
+
+	AttachUUID       string   `json:"attachUUID,omitempty"`       //
+	ContainerID      string   `json:"containerID,omitempty"`      //
+	EndpointGroupID  int      `json:"endpointGroupId,omitempty"`  //
+	EndpointGroupKey string   `json:"endpointGroupKey,omitempty"` //
+	HomingHost       string   `json:"homingHost,omitempty"`       //
+	IntfName         string   `json:"intfName,omitempty"`         //
+	IpAddress        []string `json:"ipAddress,omitempty"`
+	Labels           string   `json:"labels,omitempty"`      //
+	MacAddress       string   `json:"macAddress,omitempty"`  //
+	Name             string   `json:"name,omitempty"`        //
+	Network          string   `json:"network,omitempty"`     //
+	ServiceName      string   `json:"serviceName,omitempty"` //
+	VtepIP           string   `json:"vtepIP,omitempty"`      //
+
+}
+
+type EndpointInspect struct {
+	Oper EndpointOper
+}
+
 type EndpointGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -84,6 +112,7 @@ type EndpointGroupLinks struct {
 type EndpointGroupInspect struct {
 	Config EndpointGroup
 }
+
 type ExtContractsGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -104,6 +133,7 @@ type ExtContractsGroupLinkSets struct {
 type ExtContractsGroupInspect struct {
 	Config ExtContractsGroup
 }
+
 type Global struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -129,6 +159,7 @@ type GlobalInspect struct {
 
 	Oper GlobalOper
 }
+
 type Network struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -173,6 +204,7 @@ type NetworkInspect struct {
 
 	Oper NetworkOper
 }
+
 type Policy struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -197,6 +229,7 @@ type PolicyLinks struct {
 type PolicyInspect struct {
 	Config Policy
 }
+
 type Rule struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -227,6 +260,7 @@ type RuleLinkSets struct {
 type RuleInspect struct {
 	Config Rule
 }
+
 type ServiceLB struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -249,6 +283,7 @@ type ServiceLBLinks struct {
 type ServiceLBInspect struct {
 	Config ServiceLB
 }
+
 type Tenant struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -273,6 +308,7 @@ type TenantLinkSets struct {
 type TenantInspect struct {
 	Config Tenant
 }
+
 type Volume struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -300,6 +336,7 @@ type VolumeLinks struct {
 type VolumeInspect struct {
 	Config Volume
 }
+
 type VolumeProfile struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
@@ -328,8 +365,9 @@ type VolumeProfileInspect struct {
 	Config VolumeProfile
 }
 type Collections struct {
-	appProfiles        map[string]*AppProfile
-	Bgps               map[string]*Bgp
+	appProfiles map[string]*AppProfile
+	Bgps        map[string]*Bgp
+
 	endpointGroups     map[string]*EndpointGroup
 	extContractsGroups map[string]*ExtContractsGroup
 	globals            map[string]*Global
@@ -356,6 +394,10 @@ type BgpCallbacks interface {
 	BgpDelete(Bgp *Bgp) error
 }
 
+type EndpointCallbacks interface {
+	EndpointGetOper(endpoint *EndpointInspect) error
+}
+
 type EndpointGroupCallbacks interface {
 	EndpointGroupCreate(endpointGroup *EndpointGroup) error
 	EndpointGroupUpdate(endpointGroup, params *EndpointGroup) error
@@ -370,6 +412,7 @@ type ExtContractsGroupCallbacks interface {
 
 type GlobalCallbacks interface {
 	GlobalGetOper(global *GlobalInspect) error
+
 	GlobalCreate(global *Global) error
 	GlobalUpdate(global, params *Global) error
 	GlobalDelete(global *Global) error
@@ -377,6 +420,7 @@ type GlobalCallbacks interface {
 
 type NetworkCallbacks interface {
 	NetworkGetOper(network *NetworkInspect) error
+
 	NetworkCreate(network *Network) error
 	NetworkUpdate(network, params *Network) error
 	NetworkDelete(network *Network) error
@@ -421,6 +465,7 @@ type VolumeProfileCallbacks interface {
 type CallbackHandlers struct {
 	AppProfileCb        AppProfileCallbacks
 	BgpCb               BgpCallbacks
+	EndpointCb          EndpointCallbacks
 	EndpointGroupCb     EndpointGroupCallbacks
 	ExtContractsGroupCb ExtContractsGroupCallbacks
 	GlobalCb            GlobalCallbacks
@@ -438,6 +483,7 @@ var objCallbackHandler CallbackHandlers
 func Init() {
 	collections.appProfiles = make(map[string]*AppProfile)
 	collections.Bgps = make(map[string]*Bgp)
+
 	collections.endpointGroups = make(map[string]*EndpointGroup)
 	collections.extContractsGroups = make(map[string]*ExtContractsGroup)
 	collections.globals = make(map[string]*Global)
@@ -451,6 +497,7 @@ func Init() {
 
 	restoreAppProfile()
 	restoreBgp()
+
 	restoreEndpointGroup()
 	restoreExtContractsGroup()
 	restoreGlobal()
@@ -470,6 +517,10 @@ func RegisterAppProfileCallbacks(handler AppProfileCallbacks) {
 
 func RegisterBgpCallbacks(handler BgpCallbacks) {
 	objCallbackHandler.BgpCb = handler
+}
+
+func RegisterEndpointCallbacks(handler EndpointCallbacks) {
+	objCallbackHandler.EndpointCb = handler
 }
 
 func RegisterEndpointGroupCallbacks(handler EndpointGroupCallbacks) {
@@ -554,147 +605,180 @@ func AddRoutes(router *mux.Router) {
 	// Register appProfile
 	route = "/api/v1/appProfiles/{key}/"
 	listRoute = "/api/v1/appProfiles/"
-	inspectRoute = "/api/v1/inspect/appProfiles/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListAppProfiles))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetAppProfile))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateAppProfile))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateAppProfile))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteAppProfile))
+
+	inspectRoute = "/api/v1/inspect/appProfiles/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectAppProfile))
 
 	// Register Bgp
 	route = "/api/v1/Bgps/{key}/"
 	listRoute = "/api/v1/Bgps/"
-	inspectRoute = "/api/v1/inspect/Bgps/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListBgps))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetBgp))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateBgp))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateBgp))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteBgp))
+
+	inspectRoute = "/api/v1/inspect/Bgps/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectBgp))
+
+	inspectRoute = "/api/v1/inspect/endpoints/{key}/"
+	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectEndpoint))
 
 	// Register endpointGroup
 	route = "/api/v1/endpointGroups/{key}/"
 	listRoute = "/api/v1/endpointGroups/"
-	inspectRoute = "/api/v1/inspect/endpointGroups/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListEndpointGroups))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetEndpointGroup))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateEndpointGroup))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateEndpointGroup))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteEndpointGroup))
+
+	inspectRoute = "/api/v1/inspect/endpointGroups/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectEndpointGroup))
 
 	// Register extContractsGroup
 	route = "/api/v1/extContractsGroups/{key}/"
 	listRoute = "/api/v1/extContractsGroups/"
-	inspectRoute = "/api/v1/inspect/extContractsGroups/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListExtContractsGroups))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetExtContractsGroup))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateExtContractsGroup))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateExtContractsGroup))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteExtContractsGroup))
+
+	inspectRoute = "/api/v1/inspect/extContractsGroups/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectExtContractsGroup))
 
 	// Register global
 	route = "/api/v1/globals/{key}/"
 	listRoute = "/api/v1/globals/"
-	inspectRoute = "/api/v1/inspect/globals/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListGlobals))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetGlobal))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateGlobal))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateGlobal))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteGlobal))
+
+	inspectRoute = "/api/v1/inspect/globals/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectGlobal))
 
 	// Register network
 	route = "/api/v1/networks/{key}/"
 	listRoute = "/api/v1/networks/"
-	inspectRoute = "/api/v1/inspect/networks/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListNetworks))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetNetwork))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateNetwork))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateNetwork))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteNetwork))
+
+	inspectRoute = "/api/v1/inspect/networks/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectNetwork))
 
 	// Register policy
 	route = "/api/v1/policys/{key}/"
 	listRoute = "/api/v1/policys/"
-	inspectRoute = "/api/v1/inspect/policys/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListPolicys))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetPolicy))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreatePolicy))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreatePolicy))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeletePolicy))
+
+	inspectRoute = "/api/v1/inspect/policys/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectPolicy))
 
 	// Register rule
 	route = "/api/v1/rules/{key}/"
 	listRoute = "/api/v1/rules/"
-	inspectRoute = "/api/v1/inspect/rules/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListRules))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetRule))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateRule))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateRule))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteRule))
+
+	inspectRoute = "/api/v1/inspect/rules/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectRule))
 
 	// Register serviceLB
 	route = "/api/v1/serviceLBs/{key}/"
 	listRoute = "/api/v1/serviceLBs/"
-	inspectRoute = "/api/v1/inspect/serviceLBs/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListServiceLBs))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetServiceLB))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateServiceLB))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateServiceLB))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteServiceLB))
+
+	inspectRoute = "/api/v1/inspect/serviceLBs/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectServiceLB))
 
 	// Register tenant
 	route = "/api/v1/tenants/{key}/"
 	listRoute = "/api/v1/tenants/"
-	inspectRoute = "/api/v1/inspect/tenants/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListTenants))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetTenant))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateTenant))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateTenant))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteTenant))
+
+	inspectRoute = "/api/v1/inspect/tenants/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectTenant))
 
 	// Register volume
 	route = "/api/v1/volumes/{key}/"
 	listRoute = "/api/v1/volumes/"
-	inspectRoute = "/api/v1/inspect/volumes/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListVolumes))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetVolume))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateVolume))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateVolume))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteVolume))
+
+	inspectRoute = "/api/v1/inspect/volumes/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectVolume))
 
 	// Register volumeProfile
 	route = "/api/v1/volumeProfiles/{key}/"
 	listRoute = "/api/v1/volumeProfiles/"
-	inspectRoute = "/api/v1/inspect/volumeProfiles/{key}/"
 	log.Infof("Registering %s", route)
 	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListVolumeProfiles))
 	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetVolumeProfile))
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateVolumeProfile))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateVolumeProfile))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteVolumeProfile))
+
+	inspectRoute = "/api/v1/inspect/volumeProfiles/{key}/"
 	router.Path(inspectRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpInspectVolumeProfile))
 
+}
+
+// GET Oper REST call
+func httpInspectAppProfile(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj AppProfileInspect
+	log.Debugf("Received httpInspectAppProfile: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.appProfiles[key]
+	if objConfig == nil {
+		log.Errorf("appProfile %s not found", key)
+		return nil, errors.New("appProfile not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
 }
 
 // LIST REST call
@@ -724,24 +808,6 @@ func httpGetAppProfile(w http.ResponseWriter, r *http.Request, vars map[string]s
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectAppProfile(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj AppProfileInspect
-	log.Debugf("Received httpInspectAppProfile: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.appProfiles[key]
-	if objConfig == nil {
-		log.Errorf("appProfile %s not found", key)
-		return nil, errors.New("appProfile not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -972,6 +1038,24 @@ func ValidateAppProfile(obj *AppProfile) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectBgp(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj BgpInspect
+	log.Debugf("Received httpInspectBgp: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.Bgps[key]
+	if objConfig == nil {
+		log.Errorf("Bgp %s not found", key)
+		return nil, errors.New("Bgp not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListBgps(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListBgps: %+v", vars)
@@ -999,24 +1083,6 @@ func httpGetBgp(w http.ResponseWriter, r *http.Request, vars map[string]string) 
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectBgp(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj BgpInspect
-	log.Debugf("Received httpInspectBgp: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.Bgps[key]
-	if objConfig == nil {
-		log.Errorf("Bgp %s not found", key)
-		return nil, errors.New("Bgp not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -1264,6 +1330,58 @@ func ValidateBgp(obj *Bgp) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectEndpoint(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj EndpointInspect
+	log.Debugf("Received httpInspectEndpoint: %+v", vars)
+
+	obj.Oper.Key = vars["key"]
+
+	if err := GetOperEndpoint(&obj); err != nil {
+		log.Errorf("GetEndpoint error for: %+v. Err: %v", obj, err)
+		return nil, err
+	}
+
+	// Return the obj
+	return &obj, nil
+}
+
+// Get a endpointOper object
+func GetOperEndpoint(obj *EndpointInspect) error {
+	// Check if we handle this object
+	if objCallbackHandler.EndpointCb == nil {
+		log.Errorf("No callback registered for endpoint object")
+		return errors.New("Invalid object type")
+	}
+
+	// Perform callback
+	err := objCallbackHandler.EndpointCb.EndpointGetOper(obj)
+	if err != nil {
+		log.Errorf("EndpointDelete retruned error for: %+v. Err: %v", obj, err)
+		return err
+	}
+
+	return nil
+}
+
+// GET Oper REST call
+func httpInspectEndpointGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj EndpointGroupInspect
+	log.Debugf("Received httpInspectEndpointGroup: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.endpointGroups[key]
+	if objConfig == nil {
+		log.Errorf("endpointGroup %s not found", key)
+		return nil, errors.New("endpointGroup not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListEndpointGroups(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListEndpointGroups: %+v", vars)
@@ -1291,24 +1409,6 @@ func httpGetEndpointGroup(w http.ResponseWriter, r *http.Request, vars map[strin
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectEndpointGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj EndpointGroupInspect
-	log.Debugf("Received httpInspectEndpointGroup: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.endpointGroups[key]
-	if objConfig == nil {
-		log.Errorf("endpointGroup %s not found", key)
-		return nil, errors.New("endpointGroup not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -1548,6 +1648,24 @@ func ValidateEndpointGroup(obj *EndpointGroup) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectExtContractsGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj ExtContractsGroupInspect
+	log.Debugf("Received httpInspectExtContractsGroup: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.extContractsGroups[key]
+	if objConfig == nil {
+		log.Errorf("extContractsGroup %s not found", key)
+		return nil, errors.New("extContractsGroup not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListExtContractsGroups(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListExtContractsGroups: %+v", vars)
@@ -1575,24 +1693,6 @@ func httpGetExtContractsGroup(w http.ResponseWriter, r *http.Request, vars map[s
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectExtContractsGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj ExtContractsGroupInspect
-	log.Debugf("Received httpInspectExtContractsGroup: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.extContractsGroups[key]
-	if objConfig == nil {
-		log.Errorf("extContractsGroup %s not found", key)
-		return nil, errors.New("extContractsGroup not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -1823,35 +1923,6 @@ func ValidateExtContractsGroup(obj *ExtContractsGroup) error {
 	return nil
 }
 
-// LIST REST call
-func httpListGlobals(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	log.Debugf("Received httpListGlobals: %+v", vars)
-
-	list := make([]*Global, 0)
-	for _, obj := range collections.globals {
-		list = append(list, obj)
-	}
-
-	// Return the list
-	return list, nil
-}
-
-// GET REST call
-func httpGetGlobal(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	log.Debugf("Received httpGetGlobal: %+v", vars)
-
-	key := vars["key"]
-
-	obj := collections.globals[key]
-	if obj == nil {
-		log.Errorf("global %s not found", key)
-		return nil, errors.New("global not found")
-	}
-
-	// Return the obj
-	return obj, nil
-}
-
 // GET Oper REST call
 func httpInspectGlobal(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	var obj GlobalInspect
@@ -1891,6 +1962,35 @@ func GetOperGlobal(obj *GlobalInspect) error {
 	}
 
 	return nil
+}
+
+// LIST REST call
+func httpListGlobals(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpListGlobals: %+v", vars)
+
+	list := make([]*Global, 0)
+	for _, obj := range collections.globals {
+		list = append(list, obj)
+	}
+
+	// Return the list
+	return list, nil
+}
+
+// GET REST call
+func httpGetGlobal(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpGetGlobal: %+v", vars)
+
+	key := vars["key"]
+
+	obj := collections.globals[key]
+	if obj == nil {
+		log.Errorf("global %s not found", key)
+		return nil, errors.New("global not found")
+	}
+
+	// Return the obj
+	return obj, nil
 }
 
 // CREATE REST call
@@ -2131,35 +2231,6 @@ func ValidateGlobal(obj *Global) error {
 	return nil
 }
 
-// LIST REST call
-func httpListNetworks(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	log.Debugf("Received httpListNetworks: %+v", vars)
-
-	list := make([]*Network, 0)
-	for _, obj := range collections.networks {
-		list = append(list, obj)
-	}
-
-	// Return the list
-	return list, nil
-}
-
-// GET REST call
-func httpGetNetwork(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	log.Debugf("Received httpGetNetwork: %+v", vars)
-
-	key := vars["key"]
-
-	obj := collections.networks[key]
-	if obj == nil {
-		log.Errorf("network %s not found", key)
-		return nil, errors.New("network not found")
-	}
-
-	// Return the obj
-	return obj, nil
-}
-
 // GET Oper REST call
 func httpInspectNetwork(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	var obj NetworkInspect
@@ -2199,6 +2270,35 @@ func GetOperNetwork(obj *NetworkInspect) error {
 	}
 
 	return nil
+}
+
+// LIST REST call
+func httpListNetworks(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpListNetworks: %+v", vars)
+
+	list := make([]*Network, 0)
+	for _, obj := range collections.networks {
+		list = append(list, obj)
+	}
+
+	// Return the list
+	return list, nil
+}
+
+// GET REST call
+func httpGetNetwork(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpGetNetwork: %+v", vars)
+
+	key := vars["key"]
+
+	obj := collections.networks[key]
+	if obj == nil {
+		log.Errorf("network %s not found", key)
+		return nil, errors.New("network not found")
+	}
+
+	// Return the obj
+	return obj, nil
 }
 
 // CREATE REST call
@@ -2467,6 +2567,24 @@ func ValidateNetwork(obj *Network) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectPolicy(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj PolicyInspect
+	log.Debugf("Received httpInspectPolicy: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.policys[key]
+	if objConfig == nil {
+		log.Errorf("policy %s not found", key)
+		return nil, errors.New("policy not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListPolicys(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListPolicys: %+v", vars)
@@ -2494,24 +2612,6 @@ func httpGetPolicy(w http.ResponseWriter, r *http.Request, vars map[string]strin
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectPolicy(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj PolicyInspect
-	log.Debugf("Received httpInspectPolicy: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.policys[key]
-	if objConfig == nil {
-		log.Errorf("policy %s not found", key)
-		return nil, errors.New("policy not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -2742,6 +2842,24 @@ func ValidatePolicy(obj *Policy) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectRule(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj RuleInspect
+	log.Debugf("Received httpInspectRule: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.rules[key]
+	if objConfig == nil {
+		log.Errorf("rule %s not found", key)
+		return nil, errors.New("rule not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListRules(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListRules: %+v", vars)
@@ -2769,24 +2887,6 @@ func httpGetRule(w http.ResponseWriter, r *http.Request, vars map[string]string)
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectRule(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj RuleInspect
-	log.Debugf("Received httpInspectRule: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.rules[key]
-	if objConfig == nil {
-		log.Errorf("rule %s not found", key)
-		return nil, errors.New("rule not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -3103,6 +3203,24 @@ func ValidateRule(obj *Rule) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectServiceLB(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj ServiceLBInspect
+	log.Debugf("Received httpInspectServiceLB: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.serviceLBs[key]
+	if objConfig == nil {
+		log.Errorf("serviceLB %s not found", key)
+		return nil, errors.New("serviceLB not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListServiceLBs(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListServiceLBs: %+v", vars)
@@ -3130,24 +3248,6 @@ func httpGetServiceLB(w http.ResponseWriter, r *http.Request, vars map[string]st
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectServiceLB(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj ServiceLBInspect
-	log.Debugf("Received httpInspectServiceLB: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.serviceLBs[key]
-	if objConfig == nil {
-		log.Errorf("serviceLB %s not found", key)
-		return nil, errors.New("serviceLB not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -3396,6 +3496,24 @@ func ValidateServiceLB(obj *ServiceLB) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectTenant(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj TenantInspect
+	log.Debugf("Received httpInspectTenant: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.tenants[key]
+	if objConfig == nil {
+		log.Errorf("tenant %s not found", key)
+		return nil, errors.New("tenant not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListTenants(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListTenants: %+v", vars)
@@ -3423,24 +3541,6 @@ func httpGetTenant(w http.ResponseWriter, r *http.Request, vars map[string]strin
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectTenant(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj TenantInspect
-	log.Debugf("Received httpInspectTenant: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.tenants[key]
-	if objConfig == nil {
-		log.Errorf("tenant %s not found", key)
-		return nil, errors.New("tenant not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -3671,6 +3771,24 @@ func ValidateTenant(obj *Tenant) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectVolume(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj VolumeInspect
+	log.Debugf("Received httpInspectVolume: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.volumes[key]
+	if objConfig == nil {
+		log.Errorf("volume %s not found", key)
+		return nil, errors.New("volume not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListVolumes(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListVolumes: %+v", vars)
@@ -3698,24 +3816,6 @@ func httpGetVolume(w http.ResponseWriter, r *http.Request, vars map[string]strin
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectVolume(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj VolumeInspect
-	log.Debugf("Received httpInspectVolume: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.volumes[key]
-	if objConfig == nil {
-		log.Errorf("volume %s not found", key)
-		return nil, errors.New("volume not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call
@@ -3928,6 +4028,24 @@ func ValidateVolume(obj *Volume) error {
 	return nil
 }
 
+// GET Oper REST call
+func httpInspectVolumeProfile(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var obj VolumeProfileInspect
+	log.Debugf("Received httpInspectVolumeProfile: %+v", vars)
+
+	key := vars["key"]
+
+	objConfig := collections.volumeProfiles[key]
+	if objConfig == nil {
+		log.Errorf("volumeProfile %s not found", key)
+		return nil, errors.New("volumeProfile not found")
+	}
+	obj.Config = *objConfig
+
+	// Return the obj
+	return &obj, nil
+}
+
 // LIST REST call
 func httpListVolumeProfiles(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
 	log.Debugf("Received httpListVolumeProfiles: %+v", vars)
@@ -3955,24 +4073,6 @@ func httpGetVolumeProfile(w http.ResponseWriter, r *http.Request, vars map[strin
 
 	// Return the obj
 	return obj, nil
-}
-
-// GET Oper REST call
-func httpInspectVolumeProfile(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
-	var obj VolumeProfileInspect
-	log.Debugf("Received httpInspectVolumeProfile: %+v", vars)
-
-	key := vars["key"]
-
-	objConfig := collections.volumeProfiles[key]
-	if objConfig == nil {
-		log.Errorf("volumeProfile %s not found", key)
-		return nil, errors.New("volumeProfile not found")
-	}
-	obj.Config = *objConfig
-
-	// Return the obj
-	return &obj, nil
 }
 
 // CREATE REST call

--- a/Godeps/_workspace/src/github.com/contiv/contivmodel/endpoint.json
+++ b/Godeps/_workspace/src/github.com/contiv/contivmodel/endpoint.json
@@ -1,0 +1,56 @@
+{
+	"name": "contivModel",
+	"objects": [
+		{
+			"name": "endpoint",
+			"version": "v1",
+			"type": "object",
+			"key": [ "name" ],
+			"operProperties": {
+				"network": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"serviceName": {
+					"type": "string"
+				},
+				"endpointGroupId": {
+					"type": "int"
+				},
+				"endpointGroupKey": {
+					"type": "string"
+				},
+				"endpointGroupKey": {
+					"type": "string"
+				},
+				"attachUUID": {
+					"type": "string"
+				},
+				"ipAddress": {
+					"type": "array",
+					"items": "string"
+				},
+				"macAddress": {
+					"type": "string"
+				},
+				"homingHost": {
+					"type": "string"
+				},
+				"intfName": {
+					"type": "string"
+				},
+				"vtepIP": {
+					"type": "string"
+				},
+				"labels": {
+					"type": "string"
+				},
+				"containerID": {
+					"type": "string"
+				}
+			}
+		}
+	]
+}

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -81,6 +81,20 @@ var Commands = []cli.Command{
 		},
 	},
 	{
+		Name:    "endpoint",
+		Aliases: []string{"ep"},
+		Usage:   "Endpoint Inspection",
+		Subcommands: []cli.Command{
+			{
+				Name:      "inspect",
+				Usage:     "Inspect an Endpoint",
+				ArgsUsage: "[epid]",
+				Flags:     []cli.Flag{jsonFlag},
+				Action:    inspectEndpoint,
+			},
+		},
+	},
+	{
 		Name:    "network",
 		Aliases: []string{"net"},
 		Usage:   "Network manipulation tools",

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -417,6 +417,21 @@ func listTenants(ctx *cli.Context) {
 	}
 }
 
+func inspectEndpoint(ctx *cli.Context) {
+	argCheck(1, ctx)
+
+	epid := ctx.Args()[0]
+
+	logrus.Infof("Inspecting endpoint: %s", epid)
+
+	net, err := getClient(ctx).EndpointInspect(epid)
+	errCheck(ctx, err)
+
+	content, err := json.MarshalIndent(net, "", "  ")
+	os.Stdout.Write(content)
+	os.Stdout.WriteString("\n")
+}
+
 func createEndpointGroup(ctx *cli.Context) {
 	argCheck(2, ctx)
 


### PR DESCRIPTION
vendor in newer contivmodel
add oper object for an endpoint (show ip allocation, etc.)

```
[vagrant@netplugin-node1 netplugin]$ docker run -itd --net=junk --label=app=newapp alpine /bin/sh
efb4e447c3621169ad010558eeda474776ab62f16d41bc148ca8ae79d036fb4d

[vagrant@netplugin-node1 netplugin]$ netctl endpoint inspect efb4e
INFO[0000] Inspecting endpoint: efb4e                   
{
  "Oper": {
    "containerID": "efb4e447c3621169ad010558eeda474776ab62f16d41bc148ca8ae79d036fb4d",
    "homingHost": "netplugin-node1",
    "ipAddress": [
      "10.1.1.3",
      ""
    ],
    "labels": "map[app:newapp]",
    "macAddress": "02:02:0a:01:01:03",
    "name": "8c7e901c72dbe1eb2be496ed3727daf0de6008d88ac083b996784589cf059f2e",
    "network": "junk.default"
  }
}
```