### PR TITLE
fix host interface name as the first argument to avoid failure.

### DIFF
--- a/drivers/ovsSwitch.go
+++ b/drivers/ovsSwitch.go
@@ -701,7 +701,7 @@ func (sw *OvsSwitch) DelHostPort(intfName string, isHostNS bool) error {
 			return err
 		}
 	} else {
-		deleteVethPair(intfName, ovsPortName)
+		deleteVethPair(ovsPortName, intfName)
 	}
 
 	return nil


### PR DESCRIPTION
This fixes  error messages observed while deleting interface from host bridge.
Signed-off-by: Ranjith <rchirakk@gmail.com>