### PR TITLE
Vagrantfile: bump Go to 1.7.4

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ BEGIN {
 }
 
 # netplugin_synced_gopath="/opt/golang"
-go_version = ENV["GO_VERSION"] || "1.7.3"
+go_version = ENV["GO_VERSION"] || "1.7.4"
 docker_version = ENV["CONTIV_DOCKER_VERSION"] || "1.12.3"
 gopath_folder="/opt/gopath"
 


### PR DESCRIPTION
This PR bumps Go to the newly released 1.7.4. This new release contains security fixes and some important bug fixes.