### PR TITLE
l3-test fix

### DIFF
--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -155,7 +155,9 @@ func deleteEndpoint(hostname string) func(http.ResponseWriter, *http.Request) {
 		}
 
 		// delete the endpoint
+		netPlugin.Lock()
 		err = netPlugin.DeleteEndpoint(netID + "-" + delreq.EndpointID)
+		netPlugin.Unlock()
 		if err != nil {
 			log.Errorf("Error deleting endpoint %s. Err: %v", delreq.EndpointID, err)
 			httpError(w, "failed to delete endpoint", err)
@@ -225,7 +227,9 @@ func createEndpoint(hostname string) func(http.ResponseWriter, *http.Request) {
 		netID := netName + "." + tenantName
 
 		// Ask netplugin to create the endpoint
+		netPlugin.Lock()
 		err = netPlugin.CreateEndpoint(netID + "-" + cereq.EndpointID)
+		netPlugin.Unlock()
 		if err != nil {
 			log.Errorf("Endpoint creation failed. Error: %s", err)
 			httpError(w, "Could not create endpoint", err)

--- a/netplugin/agent/state_event.go
+++ b/netplugin/agent/state_event.go
@@ -227,6 +227,9 @@ func processEpgEvent(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, ID str
 
 func processGlobalFwdModeUpdEvent(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, fwdMode string) {
 
+	netPlugin.Lock()
+	defer func() { netPlugin.Unlock() }()
+
 	// parse store URL
 	parts := strings.Split(opts.DbURL, "://")
 	if len(parts) < 2 {
@@ -268,6 +271,9 @@ func processGlobalFwdModeUpdEvent(netPlugin *plugin.NetPlugin, opts core.Instanc
 }
 
 func processGlobalConfigUpdEvent(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, cfg *mastercfg.GlobConfig) {
+
+	netPlugin.Lock()
+	defer func() { netPlugin.Unlock() }()
 
 	// parse store URL
 	parts := strings.Split(opts.DbURL, "://")

--- a/netplugin/plugin/netplugin.go
+++ b/netplugin/plugin/netplugin.go
@@ -225,12 +225,14 @@ func (p *NetPlugin) GlobalFwdModeUpdate(cfg Config) {
 	var err error
 
 	if p.NetworkDriver != nil {
+		logrus.Infof("GlobalFwdModeUpdate De-initializing NetworkDriver")
 		p.NetworkDriver.Deinit()
 		p.NetworkDriver = nil
 	}
 
 	cfg.Instance.StateDriver, _ = utils.GetStateDriver()
 	p.NetworkDriver, err = utils.NewNetworkDriver(cfg.Drivers.Network, &cfg.Instance)
+	logrus.Infof("GlobalFwdModeUpdate Initializing NetworkDriver")
 
 	if err != nil {
 		logrus.Errorf("Error updating global forwarding mode %v", err)
@@ -239,6 +241,7 @@ func (p *NetPlugin) GlobalFwdModeUpdate(cfg Config) {
 
 	defer func() {
 		if err != nil {
+			logrus.Errorf("GlobalFwdModeUpdate De-initializing due to error: %v", err)
 			p.NetworkDriver.Deinit()
 		}
 	}()

--- a/test/systemtests/network_test.go
+++ b/test/systemtests/network_test.go
@@ -431,6 +431,10 @@ func (s *systemtestSuite) TestNetworkAddDeleteTenantFwdModeChangeVLAN(c *C) {
 }
 
 func (s *systemtestSuite) TestNetworkAddDeleteTenantArpModeChangeVXLAN(c *C) {
+	// Not applicable for routing mode
+	if s.fwdMode == "routing" {
+		return
+	}
 	arpMode := "proxy"
 	for i := 0; i < s.basicInfo.Iterations; i++ {
 		s.testNetworkAddDeleteTenant(c, "vxlan", "bridge")
@@ -461,9 +465,11 @@ func (s *systemtestSuite) TestNetworkAddDeleteTenantArpModeChangeVXLAN(c *C) {
 }
 
 func (s *systemtestSuite) TestNetworkAddDeleteTenantArpModeChangeVLAN(c *C) {
-
+	// Not applicable for routing mode
+	if s.fwdMode == "routing" {
+		return
+	}
 	for i := 0; i < s.basicInfo.Iterations; i++ {
-		s.testNetworkAddDeleteTenant(c, "vlan", s.fwdMode)
 		c.Assert(s.cli.GlobalPost(&client.Global{
 			FwdMode:          "bridge",
 			Name:             "global",

--- a/test/systemtests/util_test.go
+++ b/test/systemtests/util_test.go
@@ -1340,15 +1340,15 @@ func (s *systemtestSuite) SetUpTestVagrant(c *C) {
 
 	time.Sleep(5 * time.Second)
 	if s.basicInfo.Scheduler != "k8" {
-		for i := 0; i < 11; i++ {
+		for i := 0; i < 21; i++ {
 
 			_, err := s.cli.TenantGet("default")
 			if err == nil {
 				break
 			}
 			// Fail if we reached last iteration
-			c.Assert((i < 10), Equals, true)
-			time.Sleep(500 * time.Millisecond)
+			c.Assert((i < 20), Equals, true)
+			time.Sleep(1 * time.Second)
 		}
 	}
 


### PR DESCRIPTION
When processing global mode change and arp mode change
take the lock so that they are serialized like other
events in netplugin agent