### PR TITLE
Vagrantfile: fix linked clones on Vagrant 1.9+

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -170,7 +170,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.box_version = "0.7.0"
     end
     config.vm.provider 'virtualbox' do |v|
-        v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+        v.linked_clone = true if Vagrant::VERSION >= "1.8"
     end
 
     num_nodes = 3


### PR DESCRIPTION
VirtualBox linked clones were broken on Vagrant 1.9.1. The recommended line of code to detect the presence of support for linked clones was working only on Vagrant 1.8.x.

This minor change fixes this problem.