### PR TITLE
Inspect Support for policy and Tenant

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -54,11 +54,11 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel",
-			"Rev": "86366e2de6951a0633971256b9df6df67b2a8789"
+			"Rev": "1d3e7e88302d043ac583fbf95efc8c126d5c5609"
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel/client",
-			"Rev": "86366e2de6951a0633971256b9df6df67b2a8789"
+			"Rev": "1d3e7e88302d043ac583fbf95efc8c126d5c5609"
 		},
 		{
 			"ImportPath": "github.com/contiv/libovsdb",

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -249,6 +249,13 @@ var Commands = []cli.Command{
 				ArgsUsage: "[tenant]",
 				Action:    createTenant,
 			},
+			{
+				Name:      "inspect",
+				Usage:     "Inspect a tenant",
+				ArgsUsage: "[tenant]",
+				Flags:     []cli.Flag{jsonFlag},
+				Action:    inspectTenant,
+			},
 		},
 	},
 	{
@@ -277,6 +284,13 @@ var Commands = []cli.Command{
 				ArgsUsage: " ",
 				Flags:     []cli.Flag{tenantFlag, allFlag, jsonFlag, quietFlag},
 				Action:    listPolicies,
+			},
+			{
+				Name:      "inspect",
+				Usage:     "Inspect a policy",
+				ArgsUsage: "[policy]",
+				Flags:     []cli.Flag{tenantFlag},
+				Action:    inspectPolicy,
 			},
 			{
 				Name:      "rule-ls",

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -57,6 +57,27 @@ func deletePolicy(ctx *cli.Context) {
 	errCheck(ctx, getClient(ctx).PolicyDelete(tenant, policy))
 }
 
+func inspectPolicy(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		errExit(ctx, exitHelp, "Policy name required", true)
+	}
+
+	tenant := ctx.String("tenant")
+	policy := ctx.Args()[0]
+
+	fmt.Printf("Inspeting policy: %s tenant: %s\n", policy, tenant)
+
+	pol, err := getClient(ctx).PolicyInspect(tenant, policy)
+	errCheck(ctx, err)
+
+	content, err := json.MarshalIndent(pol, "", "  ")
+	if err != nil {
+		errExit(ctx, exitIO, err.Error(), false)
+	}
+	os.Stdout.Write(content)
+	os.Stdout.WriteString("\n")
+}
+
 func listPolicies(ctx *cli.Context) {
 	if len(ctx.Args()) != 0 {
 		errExit(ctx, exitHelp, "More arguments than required", true)
@@ -540,6 +561,23 @@ func deleteTenant(ctx *cli.Context) {
 	fmt.Printf("Deleting tenant %s\n", tenant)
 
 	errCheck(ctx, getClient(ctx).TenantDelete(tenant))
+}
+
+func inspectTenant(ctx *cli.Context) {
+	if len(ctx.Args()) != 1 {
+		errExit(ctx, exitHelp, "Tenant name required", true)
+	}
+
+	tenant := ctx.Args()[0]
+
+	fmt.Printf("Inspecting tenant: %s  ", tenant)
+
+	ten, err := getClient(ctx).TenantInspect(tenant)
+	errCheck(ctx, err)
+
+	content, err := json.MarshalIndent(ten, "", "  ")
+	os.Stdout.Write(content)
+	os.Stdout.WriteString("\n")
 }
 
 func listTenants(ctx *cli.Context) {

--- a/netmaster/mastercfg/endpointGroupState.go
+++ b/netmaster/mastercfg/endpointGroupState.go
@@ -34,7 +34,7 @@ type EndpointGroupState struct {
 	PktTagType      string `json:"pktTagType"`
 	PktTag          int    `json:"pktTag"`
 	ExtPktTag       int    `json:"extPktTag"`
-	EpCount         int    `json:"epCount"`
+	EpCount         int    `json:"epCount"` // To store endpoint Count
 	DSCP            int    `json:"DSCP"`
 	Bandwidth       string `json:"Bandwidth"`
 	Burst           int    `json:"Burst"`

--- a/vendor/github.com/contiv/contivmodel/client/contivModelClient.go
+++ b/vendor/github.com/contiv/contivmodel/client/contivModelClient.go
@@ -235,6 +235,7 @@ type EndpointGroup struct {
 
 type EndpointGroupLinkSets struct {
 	ExtContractsGrps map[string]Link `json:"ExtContractsGrps,omitempty"`
+	MatchRules       map[string]Link `json:"MatchRules,omitempty"`
 	Policies         map[string]Link `json:"Policies,omitempty"`
 	Services         map[string]Link `json:"Services,omitempty"`
 }
@@ -249,7 +250,7 @@ type EndpointGroupLinks struct {
 type EndpointGroupOper struct {
 	Endpoints      []EndpointOper `json:"endpoints,omitempty"`
 	ExternalPktTag int            `json:"externalPktTag,omitempty"` // external packet tag
-	NumEndpoints   int            `json:"numEndpoints,omitempty"`   // external packet tag
+	NumEndpoints   int            `json:"numEndpoints,omitempty"`   // number of endpoints
 	PktTag         int            `json:"pktTag,omitempty"`         // internal packet tag
 
 }
@@ -403,8 +404,17 @@ type PolicyLinks struct {
 	Tenant Link `json:"Tenant,omitempty"`
 }
 
+type PolicyOper struct {
+	Endpoints        []EndpointOper `json:"endpoints,omitempty"`
+	NumEndpoints     int            `json:"numEndpoints,omitempty"`     // number of endpoints
+	PolicyViolations int            `json:"policyViolations,omitempty"` // number of policyViolations
+
+}
+
 type PolicyInspect struct {
 	Config Policy
+
+	Oper PolicyOper
 }
 
 type Rule struct {
@@ -428,10 +438,15 @@ type Rule struct {
 
 	// add link-sets and links
 	LinkSets RuleLinkSets `json:"link-sets,omitempty"`
+	Links    RuleLinks    `json:"links,omitempty"`
 }
 
 type RuleLinkSets struct {
 	Policies map[string]Link `json:"Policies,omitempty"`
+}
+
+type RuleLinks struct {
+	MatchEndpointGroup Link `json:"MatchEndpointGroup,omitempty"`
 }
 
 type RuleInspect struct {
@@ -492,8 +507,26 @@ type TenantLinkSets struct {
 	Volumes        map[string]Link `json:"Volumes,omitempty"`
 }
 
+type TenantOper struct {
+	EndpointGroups   []EndpointGroupOper `json:"endpointGroups,omitempty"`
+	Endpoints        []EndpointOper      `json:"endpoints,omitempty"`
+	Networks         []NetworkOper       `json:"networks,omitempty"`
+	Policies         []PolicyOper        `json:"policies,omitempty"`
+	Servicelbs       []ServiceLBOper     `json:"servicelbs,omitempty"`
+	TotalAppProfiles int                 `json:"totalAppProfiles,omitempty"` // total number of App-Profiles
+	TotalEPGs        int                 `json:"totalEPGs,omitempty"`        // total number of EPGs
+	TotalEndpoints   int                 `json:"totalEndpoints,omitempty"`   // total number of endpoints in the tenant
+	TotalNetprofiles int                 `json:"totalNetprofiles,omitempty"` // total number of Netprofiles
+	TotalNetworks    int                 `json:"totalNetworks,omitempty"`    // total number of networks
+	TotalPolicies    int                 `json:"totalPolicies,omitempty"`    // total number of totalPolicies
+	TotalServicelbs  int                 `json:"totalServicelbs,omitempty"`  // total number of Servicelbs
+
+}
+
 type TenantInspect struct {
 	Config Tenant
+
+	Oper TenantOper
 }
 
 type Volume struct {

--- a/vendor/github.com/contiv/contivmodel/client/contivModelClient.py
+++ b/vendor/github.com/contiv/contivmodel/client/contivModelClient.py
@@ -436,6 +436,16 @@ class objmodelClient:
 
 
 
+	# Inspect policy
+	def createPolicy(self, obj):
+	    postUrl = self.baseUrl + '/api/v1/inspect/policy/' + obj.tenantName + ":" + obj.policyName  + '/'
+
+	    retDate = urllib2.urlopen(postUrl)
+	    if retData == "Error":
+	        errorExit("list Policy failed")
+
+	    return json.loads(retData)
+
 
 	# Create rule
 	def createRule(self, obj):
@@ -569,6 +579,16 @@ class objmodelClient:
 	    return json.loads(retData)
 
 
+
+	# Inspect tenant
+	def createTenant(self, obj):
+	    postUrl = self.baseUrl + '/api/v1/inspect/tenant/' + obj.tenantName  + '/'
+
+	    retDate = urllib2.urlopen(postUrl)
+	    if retData == "Error":
+	        errorExit("list Tenant failed")
+
+	    return json.loads(retData)
 
 
 	# Create volume

--- a/vendor/github.com/contiv/contivmodel/contivModel.go
+++ b/vendor/github.com/contiv/contivmodel/contivModel.go
@@ -109,6 +109,7 @@ type EndpointGroup struct {
 
 type EndpointGroupLinkSets struct {
 	ExtContractsGrps map[string]modeldb.Link `json:"ExtContractsGrps,omitempty"`
+	MatchRules       map[string]modeldb.Link `json:"MatchRules,omitempty"`
 	Policies         map[string]modeldb.Link `json:"Policies,omitempty"`
 	Services         map[string]modeldb.Link `json:"Services,omitempty"`
 }
@@ -123,7 +124,7 @@ type EndpointGroupLinks struct {
 type EndpointGroupOper struct {
 	Endpoints      []EndpointOper `json:"endpoints,omitempty"`
 	ExternalPktTag int            `json:"externalPktTag,omitempty"` // external packet tag
-	NumEndpoints   int            `json:"numEndpoints,omitempty"`   // external packet tag
+	NumEndpoints   int            `json:"numEndpoints,omitempty"`   // number of endpoints
 	PktTag         int            `json:"pktTag,omitempty"`         // internal packet tag
 
 }
@@ -277,8 +278,17 @@ type PolicyLinks struct {
 	Tenant modeldb.Link `json:"Tenant,omitempty"`
 }
 
+type PolicyOper struct {
+	Endpoints        []EndpointOper `json:"endpoints,omitempty"`
+	NumEndpoints     int            `json:"numEndpoints,omitempty"`     // number of endpoints
+	PolicyViolations int            `json:"policyViolations,omitempty"` // number of policyViolations
+
+}
+
 type PolicyInspect struct {
 	Config Policy
+
+	Oper PolicyOper
 }
 
 type Rule struct {
@@ -302,10 +312,15 @@ type Rule struct {
 
 	// add link-sets and links
 	LinkSets RuleLinkSets `json:"link-sets,omitempty"`
+	Links    RuleLinks    `json:"links,omitempty"`
 }
 
 type RuleLinkSets struct {
 	Policies map[string]modeldb.Link `json:"Policies,omitempty"`
+}
+
+type RuleLinks struct {
+	MatchEndpointGroup modeldb.Link `json:"MatchEndpointGroup,omitempty"`
 }
 
 type RuleInspect struct {
@@ -366,8 +381,26 @@ type TenantLinkSets struct {
 	Volumes        map[string]modeldb.Link `json:"Volumes,omitempty"`
 }
 
+type TenantOper struct {
+	EndpointGroups   []EndpointGroupOper `json:"endpointGroups,omitempty"`
+	Endpoints        []EndpointOper      `json:"endpoints,omitempty"`
+	Networks         []NetworkOper       `json:"networks,omitempty"`
+	Policies         []PolicyOper        `json:"policies,omitempty"`
+	Servicelbs       []ServiceLBOper     `json:"servicelbs,omitempty"`
+	TotalAppProfiles int                 `json:"totalAppProfiles,omitempty"` // total number of App-Profiles
+	TotalEPGs        int                 `json:"totalEPGs,omitempty"`        // total number of EPGs
+	TotalEndpoints   int                 `json:"totalEndpoints,omitempty"`   // total number of endpoints in the tenant
+	TotalNetprofiles int                 `json:"totalNetprofiles,omitempty"` // total number of Netprofiles
+	TotalNetworks    int                 `json:"totalNetworks,omitempty"`    // total number of networks
+	TotalPolicies    int                 `json:"totalPolicies,omitempty"`    // total number of totalPolicies
+	TotalServicelbs  int                 `json:"totalServicelbs,omitempty"`  // total number of Servicelbs
+
+}
+
 type TenantInspect struct {
 	Config Tenant
+
+	Oper TenantOper
 }
 
 type Volume struct {
@@ -499,6 +532,8 @@ type NetworkCallbacks interface {
 }
 
 type PolicyCallbacks interface {
+	PolicyGetOper(policy *PolicyInspect) error
+
 	PolicyCreate(policy *Policy) error
 	PolicyUpdate(policy, params *Policy) error
 	PolicyDelete(policy *Policy) error
@@ -519,6 +554,8 @@ type ServiceLBCallbacks interface {
 }
 
 type TenantCallbacks interface {
+	TenantGetOper(tenant *TenantInspect) error
+
 	TenantCreate(tenant *Tenant) error
 	TenantUpdate(tenant, params *Tenant) error
 	TenantDelete(tenant *Tenant) error
@@ -2981,7 +3018,7 @@ func ValidateNetwork(obj *Network) error {
 		return errors.New("nwType string invalid format")
 	}
 
-	if obj.PktTag > 4094 {
+	if obj.PktTag > 1.6777216e+07 {
 		return errors.New("pktTag Value Out of bound")
 	}
 
@@ -3016,8 +3053,31 @@ func httpInspectPolicy(w http.ResponseWriter, r *http.Request, vars map[string]s
 	}
 	obj.Config = *objConfig
 
+	if err := GetOperPolicy(&obj); err != nil {
+		log.Errorf("GetPolicy error for: %+v. Err: %v", obj, err)
+		return nil, err
+	}
+
 	// Return the obj
 	return &obj, nil
+}
+
+// Get a policyOper object
+func GetOperPolicy(obj *PolicyInspect) error {
+	// Check if we handle this object
+	if objCallbackHandler.PolicyCb == nil {
+		log.Errorf("No callback registered for policy object")
+		return errors.New("Invalid object type")
+	}
+
+	// Perform callback
+	err := objCallbackHandler.PolicyCb.PolicyGetOper(obj)
+	if err != nil {
+		log.Errorf("PolicyDelete retruned error for: %+v. Err: %v", obj, err)
+		return err
+	}
+
+	return nil
 }
 
 // LIST REST call
@@ -3968,8 +4028,31 @@ func httpInspectTenant(w http.ResponseWriter, r *http.Request, vars map[string]s
 	}
 	obj.Config = *objConfig
 
+	if err := GetOperTenant(&obj); err != nil {
+		log.Errorf("GetTenant error for: %+v. Err: %v", obj, err)
+		return nil, err
+	}
+
 	// Return the obj
 	return &obj, nil
+}
+
+// Get a tenantOper object
+func GetOperTenant(obj *TenantInspect) error {
+	// Check if we handle this object
+	if objCallbackHandler.TenantCb == nil {
+		log.Errorf("No callback registered for tenant object")
+		return errors.New("Invalid object type")
+	}
+
+	// Perform callback
+	err := objCallbackHandler.TenantCb.TenantGetOper(obj)
+	if err != nil {
+		log.Errorf("TenantDelete retruned error for: %+v. Err: %v", obj, err)
+		return err
+	}
+
+	return nil
 }
 
 // LIST REST call

--- a/vendor/github.com/contiv/contivmodel/endpointGroup.json
+++ b/vendor/github.com/contiv/contivmodel/endpointGroup.json
@@ -60,7 +60,7 @@
 				},
 				"numEndpoints": {
 					"type": "int",
-					"title": "external packet tag"
+					"title": "number of endpoints"
 				},
 				"endpoints": {
 					"type": "array",
@@ -74,6 +74,9 @@
 				},
 				"policies": {
 					"ref": "policy"
+				},
+				"matchRules": {
+					"ref": "rule"
 				},
 				"extContractsGrps": {
 					"ref": "extContractsGrp"

--- a/vendor/github.com/contiv/contivmodel/network.json
+++ b/vendor/github.com/contiv/contivmodel/network.json
@@ -37,7 +37,7 @@
 					"type": "int",
 					"title": "Vlan/Vxlan Tag",
 					"showSummary": true,
-					"max": 4094
+					"max": 16777216
 				},
 				"subnet": {
 					"type": "string",

--- a/vendor/github.com/contiv/contivmodel/policy.json
+++ b/vendor/github.com/contiv/contivmodel/policy.json
@@ -24,6 +24,21 @@
 					"showSummary": true
 				}
 			},
+			"operProperties": {
+				"numEndpoints": {
+					"type": "int",
+					"title": "number of endpoints"
+				},
+				"policyViolations": {
+					"type": "int",
+					"title": "number of policyViolations"
+				},
+				"endpoints": {
+					"type": "array",
+					"items": "endpoint",
+					"title": "endpoints associate with the policy"
+				}
+			},
 			"link-sets": {
 				"endpointGroups": {
 					"ref": "endpointGroup"

--- a/vendor/github.com/contiv/contivmodel/rule.json
+++ b/vendor/github.com/contiv/contivmodel/rule.json
@@ -114,7 +114,12 @@
 				"policies": {
 					"ref": "policy"
 				}
-			}
+			},
+			"links": {
+                                "matchEndpointGroup": {
+                                        "ref": "endpointGroup"
+                                }
+                        }
 		}
 	]
 }

--- a/vendor/github.com/contiv/contivmodel/tenant.json
+++ b/vendor/github.com/contiv/contivmodel/tenant.json
@@ -20,6 +20,61 @@
 					"format": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])?$"
 				}
 			},
+			"operProperties": {
+				"totalNetworks": {
+          "type": "int",
+					"title": "total number of networks"
+        },
+				"totalEPGs": {
+          "type": "int",
+					"title": "total number of EPGs"
+        },
+				"totalNetprofiles": {
+          "type": "int",
+					"title": "total number of Netprofiles"
+        },
+				"totalAppProfiles": {
+          "type": "int",
+					"title": "total number of App-Profiles"
+        },
+				"totalServicelbs": {
+          "type": "int",
+					"title": "total number of Servicelbs"
+        },
+				"totalPolicies": {
+          "type": "int",
+					"title": "total number of totalPolicies"
+        },
+				"totalEndpoints": {
+					"type": "int",
+					"title": "total number of endpoints in the tenant"
+				},
+				"endpoints": {
+          "type": "array",
+          "items": "endpoint",
+					"title": "endpoints in the tenant"
+        },
+				"networks": {
+					"type": "array",
+          "items": "network",
+          "title": "networks in the tenant"
+				},
+				"endpointGroups": {
+					"type": "array",
+          "items": "endpointGroup",
+          "title": "endpointGroups in the tenant"
+				},
+				"policies": {
+					"type": "array",
+          "items": "policy",
+          "title": "policies in the tenant"
+				},
+				"servicelbs": {
+					"type": "array",
+          "items": "serviceLB",
+          "title": "servicelbs in the tenant"
+        }
+			},
 			"link-sets": {
 				"networks": {
 					"ref": "network"


### PR DESCRIPTION
Completed: 
1: Tenant Inspect and Policy Inspect support.
2: Adding basic Integration tests for these two operations.

To be Done:
1:Adding number of violations stats per endpoint.
2: Adding few more Integration Tests.
3: TestTenantCreateDelete is still failing. Need to check.