### PR TITLE
mgmtfn/k8splugin: add network setup unit test

### DIFF
--- a/mgmtfn/k8splugin/driver_test.go
+++ b/mgmtfn/k8splugin/driver_test.go
@@ -1,0 +1,215 @@
+/***
+Copyright 2016 Cisco Systems Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8splugin
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"runtime"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	. "gopkg.in/check.v1"
+)
+
+type NetSetup struct {
+	newNS    netns.NsHandle
+	globalNS netns.NsHandle
+	pid      int
+	cmd      *exec.Cmd
+	ifName   string
+	link     netlink.Link
+}
+
+var _ = Suite(&NetSetup{})
+
+func (s *NetSetup) SetUpTest(c *C) {
+	la := netlink.NewLinkAttrs()
+	s.ifName = "testlinkfoo"
+	la.Name = s.ifName
+	runtime.LockOSThread()
+	locked := true
+	defer func() {
+		if locked {
+			runtime.UnlockOSThread()
+		}
+	}()
+
+	globalNS, err := netns.Get()
+	if err != nil {
+		c.Fatalf("failed to get the global network namespace: %v", err)
+	}
+	s.globalNS = globalNS
+	defer func() {
+		netns.Set(globalNS)
+	}()
+
+	newNS, err := netns.New()
+	if err != nil {
+		c.Fatal("failed to create new network namespace")
+	}
+	s.newNS = newNS
+
+	cmd := exec.Command("sleep", "infinity")
+	if err = cmd.Start(); err != nil {
+		c.Fatalf("failed to start the 'sleep 9999' process: %v", err)
+	}
+	s.cmd = cmd
+
+	s.pid = cmd.Process.Pid
+
+	if err = netns.Set(globalNS); err != nil {
+		c.Fatalf("failed to return to the global netns: %v", err)
+	}
+
+	// the rest of the code should run without a locked thread
+	if locked {
+		runtime.UnlockOSThread()
+		locked = false
+	}
+
+	dummy := &netlink.Dummy{LinkAttrs: la}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		c.Fatalf("failed to add dummy interface: %v", err)
+	}
+
+	link, err := netlink.LinkByName(la.Name)
+	if err != nil {
+		c.Fatalf("failed to get interface by name: %v", err)
+	}
+	s.link = link
+
+	netIf, err := net.InterfaceByName(la.Name)
+	if err != nil {
+		c.Fatalf("InterfaceByName failed: %v", err)
+	}
+
+	if netIf.Flags&net.FlagUp != 0 {
+		c.Fatalf("expected interface to be down, but it's up")
+	}
+}
+
+func (s *NetSetup) TearDownTest(c *C) {
+	s.newNS.Close()
+	s.cmd.Process.Kill()
+	netns.Set(s.globalNS)
+	s.globalNS.Close()
+	netlink.LinkDel(s.link)
+}
+
+func (s *NetSetup) TestNetSetup(c *C) {
+	newName := "testlinknewname"
+	address := "192.168.68.68/24"
+	defGW := "192.168.68.1"
+	staticRoute := "192.168.32.0/24"
+
+	if err := setIfAttrs(s.pid, s.ifName, address, newName); err != nil {
+		c.Fatalf("setIfAttrs failed: %v", err)
+	}
+
+	if err := setDefGw(s.pid, defGW, newName); err != nil {
+		c.Fatalf("setDefGw failed: %v", err)
+	}
+
+	if err := addStaticRoute(s.pid, staticRoute, newName); err != nil {
+		c.Fatalf("addStaticRoute failed: %v", err)
+	}
+
+	// check if the interface still has its old name & is in globalNS
+	if _, err := netlink.LinkByName(s.ifName); err == nil {
+		c.Fatal("interface wasn't moved to the namespace")
+	}
+
+	// check if the interface has been renamed & is in globalNS
+	if _, err := netlink.LinkByName(newName); err == nil {
+		c.Fatal("interface wasn't moved to the namespace")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := netns.Set(s.newNS); err != nil {
+		c.Fatalf("failed to enter the new network namespace: %v", err)
+	}
+
+	// ensure the interface's name has been changed
+	newLink, err := netlink.LinkByName(newName)
+	if err != nil {
+		c.Fatalf("failed to get interface by name: %v", err)
+	}
+	defer netlink.LinkDel(newLink)
+
+	// ensure that the interface's IP address has been set properly
+	addresses, err := netlink.AddrList(newLink, netlink.FAMILY_V4)
+	ifAddr := addresses[0].IPNet.String()
+	if address != ifAddr {
+		c.Errorf("expected IP address %v, found: %v", address, ifAddr)
+	}
+
+	netIf, err := net.InterfaceByName(newName)
+	if err != nil {
+		c.Errorf("InterfaceByName failed: %v", err)
+	}
+
+	// ensure the default gateway route has been set properly
+	routes, err := netlink.RouteList(newLink, netlink.FAMILY_V4)
+	if err != nil {
+		c.Errorf("failed to fetch routes")
+	}
+
+	foundDefaultGW := false
+	foundStaticRoute := false
+	for _, route := range routes {
+		gw := route.Gw.String()
+		if gw != defGW {
+			continue
+		}
+		if route.Dst != nil {
+			c.Errorf("expected nil GW Dst, found: %v", route.Dst)
+		}
+		if route.Src != nil {
+			c.Errorf("expected nil GW Src, found: %v", route.Dst)
+		}
+		foundDefaultGW = true
+	}
+	if !foundDefaultGW {
+		c.Error("couldn't find default gateway")
+	}
+
+	for _, route := range routes {
+		dst := fmt.Sprintf("%v", route.Dst)
+		if dst != staticRoute {
+			continue
+		}
+		if route.Gw != nil {
+			c.Errorf("expected nil gateway, found: %v", route.Gw)
+		}
+		if route.Src != nil {
+			c.Errorf("expected nil source, found: %v", route.Dst)
+		}
+		foundStaticRoute = true
+	}
+
+	if !foundStaticRoute {
+		c.Error("couldn't find static route")
+	}
+
+	// ensure that the interface is up
+	if netIf.Flags&net.FlagUp == 0 {
+		c.Errorf("expected interface to be up, but it's down")
+	}
+}

--- a/mgmtfn/k8splugin/kubeClient_test.go
+++ b/mgmtfn/k8splugin/kubeClient_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	osexec "os/exec"
 	"strings"
 	"testing"
@@ -32,6 +31,7 @@ import (
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/netplugin/plugin"
 	"github.com/gorilla/mux"
+	. "gopkg.in/check.v1"
 )
 
 const (
@@ -344,7 +344,7 @@ func epWatch(r *http.Request, iter int) (interface{}, bool, error) {
 }
 
 // setupTestServer creates a listener for the rest requests.
-func setupTestServer(m *testing.M) {
+func setupTestServer(c *C) {
 
 	// Read client cert
 	cert, err := tls.LoadX509KeyPair("/tmp/certs/server.crt", "/tmp/certs/server.key")
@@ -405,7 +405,7 @@ func setupTestServer(m *testing.M) {
 	log.Fatalf("Kube server not ready after 5 sec")
 }
 
-func setupCerts(m *testing.M) {
+func setupCerts(c *C) {
 	_, err := osexec.Command("mkdir", "-p", contivKubeCfgDir).CombinedOutput()
 	if err != nil {
 		log.Fatalf("mkdir failed: %v", err)
@@ -419,43 +419,50 @@ func setupCerts(m *testing.M) {
 	}
 }
 
-// TestMain sets up a fake kube server to enable testing the client
-func TestMain(m *testing.M) {
-	setupCerts(m)
-	setupTestServer(m)
-	os.Exit(m.Run())
-}
-
-func verifySvc(m *testing.T, drv *KubeTestNetDrv) {
+func verifySvc(c *C, drv *KubeTestNetDrv) {
 	ls, ok := drv.services["LipService"]
 	if !ok {
-		m.Errorf("Service was not correctly updated on client")
+		c.Errorf("Service was not correctly updated on client")
 	} else {
-		m.Logf("service: %+v", ls)
+		c.Logf("service: %+v", ls)
 		if ls.IPAddress != testClusterIP {
-			m.Errorf("ClusterIP is incorrect")
+			c.Errorf("ClusterIP is incorrect")
 		}
 
 		if len(ls.Ports) != 1 {
-			m.Errorf("Noumber of ports is incorrect")
+			c.Errorf("Noumber of ports is incorrect")
 		}
 
 		if ls.Ports[0].Protocol != "TCP" {
-			m.Errorf("Protocol is incorrect")
+			c.Errorf("Protocol is incorrect")
 		}
 
 		if ls.Ports[0].SvcPort != testSvcPort {
-			m.Errorf("Svc port is incorrect")
+			c.Errorf("Svc port is incorrect")
 		}
 
 		if ls.Ports[0].ProvPort != testTgtPort {
-			m.Errorf("Prov port is incorrect")
+			c.Errorf("Prov port is incorrect")
 		}
 	}
 }
 
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type TestKube struct{}
+
+var _ = Suite(&TestKube{})
+
+//  sets up a fake kube server to enable testing the client
+func (s *TestKube) SetUpSuite(c *C) {
+	setupCerts(c)
+	setupTestServer(c)
+}
+
 // TestKubeWatch tests the watch interface
-func TestKubeWatch(m *testing.T) {
+func (s *TestKube) TestKubeWatch(c *C) {
 	drv := &KubeTestNetDrv{}
 	np := &plugin.NetPlugin{
 		NetworkDriver: drv,
@@ -465,64 +472,64 @@ func TestKubeWatch(m *testing.T) {
 	totalEPResp = 0
 
 	InitKubServiceWatch(np)
-	m.Logf("--ADD--")
+	c.Logf("--ADD--")
 	maxEPResp = 0
 	maxSvcResp = 1
 	for ix := 0; ix < 2; ix++ {
 		time.Sleep(time.Second)
 	}
-	m.Logf("Drv: %+v", drv)
+	c.Logf("Drv: %+v", drv)
 	if drv.numAddSvc != 1 {
-		m.Errorf("Add service was not seen by client")
+		c.Errorf("Add service was not seen by client")
 	} else {
-		m.Logf("Add service seen by client, as expected")
+		c.Logf("Add service seen by client, as expected")
 	}
 
-	verifySvc(m, drv)
+	verifySvc(c, drv)
 
 	if len(drv.providers) != 0 {
-		m.Errorf("Provider list is incorrect")
+		c.Errorf("Provider list is incorrect")
 
 	}
 
-	m.Logf("--DEL--")
+	c.Logf("--DEL--")
 	maxEPResp = 0
 	maxSvcResp = 2
 	for ix := 0; ix < 3; ix++ {
 		time.Sleep(time.Second)
 	}
-	m.Logf("Drv: %+v", drv)
+	c.Logf("Drv: %+v", drv)
 	if drv.numDelSvc != 1 {
-		m.Errorf("Del service was not seen by client")
+		c.Errorf("Del service was not seen by client")
 	} else {
-		m.Logf("Del service seen by client, as expected")
+		c.Logf("Del service seen by client, as expected")
 	}
 
 	_, ok := drv.services["LipService"]
 	if ok {
-		m.Errorf("Service was not deleted on client")
+		c.Errorf("Service was not deleted on client")
 	}
 
-	m.Logf("--CLOSE--")
+	c.Logf("--CLOSE--")
 	maxEPResp = 6
 	maxSvcResp = 4
 	for ix := 0; ix < 8; ix++ {
 		time.Sleep(time.Second)
 	}
-	m.Logf("Drv: %+v", drv)
-	m.Logf("services: %+v", drv.services["LipService"])
+	c.Logf("Drv: %+v", drv)
+	c.Logf("services: %+v", drv.services["LipService"])
 	if (drv.numAddSvc != 3) || (drv.numDelSvc != 1) || (drv.numProvUpd != 6) {
-		m.Errorf("All updates were not seen by client")
+		c.Errorf("All updates were not seen by client")
 	}
 
-	verifySvc(m, drv)
+	verifySvc(c, drv)
 
 	provs, ok := drv.providers["LipService"]
 	if !ok {
-		m.Errorf("Providers were not updated on client")
+		c.Errorf("Providers were not updated on client")
 	} else {
 		if len(provs) != 2 {
-			m.Errorf("Providers were not updated correctly on client")
+			c.Errorf("Providers were not updated correctly on client")
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a unit test for some of the network setup functions from driver.go.

This increases the coverage from 25% to 33.4%.