### PR TITLE
resolve http/https proxy conflict between host and vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -136,7 +136,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                          virtualbox__intnet: "contiv_blue"
         quagga1.vm.provision "shell" do |s|
           s.inline = provision_bird
-          s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+          s.args = [ENV["HTTP_PROXY"] || "", ENV["HTTPS_PROXY"] || ""]
         end
       end
       config.vm.define "quagga2" do |quagga2|
@@ -156,7 +156,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         quagga2.vm.provision "shell" do |s|
           s.inline = provision_bird
-          s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+          s.args = [ENV["HTTP_PROXY"] || "", ENV["HTTPS_PROXY"] || ""]
         end
       end
     end
@@ -225,7 +225,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             end
             node.vm.provision "shell" do |s|
                 s.inline = provision_common_once
-                s.args = [node_name, node_addr, cluster_ip_nodes, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["USE_RELEASE"] || "", ENV["CONTIV_CLUSTER_STORE"] || "etcd://localhost:2379", ENV["CONTIV_DOCKER_VERSION"] || "", ENV['CONTIV_NODE_OS'] || "", *ENV['CONTIV_ENV']]
+                s.args = [node_name, node_addr, cluster_ip_nodes, ENV["HTTP_PROXY"] || "", ENV["HTTPS_PROXY"] || "", ENV["USE_RELEASE"] || "", ENV["CONTIV_CLUSTER_STORE"] || "etcd://localhost:2379", ENV["CONTIV_DOCKER_VERSION"] || "", ENV['CONTIV_NODE_OS'] || "", *ENV['CONTIV_ENV']]
             end
             if ENV['CONTIV_L3'] then
                 node.vm.provision "shell" do |s|


### PR DESCRIPTION
I'd started VM demo cluster for testing with proxy settings. 

To get free from the GFW(mainly for download vagrant box from atlas.hashicorp.com),  set http proxy on my host: `export http_proxy=http://127.0.0.1:8787 && export https_proxy=$http_proxy`.

Unfortunately, my vm cant visit golang.org, then also set http proxy in Makefile(line78): `http_proxy=http://10.0.2.2:8787 https_proxy=http://10.0.2.2:8787 vagrant up`. VMs use NAT network, so http proxy to virtual router(with IP 10.0.2.2). Then, run `make demo` and host proxy confict with vm proxy settings.
