### PR TITLE
Fix intermittent test failure

### DIFF
--- a/test/systemtests/trigger_test.go
+++ b/test/systemtests/trigger_test.go
@@ -276,10 +276,10 @@ func (s *systemtestSuite) TestTriggerNetPartition(c *C) {
 
 			// flap the control interface
 			c.Assert(node.bringDownIf("eth1"), IsNil)
-			time.Sleep(50 * time.Second) // wait till sessions/locks timeout
+			time.Sleep(25 * time.Second) // wait till sessions/locks timeout
 			c.Assert(node.bringUpIf("eth1", nodeIP), IsNil)
 
-			time.Sleep(20 * time.Second)
+			time.Sleep(23 * time.Second)
 			c.Assert(s.verifyVTEPs(), IsNil)
 
 			c.Assert(s.verifyEPs(containers), IsNil)
@@ -288,10 +288,10 @@ func (s *systemtestSuite) TestTriggerNetPartition(c *C) {
 			c.Assert(s.pingTest(containers), IsNil)
 		}
 
-		c.Assert(s.removeContainers(containers), IsNil)
 		for _, node := range s.nodes {
 			c.Assert(node.checkSchedulerNetworkOnNodeCreated([]string{"private"}), IsNil)
 		}
+		c.Assert(s.removeContainers(containers), IsNil)
 	}
 
 	// delete the network


### PR DESCRIPTION
Fix the following failure:
```time="2016-11-27T02:58:24-08:00" level=info msg="cmd \"docker run -itd --name=private-srv0-0-0 --net=private   contiv/alpine sleep 600m\" failed: output below" 
time="2016-11-27T02:58:24-08:00" level=info msg="4cf299b4ec9e7e27a4c76f9c6fec79488a68006f69d8521240021ed93a3b2167\ndocker: Error response from daemon: service endpoint with name private-srv0-0-0 already exists.\n" ```