### PR TITLE
Initial creation of cleanup script for Jenkins job.

### DIFF
--- a/scripts/jenkins_cleanup.sh
+++ b/scripts/jenkins_cleanup.sh
@@ -16,7 +16,7 @@ rm -rf /home/admin/VirtualBox\ VMs/* || true
 rm -rf .vagrant/* || true
 rm -f *.vdi || true
 
-for f in $(vboxmanage list vms | grep inaccessible | awk {'print $2'} | cut -d'{' -f2 | cut -d'}' -f1); do
+for f in $(vboxmanage list vms | awk {'print $2'} | cut -d'{' -f2 | cut -d'}' -f1); do
     echo $f
     vboxmanage unregistervm --delete $f || true
 done

--- a/scripts/jenkins_cleanup.sh
+++ b/scripts/jenkins_cleanup.sh
@@ -1,0 +1,22 @@
+#/!/bin/bash
+
+# Script run on the Jenkins Node after the build(tests) are completed.
+# Forcibly cleans up _ALL_ VirtualBox VMs, not just those created during
+# the Jenkins run.
+
+# Doing each command with "|| true" so that even if a command fails, it won't
+# cause Jenkins to mark the build as failed.
+
+set -e
+
+cd $WORKSPACE/src/github.com/contiv/netplugin
+vagrant destroy -f || true
+
+rm -rf /home/admin/VirtualBox\ VMs/* || true
+rm -rf .vagrant/* || true
+rm -f *.vdi || true
+
+for f in $(vboxmanage list vms | grep inaccessible | awk {'print $2'} | cut -d'{' -f2 | cut -d'}' -f1); do
+    echo $f
+    vboxmanage unregistervm $f || true
+done

--- a/scripts/jenkins_cleanup.sh
+++ b/scripts/jenkins_cleanup.sh
@@ -18,5 +18,5 @@ rm -f *.vdi || true
 
 for f in $(vboxmanage list vms | grep inaccessible | awk {'print $2'} | cut -d'{' -f2 | cut -d'}' -f1); do
     echo $f
-    vboxmanage unregistervm $f || true
+    vboxmanage unregistervm --delete $f || true
 done


### PR DESCRIPTION
New cleanup script for Jenkins CI jobs, such as Netplugin_CI.

Attempts to forcibly remove every VirtualBox VM that is on the Jenkins Node.

This will be run as a post-build script, and will hopefully solve a number of issues CI has been having when it runs on a "dirty" VirtualBox environment. 

I tested this script on my test Jenkins server with a copy of Netplugin_CI.