### PR TITLE
Vagrantfile,.gitignore: Maintain state between vagrant runs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ cscope*
 
 # version
 version/version_gen.go
+
+.vagrant-state


### PR DESCRIPTION
This patch implements a state tracker for vagrant runs. It does this by saving your current environment to a file called `.vagrant-state` in the CWD. It then restores that state (if it exists) for each run, allowing you to do any vagrant command without worrying about supplying environment variables to control it. On destroy, the file is removed.

This is sufficiently advanced ruby, so please do focus on the functionality. Perhaps @dseevr would like to review this one as I know he's more than capable of doing so.