### PR TITLE
Incorporate review comment for CLI

### DIFF
--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -51,13 +51,13 @@ var Commands = []cli.Command{
 				ArgsUsage: "[network] [group]",
 				Flags: []cli.Flag{
 					tenantFlag,
-					cli.StringFlag{
+					cli.StringSliceFlag{
 						Name:  "policy, p",
-						Usage: "Policy List (separated by commas)",
+						Usage: "Policy",
 					},
-					cli.StringFlag{
-						Name:  "external-contracts, e",
-						Usage: "External contracts(separated by commas)",
+					cli.StringSliceFlag{
+						Name:  "external-contract, e",
+						Usage: "External contract",
 					},
 				},
 				Action: createEndpointGroup,
@@ -291,9 +291,9 @@ var Commands = []cli.Command{
 						Name:  "provided, p",
 						Usage: "External contracts type - provided",
 					},
-					cli.StringFlag{
-						Name:  "contracts, a",
-						Usage: "Contracts (separated by commas)",
+					cli.StringSliceFlag{
+						Name:  "contract, a",
+						Usage: "Contract",
 					},
 				},
 				Action: createExternalContracts,

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -396,15 +396,9 @@ func createEndpointGroup(ctx *cli.Context) {
 	network := ctx.Args()[0]
 	group := ctx.Args()[1]
 
-	policies := strings.Split(ctx.String("policy"), ",")
-	if ctx.String("policy") == "" {
-		policies = []string{}
-	}
+	policies := ctx.StringSlice("policy")
 
-	extContractsGrps := strings.Split(ctx.String("external-contracts"), ",")
-	if ctx.String("external-contracts") == "" {
-		extContractsGrps = []string{}
-	}
+	extContractsGrps := ctx.StringSlice("external-contract")
 
 	errCheck(ctx, getClient(ctx).EndpointGroupPost(&contivClient.EndpointGroup{
 		TenantName:       tenant,
@@ -865,8 +859,8 @@ func createExternalContracts(ctx *cli.Context) {
 
 	tenant := ctx.String("tenant")
 
-	contracts := strings.Split(ctx.String("contracts"), ",")
-	if ctx.String("contracts") == "" {
+	contracts := ctx.StringSlice("contracts")
+	if len(contracts) == 0 {
 		errExit(ctx, exitHelp, "Contracts not provided", false)
 	}
 


### PR DESCRIPTION
Incorporating Sukhesh's review comment.
The contracts are not comma separated any more. Each contract is specified individually. Similarly, the way the policies and external contracts are specified is also changed.
Example:

netctl external-contracts create -t THIRSTY -p -a "uni/tn-common/brc-default" -a "uni/tn-common/brc-icmp-contract" prov-grp-1

netctl group create -p test-policy -t THIRSTY -e cons-grp-1 -e prov-grp-1 THIRSTY-net coconutwater