### PR TITLE
Support inter-profile contracts with ACI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,11 +201,17 @@ host-unit-test-coverage-detail:
 	@echo dev: running unit tests...
 	cd $(GOPATH)/src/github.com/contiv/netplugin && sudo -E PATH=$(PATH) scripts/unittests --coverage-detail
 
-host-integ-test: host-cleanup
+host-integ-test: host-cleanup start-aci-gw
 	@echo dev: running integration tests...
 	sudo -E /usr/local/go/bin/go test -v ./test/integration/ -check.v -encap vlan -fwd-mode bridge
 	sudo -E /usr/local/go/bin/go test -v ./test/integration/ -check.v -encap vxlan -fwd-mode bridge
 	sudo -E /usr/local/go/bin/go test -v ./test/integration/ -check.v -encap vxlan -fwd-mode routing
+	sudo -E /usr/local/go/bin/go test -v ./test/integration/ -check.v -check.f "AppProfile" -encap vlan -fwd-mode bridge --fabric-mode aci
+
+start-aci-gw:
+	@echo dev: starting aci gw...
+	docker pull contiv/aci-gw:integ_test
+	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" -e "APIC_LEAF_NODE=IGNORE" -e "APIC_PHYS_DOMAIN=IGNORE" --name=contiv-aci-gw contiv/aci-gw:integ_test
 
 host-cleanup:
 	@echo dev: cleaning up services...

--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -1298,21 +1298,37 @@ func (ac *APIController) PolicyDelete(policy *contivModel.Policy) error {
 	return nil
 }
 
