### PR TITLE
Makefile: update 'clean' target to delete the netplugin pkg directory rather than the root pkg directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ build:
 	make stop
 
 clean: deps
-	rm -rf $(GOPATH)/pkg/*
+	rm -rf $(GOPATH)/pkg/*/github.com/contiv/netplugin/
 	go clean -i -v ./...
 
 update:


### PR DESCRIPTION
Signed-off-by: Bill Robinson dseevr@users.noreply.github.com

cc: @dcheperd @jojimt
