### PR TITLE
set vagrant box update to false

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -156,6 +156,7 @@ end
 
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box_check_update = false
     if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "ubuntu" then
         config.vm.box = "contiv/ubuntu1604-netplugin"
         config.vm.box_version = "0.7.0"


### PR DESCRIPTION
Adding vagrant box_check_update to false. Since we are checking for box version constraint, we can leverage this check to fasten box bringup.