### PR TITLE
upgrade uplink changes

### DIFF
--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -190,7 +190,7 @@ func (d *OvsDriver) Init(info *core.InstanceInfo) error {
 
 	// Add uplink to VLAN switch
 	if len(info.UplinkIntf) != 0 {
-		err = d.switchDb["vlan"].AddUplink("uplinkBond", info.UplinkIntf)
+		err = d.switchDb["vlan"].AddUplink("uplinkPort", info.UplinkIntf)
 		if err != nil {
 			log.Errorf("Could not add uplink %v to vlan OVS. Err: %v", info.UplinkIntf, err)
 		}

--- a/drivers/ovsdriver_test.go
+++ b/drivers/ovsdriver_test.go
@@ -518,7 +518,7 @@ func TestOvsDriverUplinkBridgeMode(t *testing.T) {
 		t.Fatalf("Could not add uplink %+v to vlan OVS. Err: %v", uplinkPorts, err)
 	}
 
-	time.Sleep(300 * time.Millisecond)
+	time.Sleep(time.Second)
 
 	// verify uplink port
 	output, err := exec.Command("ovs-vsctl", "list", "Port").CombinedOutput()

--- a/test/systemtests/docker_test.go
+++ b/test/systemtests/docker_test.go
@@ -468,6 +468,7 @@ func (d *docker) cleanupSlave() {
 	vNode := d.node.tbnode
 	vNode.RunCommand("sudo ovs-vsctl del-br contivVxlanBridge")
 	vNode.RunCommand("sudo ovs-vsctl del-br contivVlanBridge")
+	vNode.RunCommand("sudo ovs-vsctl del-br contivHostBridge")
 	vNode.RunCommand("for p in `ifconfig  | grep vport | awk '{print $1}'`; do sudo ip link delete $p type veth; done")
 	vNode.RunCommand("sudo rm /var/run/docker/plugins/netplugin.sock")
 	vNode.RunCommand("sudo service docker restart")

--- a/test/systemtests/k8setup_test.go
+++ b/test/systemtests/k8setup_test.go
@@ -486,6 +486,7 @@ func (k *kubernetes) cleanupSlave() {
 	vNode := k.node.tbnode
 	vNode.RunCommand("sudo ovs-vsctl del-br contivVxlanBridge")
 	vNode.RunCommand("sudo ovs-vsctl del-br contivVlanBridge")
+	vNode.RunCommand("sudo ovs-vsctl del-br contivHostBridge")
 	vNode.RunCommand("for p in `ifconfig  | grep vport | awk '{print $1}'`; do sudo ip link delete $p type veth; done")
 	vNode.RunCommand("sudo rm /var/run/docker/plugins/netplugin.sock")
 	vNode.RunCommand("sudo service docker restart")

--- a/test/systemtests/node_test.go
+++ b/test/systemtests/node_test.go
@@ -110,6 +110,38 @@ func (n *node) cleanupMaster() {
 	n.exec.cleanupMaster()
 }
 
+func (n *node) verifyUplinkState(uplinks []string) error {
+	var err error
+	var portName string
+	var cmd, output string
+
+	if len(uplinks) > 1 {
+		portName = "uplinkPort"
+	} else {
+		portName = uplinks[0]
+	}
+
+	// Verify port state
+	cmd = fmt.Sprintf("sudo ovs-vsctl find Port name=%s", portName)
+	output, err = n.runCommand(cmd)
+	if err != nil || !(strings.Contains(string(output), portName)) {
+		err = fmt.Errorf("Lookup failed for uplink Port %s. Err: %+v", portName, err)
+		return err
+	}
+
+	// Verify Interface state
+	for _, uplink := range uplinks {
+		cmd = fmt.Sprintf("sudo ovs-vsctl find Interface name=%s", uplink)
+		output, err = n.runCommand(cmd)
+		if err != nil || !(strings.Contains(string(output), uplink)) {
+			err = fmt.Errorf("Lookup failed for uplink interface %s for uplink cfg:%+v. Err: %+v", uplink, uplinks, err)
+			return err
+		}
+	}
+
+	return err
+}
+
 func (n *node) runCommand(cmd string) (string, error) {
 	var (
 		str string

--- a/test/systemtests/swarm_test.go
+++ b/test/systemtests/swarm_test.go
@@ -430,6 +430,7 @@ func (w *swarm) cleanupSlave() {
 	vNode := w.node.tbnode
 	vNode.RunCommand("sudo ovs-vsctl del-br contivVxlanBridge")
 	vNode.RunCommand("sudo ovs-vsctl del-br contivVlanBridge")
+	vNode.RunCommand("sudo ovs-vsctl del-br contivHostBridge")
 	vNode.RunCommand("for p in `ifconfig  | grep vport | awk '{print $1}'`; do sudo ip link delete $p type veth; done")
 }
 


### PR DESCRIPTION
PR handles upgrade scenario for uplinks. 
**Cases:** 
- If the previous uplink was an individual interface, it is silently bonded to form a port bond
- If the uplink interfaces are already part of the OVS bridge, the user is warned that the interfaces are being made of the port bond and proceeds
