### PR TITLE
test/{integration,systemtests}: gofmt fixes

### DIFF
--- a/test/integration/app_prof_test.go
+++ b/test/integration/app_prof_test.go
@@ -26,7 +26,7 @@ import (
 func (its *integTestSuite) TestSingleAppProfile(c *C) {
 
 	if its.fabricMode != "aci" {
-		return  // run only in aci mode
+		return // run only in aci mode
 	}
 
 	// Create a tenant
@@ -126,9 +126,9 @@ func (its *integTestSuite) TestSingleAppProfile(c *C) {
 
 	// set aci-gw config
 	err = its.client.AciGwPost(&client.AciGw{
-		Name: "aciGw",
-		PhysicalDomain: "testDomain",
-		EnforcePolicies: "yes",
+		Name:                "aciGw",
+		PhysicalDomain:      "testDomain",
+		EnforcePolicies:     "yes",
 		IncludeCommonTenant: "no",
 	})
 	assertNoErr(err, c, "creating aciGw config")
@@ -141,13 +141,12 @@ func (its *integTestSuite) TestSingleAppProfile(c *C) {
 	})
 	assertErr(err, c, "creating application-profile without bindings")
 
-
 	// set aci-gw config
 	err = its.client.AciGwPost(&client.AciGw{
-		Name: "aciGw",
-		PathBindings: "topology/pod-1/paths-101/pathep-[eth1/14]",
-		PhysicalDomain: "testDomain",
-		EnforcePolicies: "yes",
+		Name:                "aciGw",
+		PathBindings:        "topology/pod-1/paths-101/pathep-[eth1/14]",
+		PhysicalDomain:      "testDomain",
+		EnforcePolicies:     "yes",
 		IncludeCommonTenant: "no",
 	})
 	assertNoErr(err, c, "creating aciGw config")
@@ -191,7 +190,7 @@ func (its *integTestSuite) TestSingleAppProfile(c *C) {
 
 func (its *integTestSuite) TestMultiAppProfile(c *C) {
 	if its.fabricMode != "aci" {
-		return  // run only in aci mode
+		return // run only in aci mode
 	}
 
 	// Create a tenant
@@ -296,10 +295,10 @@ func (its *integTestSuite) TestMultiAppProfile(c *C) {
 
 	// set aci-gw config
 	err = its.client.AciGwPost(&client.AciGw{
-		Name: "aciGw",
-		PathBindings: "topology/pod-1/paths-101/pathep-[eth1/14]",
-		PhysicalDomain: "testDomain",
-		EnforcePolicies: "yes",
+		Name:                "aciGw",
+		PathBindings:        "topology/pod-1/paths-101/pathep-[eth1/14]",
+		PhysicalDomain:      "testDomain",
+		EnforcePolicies:     "yes",
 		IncludeCommonTenant: "no",
 	})
 	assertNoErr(err, c, "creating aciGw config")

--- a/test/integration/npcluster_test.go
+++ b/test/integration/npcluster_test.go
@@ -83,7 +83,7 @@ func NewNPCluster(its *integTestSuite) (*NPCluster, error) {
 	go md.RunMasterFsm()
 
 	// Wait for a second for master to initialize
-	time.Sleep(10*time.Second)
+	time.Sleep(10 * time.Second)
 
 	// set forwarding mode if required
 	if its.fwdMode != "bridge" || its.fabricMode != "default" {

--- a/test/systemtests/service_test.go
+++ b/test/systemtests/service_test.go
@@ -152,7 +152,7 @@ func (s *systemtestSuite) testServiceAddDeleteService(c *C, encap string) {
 			}
 
 			for range serviceIPs {
-				for _ = range containers {
+				for range containers {
 					c.Assert(<-endChan, IsNil)
 				}
 			}
@@ -322,7 +322,7 @@ func (s *systemtestSuite) testServiceAddDeleteProviders(c *C, encap string) {
 						}(c, conts, serviceIPs[tenant], 80, "tcp")
 					}
 
-					for _ = range containers {
+					for range containers {
 						c.Assert(<-endChan, IsNil)
 					}
 					numSvcContainers := len(serviceContainers[svc.ServiceName])
@@ -343,7 +343,7 @@ func (s *systemtestSuite) testServiceAddDeleteProviders(c *C, encap string) {
 						}(c, conts, serviceIPs[tenant], 80, "tcp")
 					}
 
-					for _ = range containers {
+					for range containers {
 						c.Assert(<-endChan, IsNil)
 					}
 					serviceContainers[svc.ServiceName] = append(serviceContainers[svc.ServiceName],
@@ -511,7 +511,7 @@ func (s *systemtestSuite) testServiceSequenceProviderAddServiceAdd(c *C, encap s
 				endChan <- s.checkConnectionToService(conts, ips, port, "tcp")
 			}(c, conts, serviceIPs[contTenant], 80, "tcp")
 		}
-		for _ = range containers {
+		for range containers {
 			x := <-endChan
 			c.Assert(x, IsNil)
 		}
@@ -690,7 +690,7 @@ func (s systemtestSuite) testServiceTriggerNetmasterSwitchover(c *C, encap strin
 				}
 
 				for range serviceIPs {
-					for _ = range containers {
+					for range containers {
 						c.Assert(<-endChan, IsNil)
 					}
 				}
@@ -921,7 +921,7 @@ func (s systemtestSuite) testServiceTriggerNetpluginRestart(c *C, encap string) 
 						endChan <- s.checkConnectionToService(conts, ips, port, "tcp")
 					}(c, conts, ips, 80, "tcp")
 				}
-				for _ = range containers {
+				for range containers {
 					c.Assert(<-endChan, IsNil)
 				}
 			}


### PR DESCRIPTION
This fixes some gofmt issues in the test directory. It's fine if we don't want this to pass `go vet` and `golint`. We might at least want to gofmt the code so our editors don't make this change when making other changes.