### PR TITLE
finish the skydns cleanup & clean up the Vagrantfile a bit

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,8 +93,6 @@ rm /etc/docker/key.json
 (service docker restart) || exit 1
 
 usermod -aG docker vagrant
-docker load --input #{gopath_folder}/src/github.com/contiv/netplugin/scripts/dnscontainer.tar || echo "Loading skydns container failed"
-
 SCRIPT
 
 provision_common_always = <<SCRIPT

--- a/vagrant/mesos-cni/Vagrantfile
+++ b/vagrant/mesos-cni/Vagrantfile
@@ -71,9 +71,6 @@ sudo systemctl restart docker
 # remove duplicate docker key
 rm /etc/docker/key.json
 service docker restart || exit 1
-
-docker load --input #{gopath_folder}/src/github.com/contiv/netplugin/scripts/dnscontainer.tar
-
 SCRIPT
 
 provision_common_always = <<SCRIPT

--- a/vagrant/mesos-docker/Vagrantfile
+++ b/vagrant/mesos-docker/Vagrantfile
@@ -86,8 +86,6 @@ rm /etc/docker/key.json
 
 (ovs-vsctl set-manager tcp:127.0.0.1:6640 && \
  ovs-vsctl set-manager ptcp:6640) || exit 1
-
-docker load --input #{gopath_folder}/src/github.com/contiv/netplugin/scripts/dnscontainer.tar
 SCRIPT
 
 VAGRANTFILE_API_VERSION = "2"

--- a/vagrant/nomad-docker/Vagrantfile
+++ b/vagrant/nomad-docker/Vagrantfile
@@ -69,9 +69,6 @@ sudo systemctl start docker
 # remove duplicate docker key
 rm /etc/docker/key.json
 (service docker restart) || exit 1
-
-docker load --input #{gopath_folder}/src/github.com/contiv/netplugin/scripts/dnscontainer.tar
-
 SCRIPT
 
 provision_common_always = <<SCRIPT


### PR DESCRIPTION
This PR removes the leftover scripts/dnscontainer.tar skydns image and makes a few small changes to clean up the Vagrantfile. We should use the Vagrant hostname setup.