### PR TITLE
LACP monitoring

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/contiv/netplugin",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v75",
+	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -75,23 +75,23 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "ec547608cb51ef62865f225f98631f2635b8edac"
+			"Rev": "44862757fc326aa78e5e8efeba47fe5bfbfb96d5"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ofctrl",
-			"Rev": "ec547608cb51ef62865f225f98631f2635b8edac"
+			"Rev": "44862757fc326aa78e5e8efeba47fe5bfbfb96d5"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ovsdbDriver",
-			"Rev": "ec547608cb51ef62865f225f98631f2635b8edac"
+			"Rev": "44862757fc326aa78e5e8efeba47fe5bfbfb96d5"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/pqueue",
-			"Rev": "ec547608cb51ef62865f225f98631f2635b8edac"
+			"Rev": "44862757fc326aa78e5e8efeba47fe5bfbfb96d5"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/rpcHub",
-			"Rev": "ec547608cb51ef62865f225f98631f2635b8edac"
+			"Rev": "44862757fc326aa78e5e8efeba47fe5bfbfb96d5"
 		},
 		{
 			"ImportPath": "github.com/contiv/remotessh",

--- a/vendor/github.com/contiv/ofnet/ofnet.go
+++ b/vendor/github.com/contiv/ofnet/ofnet.go
@@ -69,6 +69,9 @@ type OfnetDatapath interface {
 	//Add uplink port
 	AddUplink(uplinkPort *PortInfo) error
 
+	//Update uplink port
+	UpdateUplink(uplinkName string, update PortUpdates) error
+
 	//Delete uplink port
 	RemoveUplink(uplinkName string) error
 
@@ -206,6 +209,18 @@ const (
 
 	// ArpProxy - ARP packets will be redirected to controller
 	ArpProxy ArpModeT = "proxy"
+
+	// PortType - individual port
+	PortType = "individual"
+
+	// BondType - bonded port
+	BondType = "bond"
+
+	// LACPUpdate - for port update info
+	LacpUpdate = "lacp-upd"
+
+	// AddLink - for port update info
+	AddLink = "add-link"
 )
 
 // OfnetGlobalConfig has global level configs for ofnet
@@ -263,14 +278,6 @@ const (
 	linkUp
 )
 
-const (
-	// PortType - individual port
-	PortType = "individual"
-
-	// BondType - bonded port
-	BondType = "bond"
-)
-
 // LinkInfo maintains individual link information
 type LinkInfo struct {
 	Name       string
@@ -286,4 +293,22 @@ type PortInfo struct {
 	LinkStatus  linkStatus
 	MbrLinks    []*LinkInfo
 	ActiveLinks []*LinkInfo
+}
+
+// PortUpdates maintains multiplae port update info
+type PortUpdates struct {
+	PortName string
+	Updates  []PortUpdate `json:"updates,overflow"`
+}
+
+// PortUpdate maintains information about port update
+type PortUpdate struct {
+	UpdateType string      `json:"update-type,omitinfo"`
+	UpdateInfo interface{} `json:"update-info,omitinfo"`
+}
+
+// LACP update
+type LinkUpdateInfo struct {
+	LinkName   string `json:"-,omitempty"`
+	LacpStatus bool   `json:"lacp-status,omitinfo"`
 }

--- a/vendor/github.com/contiv/ofnet/ofnetAgent.go
+++ b/vendor/github.com/contiv/ofnet/ofnetAgent.go
@@ -819,6 +819,12 @@ func (self *OfnetAgent) AddUplink(uplinkPort *PortInfo) error {
 	return self.datapath.AddUplink(uplinkPort)
 }
 
+// UpdateUplink Updates an uplink to the switch
+func (self *OfnetAgent) UpdateUplink(uplinkName string, portUpds PortUpdates) error {
+	// Call the datapath
+	return self.datapath.UpdateUplink(uplinkName, portUpds)
+}
+
 // RemoveUplink remove an uplink to the switch
 func (self *OfnetAgent) RemoveUplink(uplinkName string) error {
 	// Call the datapath

--- a/vendor/github.com/contiv/ofnet/util.go
+++ b/vendor/github.com/contiv/ofnet/util.go
@@ -318,6 +318,32 @@ func (port *PortInfo) checkLinkStatus() error {
 	return nil
 }
 
+// handleLacpUpdate
+func (link *LinkInfo) handleLacpUpdate(lacpActive bool) {
+	log.Infof("Handling LACP update for link: %s, Lacp status: %+v", link.Name, lacpActive)
+	port := link.Port
+	if !lacpActive {
+		for idx, activeLink := range port.ActiveLinks {
+			if link == activeLink {
+				if idx == len(port.ActiveLinks) {
+					port.ActiveLinks = port.ActiveLinks[:idx-1]
+				} else {
+					port.ActiveLinks = append(port.ActiveLinks[:idx], port.ActiveLinks[idx+1:]...)
+				}
+				break
+			}
+		}
+	} else {
+		for _, activeLink := range port.ActiveLinks {
+			if link == activeLink {
+				// Link already part of port
+				return
+			}
+		}
+		port.ActiveLinks = append(port.ActiveLinks, link)
+	}
+}
+
 // setLinkStatus sets interface link status and updates active links of the port
 func (link *LinkInfo) setLinkStatus(status linkStatus) {
 	if link.LinkStatus == status {

--- a/vendor/github.com/contiv/ofnet/vlrouter.go
+++ b/vendor/github.com/contiv/ofnet/vlrouter.go
@@ -1115,6 +1115,11 @@ func (self *Vlrouter) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
+// UpdateUplink updates uplink info
+func (self *Vlrouter) UpdateUplink(uplinkName string, updates PortUpdates) error {
+	return nil
+}
+
 func (self *Vlrouter) RemoveUplink(uplinkName string) error {
 	uplinkPort := self.GetUplink(uplinkName)
 

--- a/vendor/github.com/contiv/ofnet/vrouter.go
+++ b/vendor/github.com/contiv/ofnet/vrouter.go
@@ -906,6 +906,11 @@ func (vr *Vrouter) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
+// UpdateUplink updates uplink info
+func (vr *Vrouter) UpdateUplink(uplinkName string, updates PortUpdates) error {
+	return nil
+}
+
 // RemoveUplink remove an uplink to the switch
 func (vr *Vrouter) RemoveUplink(uplinkName string) error {
 	// Nothing to do

--- a/vendor/github.com/contiv/ofnet/vxlanBridge.go
+++ b/vendor/github.com/contiv/ofnet/vxlanBridge.go
@@ -849,6 +849,11 @@ func (vx *Vxlan) AddUplink(uplinkPort *PortInfo) error {
 	return nil
 }
 
+// UpdateUplink updates uplink info
+func (vx *Vxlan) UpdateUplink(uplinkName string, updates PortUpdates) error {
+	return nil
+}
+
 // RemoveUplink remove an uplink to the switch
 func (vx *Vxlan) RemoveUplink(uplinkName string) error {
 	return nil


### PR DESCRIPTION
This PR includes changes to monitor lacp status in interface table and communicate the changes to ofnet.

Test cases executed:
1. Remove member link and check that it is not used by control plane to send any packets
2. Add member link and check that it is included in the list of active links and the packets are load balanced
3. Check multiple link updates at the same time