### PR TITLE
Fixing Netplugin disconnect 

### DIFF
--- a/drivers/ovsdbDriver.go
+++ b/drivers/ovsdbDriver.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Max number of retries to get ofp port number
-const maxOfportRetry = 10
+const maxOfportRetry = 20
 
 // OvsdbDriver is responsible for programming OVS using ovsdb protocol. It also
 // implements the libovsdb.Notifier interface to keep cache of ovs table state.


### PR DESCRIPTION
NetpluginDisconnect trigger exposed issue with vxlan vrep creation with ofport not found error.
First suspicion was ovsdb operation being async would need more retries. Also cherry picked sukhesh's commit in this area.
