### PR TITLE
minor makefile change to destroy 3 vms by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ ifdef NET_CONTAINER_BUILD
 stop:
 else
 stop:
-	CONTIV_NODES=$${CONTIV_NODES:-2} vagrant destroy -f
+	CONTIV_NODES=$${CONTIV_NODES:-3} vagrant destroy -f
 endif
 
 demo:

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -125,8 +125,8 @@ Vagrant.configure(2) do |config|
                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
            end
 	else
-	    c.vm.box = "contiv/centos-k8"
-  	    c.vm.box_version = "0.0.0"
+	    c.vm.box = "contiv/k8s-centos"
+  	    c.vm.box_version = "0.0.6"
             c.vm.provision "shell" do |s|
                 s.inline = provision_master
                 s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]


### PR DESCRIPTION
observed make build was bringing up 3vms and make stop was destroying only 2. This would cause etcd issues. 
