### PR TITLE
Fixing TriggerNetpartition test error

### DIFF
--- a/test/systemtests/k8setup_test.go
+++ b/test/systemtests/k8setup_test.go
@@ -616,6 +616,10 @@ func (k *kubernetes) checkSchedulerNetworkCreated(nwName string, expectedOp bool
 	return nil
 }
 
+func (k *kubernetes) checkSchedulerNetworkOnNodeCreated(nwName []string, n *node) error {
+	return nil
+}
+
 func (k *kubernetes) waitForListeners() error {
 	if k.node.Name() == "k8master" {
 		return nil

--- a/test/systemtests/node_test.go
+++ b/test/systemtests/node_test.go
@@ -258,3 +258,7 @@ func (c *container) String() string {
 func (n *node) checkSchedulerNetworkCreated(nwName string, expectedOp bool) error {
 	return n.exec.checkSchedulerNetworkCreated(nwName, expectedOp)
 }
+
+func (n *node) checkSchedulerNetworkOnNodeCreated(nwName []string) error {
+	return n.exec.checkSchedulerNetworkOnNodeCreated(nwName, n)
+}

--- a/test/systemtests/scheduler_test.go
+++ b/test/systemtests/scheduler_test.go
@@ -37,6 +37,7 @@ type systemTestScheduler interface {
 	checkPingWithCount(c *container, ipaddr string, count int) error
 	checkPing6WithCount(c *container, ipaddr string, count int) error
 	checkSchedulerNetworkCreated(nwName string, expectedOp bool) error
+	checkSchedulerNetworkOnNodeCreated(nwName []string, n *node) error
 	waitForListeners() error
 	verifyVTEPs(expVTEPS map[string]bool) (string, error)
 	verifyAgents(expVTEPS map[string]bool) (string, error)

--- a/test/systemtests/swarm_test.go
+++ b/test/systemtests/swarm_test.go
@@ -565,6 +565,38 @@ func (w *swarm) checkSchedulerNetworkCreated(nwName string, expectedOp bool) err
 	return err
 }
 
+func (w *swarm) checkSchedulerNetworkOnNodeCreated(nwNames []string, n *node) error {
+	ch := make(chan error, 1)
+	for _, nwName := range nwNames {
+		go func(nwName string, n *node, ch chan error) {
+			logrus.Infof("Checking whether docker network %s is created on node %s", nwName, n.Name())
+			cmd := fmt.Sprintf("docker network ls | grep netplugin | grep %s | awk \"{print \\$2}\"", nwName)
+			logrus.Infof("Command to be executed is = %s", cmd)
+			count := 0
+			//check if docker network is created for a minute
+			for count < 60 {
+				op, err := n.runCommand(cmd)
+
+				if err == nil {
+					ret := strings.Contains(op, nwName)
+					if ret == true {
+						ch <- nil
+					}
+					count++
+					time.Sleep(1 * time.Second)
+				}
+			}
+			ch <- fmt.Errorf("Swarm Network %s not created on node %s \n", nwName, n.Name())
+		}(nwName, n, ch)
+	}
+	for range nwNames {
+		if err := <-ch; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *swarm) waitForListeners() error {
 	return w.node.runCommandWithTimeOut("netstat -tlpn | grep 9090 | grep LISTEN", 500*time.Millisecond, 50*time.Second)
 }

--- a/test/systemtests/trigger_test.go
+++ b/test/systemtests/trigger_test.go
@@ -262,6 +262,7 @@ func (s *systemtestSuite) TestTriggerNetPartition(c *C) {
 	c.Assert(s.cli.NetworkPost(network), IsNil)
 
 	for i := 0; i < s.basicInfo.Iterations; i++ {
+
 		containers, err := s.runContainers(s.basicInfo.Containers, false, "private", "default", nil, nil)
 		c.Assert(err, IsNil)
 
@@ -283,12 +284,14 @@ func (s *systemtestSuite) TestTriggerNetPartition(c *C) {
 
 			c.Assert(s.verifyEPs(containers), IsNil)
 			time.Sleep(2 * time.Second)
-
 			// test ping for all containers
 			c.Assert(s.pingTest(containers), IsNil)
 		}
 
 		c.Assert(s.removeContainers(containers), IsNil)
+		for _, node := range s.nodes {
+			c.Assert(node.checkSchedulerNetworkOnNodeCreated([]string{"private"}), IsNil)
+		}
 	}
 
 	// delete the network


### PR DESCRIPTION
RC: Test failed because during etcd flaps we were trying to create containers when etcd was still not healthy and docker was reconnecting to etcd. 