-func syncAppProfile(policy *contivModel.Policy) {
-	// find all appProfiles that have an association
+func getAffectedProfs(policy *contivModel.Policy,
+	matchEpg *contivModel.EndpointGroup) map[string]bool {
 	profMap := make(map[string]bool)
-
+	// find all appProfiles that have an association via policy
 	for epg := range policy.LinkSets.EndpointGroups {
 		epgObj := contivModel.FindEndpointGroup(epg)
 		if epgObj == nil {
 			log.Warnf("syncAppProfile epg %s not found", epg)
 		} else {
 			prof := epgObj.Links.AppProfile.ObjKey
-			profMap[prof] = true
-			log.Infof("syncAppProfile epg %s ==> prof %s", epg, prof)
+			if prof != "" {
+				profMap[prof] = true
+				log.Infof("syncAppProfile epg %s ==> prof %s", epg, prof)
+			}
 		}
 	}
 
+	// add any app-profile associated via a matching epg
+	if matchEpg != nil {
+		prof := matchEpg.Links.AppProfile.ObjKey
+		if prof != "" {
+			profMap[prof] = true
+			log.Infof("syncAppProfile epg %s ==> prof %s",
+				matchEpg, prof)
+		}
+	}
+
+	return profMap
+}
+
+func syncAppProfile(profMap map[string]bool) {
 	for ap := range profMap {
 		profObj := contivModel.FindAppProfile(ap)
 		if profObj == nil {
@@ -1328,6 +1344,8 @@ func syncAppProfile(policy *contivModel.Policy) {
 // RuleCreate Creates the rule within a policy
 func (ac *APIController) RuleCreate(rule *contivModel.Rule) error {
 	log.Infof("Received RuleCreate: %+v", rule)
+	var epg *contivModel.EndpointGroup
+	epg = nil
 
 	// verify parameter values
 	if rule.Direction == "in" {
@@ -1359,7 +1377,7 @@ func (ac *APIController) RuleCreate(rule *contivModel.Rule) error {
 	if rule.FromEndpointGroup != "" {
 		epgKey := rule.TenantName + ":" + rule.FromEndpointGroup
 		// find the endpoint group
-		epg := contivModel.FindEndpointGroup(epgKey)
+		epg = contivModel.FindEndpointGroup(epgKey)
 		if epg == nil {
 			log.Errorf("Error finding endpoint group %s", epgKey)
 			return errors.New("endpoint group not found")
@@ -1368,7 +1386,7 @@ func (ac *APIController) RuleCreate(rule *contivModel.Rule) error {
 		epgKey := rule.TenantName + ":" + rule.ToEndpointGroup
 
 		// find the endpoint group
-		epg := contivModel.FindEndpointGroup(epgKey)
+		epg = contivModel.FindEndpointGroup(epgKey)
 		if epg == nil {
 			log.Errorf("Error finding endpoint group %s", epgKey)
 			return errors.New("endpoint group not found")
@@ -1415,8 +1433,19 @@ func (ac *APIController) RuleCreate(rule *contivModel.Rule) error {
 		return err
 	}
 
+	// link the rule to epg and vice versa
+	if epg != nil {
+		modeldb.AddLinkSet(&epg.LinkSets.MatchRules, rule)
+		modeldb.AddLink(&rule.Links.MatchEndpointGroup, epg)
+		err = epg.Write()
+		if err != nil {
+			return err
+		}
+	}
+
 	// Update any affected app profiles
-	syncAppProfile(policy)
+	pMap := getAffectedProfs(policy, epg)
+	syncAppProfile(pMap)
 
 	return nil
 }
@@ -1429,6 +1458,9 @@ func (ac *APIController) RuleUpdate(rule, params *contivModel.Rule) error {
 
 // RuleDelete deletes the rule within a policy
 func (ac *APIController) RuleDelete(rule *contivModel.Rule) error {
+	var epg *contivModel.EndpointGroup
+
+	epg = nil
 	log.Infof("Received RuleDelete: %+v", rule)
 
 	policyKey := GetpolicyKey(rule.TenantName, rule.PolicyName)
@@ -1447,6 +1479,15 @@ func (ac *APIController) RuleDelete(rule *contivModel.Rule) error {
 		return err
 	}
 
+	// unlink the rule from matching epg
+	epgKey := rule.Links.MatchEndpointGroup.ObjKey
+	if epgKey != "" {
+		epg = contivModel.FindEndpointGroup(epgKey)
+		if epg != nil {
+			modeldb.RemoveLinkSet(&epg.LinkSets.MatchRules, rule)
+		}
+	}
+
 	// Trigger policyDB Update
 	err = master.PolicyDelRule(policy, rule)
 	if err != nil {
@@ -1455,7 +1496,8 @@ func (ac *APIController) RuleDelete(rule *contivModel.Rule) error {
 	}
 
 	// Update any affected app profiles
-	syncAppProfile(policy)
+	pMap := getAffectedProfs(policy, epg)
+	syncAppProfile(pMap)
 
 	return nil
 }

--- a/test/integration/app_prof_test.go
+++ b/test/integration/app_prof_test.go
@@ -1,0 +1,275 @@
+/***
+Copyright 2016 Cisco Systems Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/contivmodel/client"
+
+	. "gopkg.in/check.v1"
+)
+
+// TestSingleAppProfile verifies a simple app-profile creation
+func (its *integTestSuite) TestSingleAppProfile(c *C) {
+	// Create a tenant
+	c.Assert(its.client.TenantPost(&client.Tenant{
+		TenantName: "BBTenant",
+	}), IsNil)
+
+	// Create an external contract
+	err := its.client.ExtContractsGroupPost(&client.ExtContractsGroup{
+		TenantName:         "BBTenant",
+		ContractsGroupName: "extETCD",
+		ContractsType:      "consumed",
+		Contracts:          []string{"uni/tn-BBTenant/brc-etcdAllow"},
+	})
+	assertNoErr(err, c, "creating external contract")
+
+	// Create another external contract
+	err = its.client.ExtContractsGroupPost(&client.ExtContractsGroup{
+		TenantName:         "BBTenant",
+		ContractsGroupName: "extWeb",
+		ContractsType:      "provided",
+		Contracts:          []string{"uni/tn-BBTenant/brc-webAllow"},
+	})
+	assertNoErr(err, c, "creating external contract")
+
+	// Create a network
+	err = its.client.NetworkPost(&client.Network{
+		TenantName:  "BBTenant",
+		NetworkName: "NetNet",
+		Subnet:      "29.1.1.0/24",
+		Encap:       its.encap,
+	})
+	assertNoErr(err, c, "creating network")
+
+	// Create a policy
+	c.Assert(its.client.PolicyPost(&client.Policy{
+		PolicyName: "Policy1",
+		TenantName: "BBTenant",
+	}), IsNil)
+
+	// Create a epg
+	err = its.client.EndpointGroupPost(&client.EndpointGroup{
+		TenantName:       "BBTenant",
+		NetworkName:      "NetNet",
+		GroupName:        "epgA",
+		Policies:         []string{"Policy1"},
+		ExtContractsGrps: []string{"extWeb", "extETCD"},
+	})
+	assertNoErr(err, c, "creating endpointgroup")
+
+	// Create another epg
+	err = its.client.EndpointGroupPost(&client.EndpointGroup{
+		TenantName:       "BBTenant",
+		NetworkName:      "NetNet",
+		GroupName:        "epgB",
+		ExtContractsGrps: []string{"extETCD"},
+	})
+	assertNoErr(err, c, "creating endpointgroup")
+
+	// add some rules to the policy
+	rules := []*client.Rule{
+		{
+			RuleID:            "1",
+			PolicyName:        "Policy1",
+			TenantName:        "BBTenant",
+			Direction:         "in",
+			Protocol:          "tcp",
+			Action:            "allow",
+			FromEndpointGroup: "epgB",
+		},
+		{
+			RuleID:            "2",
+			PolicyName:        "Policy1",
+			TenantName:        "BBTenant",
+			Priority:          100,
+			Direction:         "in",
+			Protocol:          "udp",
+			Port:              8000,
+			Action:            "allow",
+			FromEndpointGroup: "epgB",
+		},
+	}
+	for _, rule := range rules {
+		c.Assert(its.client.RulePost(rule), IsNil)
+	}
+
+	// Create an app-profile
+	err = its.client.AppProfilePost(&client.AppProfile{
+		TenantName:     "BBTenant",
+		AppProfileName: "TestProfile",
+		EndpointGroups: []string{"epgA", "epgB"},
+	})
+	assertNoErr(err, c, "creating application-profile")
+
+	// verify tenant state is correct
+	insp, err := its.client.TenantInspect("BBTenant")
+	assertNoErr(err, c, "inspecting tenant")
+	log.Infof("Inspecting tenant: %+v", insp)
+	c.Assert(insp.Oper.TotalEndpoints, Equals, 0)
+	c.Assert(insp.Oper.TotalNetworks, Equals, 1)
+	c.Assert(insp.Oper.TotalEPGs, Equals, 2)
+	c.Assert(insp.Oper.TotalPolicies, Equals, 1)
+	c.Assert(insp.Oper.TotalAppProfiles, Equals, 1)
+
+	assertNoErr(its.client.AppProfileDelete("BBTenant", "TestProfile"), c, "deleting app profile")
+	assertNoErr(its.client.EndpointGroupDelete("BBTenant", "epgA"), c, "deleting endpointGroup")
+	assertNoErr(its.client.EndpointGroupDelete("BBTenant", "epgB"), c, "deleting endpointGroup")
+	assertNoErr(its.client.PolicyDelete("BBTenant", "Policy1"), c, "deleting policy")
+	assertNoErr(its.client.NetworkDelete("BBTenant", "NetNet"), c, "deleting network")
+	assertNoErr(its.client.ExtContractsGroupDelete("BBTenant", "extWeb"), c, "deleting ext contract")
+	assertNoErr(its.client.ExtContractsGroupDelete("BBTenant", "extETCD"), c, "deleting ext contract")
+	assertNoErr(its.client.TenantDelete("BBTenant"), c, "deleting Tenant")
+}
+
+func (its *integTestSuite) TestMultiAppProfile(c *C) {
+	// Create a tenant
+	c.Assert(its.client.TenantPost(&client.Tenant{
+		TenantName: "AATenant",
+	}), IsNil)
+
+	// Create an external contract
+	err := its.client.ExtContractsGroupPost(&client.ExtContractsGroup{
+		TenantName:         "AATenant",
+		ContractsGroupName: "extETCD",
+		ContractsType:      "consumed",
+		Contracts:          []string{"uni/tn-AATenant/brc-etcdAllow"},
+	})
+	assertNoErr(err, c, "creating external contract")
+
+	// Create a network
+	err = its.client.NetworkPost(&client.Network{
+		TenantName:  "AATenant",
+		NetworkName: "NetNet",
+		Subnet:      "29.1.1.0/24",
+		Encap:       its.encap,
+	})
+	assertNoErr(err, c, "creating network")
+
+	// Create a policy
+	c.Assert(its.client.PolicyPost(&client.Policy{
+		PolicyName: "Policy1",
+		TenantName: "AATenant",
+	}), IsNil)
+
+	// Create another policy
+	c.Assert(its.client.PolicyPost(&client.Policy{
+		PolicyName: "Policy2",
+		TenantName: "AATenant",
+	}), IsNil)
+
+	// Create a epg
+	err = its.client.EndpointGroupPost(&client.EndpointGroup{
+		TenantName:       "AATenant",
+		NetworkName:      "NetNet",
+		GroupName:        "epgA",
+		Policies:         []string{"Policy1"},
+		ExtContractsGrps: []string{"extETCD"},
+	})
+	assertNoErr(err, c, "creating endpointgroup")
+
+	// Create another epg
+	err = its.client.EndpointGroupPost(&client.EndpointGroup{
+		TenantName:  "AATenant",
+		NetworkName: "NetNet",
+		GroupName:   "epgB",
+		Policies:    []string{"Policy2"},
+	})
+	assertNoErr(err, c, "creating endpointgroup")
+
+	// Create another epg
+	err = its.client.EndpointGroupPost(&client.EndpointGroup{
+		TenantName:  "AATenant",
+		NetworkName: "NetNet",
+		GroupName:   "epgC",
+	})
+	assertNoErr(err, c, "creating endpointgroup")
+
+	// add some rules to the policy
+	rules := []*client.Rule{
+		{
+			RuleID:            "1",
+			PolicyName:        "Policy1",
+			TenantName:        "AATenant",
+			Direction:         "in",
+			Protocol:          "tcp",
+			Action:            "allow",
+			FromEndpointGroup: "epgB",
+		},
+		{
+			RuleID:            "2",
+			PolicyName:        "Policy1",
+			TenantName:        "AATenant",
+			Priority:          100,
+			Direction:         "in",
+			Protocol:          "udp",
+			Port:              8000,
+			Action:            "allow",
+			FromEndpointGroup: "epgB",
+		},
+		{
+			RuleID:          "3",
+			PolicyName:      "Policy2",
+			TenantName:      "AATenant",
+			Priority:        100,
+			Direction:       "out",
+			Protocol:        "tcp",
+			Port:            8001,
+			Action:          "allow",
+			ToEndpointGroup: "epgC",
+		},
+	}
+	for _, rule := range rules {
+		c.Assert(its.client.RulePost(rule), IsNil)
+	}
+
+	// Create an app-profile
+	err = its.client.AppProfilePost(&client.AppProfile{
+		TenantName:     "AATenant",
+		AppProfileName: "TestProfile1",
+		EndpointGroups: []string{"epgA", "epgB"},
+	})
+	assertNoErr(err, c, "creating application-profile")
+
+	// Create another app-profile
+	err = its.client.AppProfilePost(&client.AppProfile{
+		TenantName:     "AATenant",
+		AppProfileName: "TestProfile2",
+		EndpointGroups: []string{"epgC"},
+	})
+	assertNoErr(err, c, "creating application-profile")
+
+	// verify tenant state is correct
+	insp, err := its.client.TenantInspect("AATenant")
+	assertNoErr(err, c, "inspecting tenant")
+	log.Infof("Inspecting tenant: %+v", insp)
+	c.Assert(insp.Oper.TotalEndpoints, Equals, 0)
+	c.Assert(insp.Oper.TotalNetworks, Equals, 1)
+	c.Assert(insp.Oper.TotalEPGs, Equals, 3)
+	c.Assert(insp.Oper.TotalPolicies, Equals, 2)
+	c.Assert(insp.Oper.TotalAppProfiles, Equals, 2)
+
+	assertNoErr(its.client.AppProfileDelete("AATenant", "TestProfile1"), c, "deleting app profile")
+	assertNoErr(its.client.AppProfileDelete("AATenant", "TestProfile2"), c, "deleting app profile")
+	assertNoErr(its.client.EndpointGroupDelete("AATenant", "epgA"), c, "deleting endpointGroup")
+	assertNoErr(its.client.EndpointGroupDelete("AATenant", "epgB"), c, "deleting endpointGroup")
+	assertNoErr(its.client.EndpointGroupDelete("AATenant", "epgC"), c, "deleting endpointGroup")
+	assertNoErr(its.client.PolicyDelete("AATenant", "Policy1"), c, "deleting policy")
+	assertNoErr(its.client.PolicyDelete("AATenant", "Policy2"), c, "deleting policy")
+	assertNoErr(its.client.NetworkDelete("AATenant", "NetNet"), c, "deleting network")
+	assertNoErr(its.client.TenantDelete("AATenant"), c, "deleting Tenant")
+}

--- a/test/integration/integ_test.go
+++ b/test/integration/integ_test.go
@@ -33,6 +33,7 @@ type integTestSuite struct {
 	parallels    int    // number of parallel tests to run
 	fwdMode      string // forwarding mode bridging/routing
 	encap        string // encap vlan/vxlan
+	fabricMode   string // aci or default
 	clusterStore string // cluster store URL
 
 	// internal state
@@ -49,6 +50,7 @@ func TestMain(m *M) {
 	flag.IntVar(&integ.parallels, "parallels", 10, "Number of parallel actions")
 	flag.StringVar(&integ.fwdMode, "fwd-mode", "bridge", "forwarding mode [ bridge | routing ]")
 	flag.StringVar(&integ.encap, "encap", "vlan", "Encap [ vlan | vxlan ]")
+	flag.StringVar(&integ.fabricMode, "fabric-mode", "default", "fabric-mode [ aci | default ]")
 	flag.StringVar(&integ.clusterStore, "cluster-store", "etcd://127.0.0.1:2379", "Cluster store URL")
 
 	flag.Parse()
@@ -68,7 +70,7 @@ func (its *integTestSuite) SetUpSuite(c *C) {
 	// clear all etcd state before running the tests
 	exec.Command("etcdctl", "rm", "--recursive", "/contiv.io").Output()
 
-	npcluster, err := NewNPCluster(its.fwdMode, its.clusterStore)
+	npcluster, err := NewNPCluster(its)
 	assertNoErr(err, c, "creating cluster")
 
 	// create a new contiv client


### PR DESCRIPTION
This commit adds explicit support for contracts across two app-profiles. Up until now, such contracts had to be defined as external.