### PR TITLE
Resolving issue 486

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,6 @@ else
 start: update
 	CONTIV_NODE_OS=${CONTIV_NODE_OS} vagrant up
 endif
-system-test-start:
-	CONTIV_NODES=3 vagrant up
 
 #kubernetes demo targets
 k8s-cluster:
@@ -140,7 +138,7 @@ unit-test: stop clean build
 ubuntu-tests:
 	CONTIV_NODE_OS=ubuntu make clean build unit-test system-test stop
 
-system-test:system-test-start
+system-test:start
 	go test -v -timeout 240m ./systemtests -check.v -check.f "00SSH|Basic|Network|Policy|TestTrigger|ACIM"
 
 l3-test:

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ else
 start: update
 	CONTIV_NODE_OS=${CONTIV_NODE_OS} vagrant up
 endif
+system-test-start:
+	CONTIV_NODES=3 vagrant up
 
 #kubernetes demo targets
 k8s-cluster:
@@ -138,7 +140,7 @@ unit-test: stop clean build
 ubuntu-tests:
 	CONTIV_NODE_OS=ubuntu make clean build unit-test system-test stop
 
-system-test:start
+system-test:system-test-start
 	go test -v -timeout 240m ./systemtests -check.v -check.f "00SSH|Basic|Network|Policy|TestTrigger|ACIM"
 
 l3-test:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -118,7 +118,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
     end
 
-    num_nodes = 2
+    num_nodes = 3
     if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then
         num_nodes = ENV['CONTIV_NODES'].to_i
     end


### PR DESCRIPTION
This PR is to take care of Issue#486. By default 3 nodes should be running whenever we are running system-tests.
make demo, make start should be working as it is on 2 nodes before.