### PR TITLE
Handling netctl error gracefully

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -160,6 +160,9 @@ end
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box_check_update = false
+    if Vagrant.has_plugin?("vagrant-vbguest")
+        config.vbguest.auto_update = false
+    end 
     if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "ubuntu" then
         config.vm.box = "contiv/ubuntu1604-netplugin"
         config.vm.box_version = "0.7.0"

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -887,7 +887,8 @@ func setGlobal(ctx *cli.Context) {
 	fwdMode := ctx.String("fwd-mode")
 	arpMode := ctx.String("arp-mode")
 
-	global, _ := getClient(ctx).GlobalGet("global")
+	global, err := getClient(ctx).GlobalGet("global")
+	errCheck(ctx, err)
 
 	if fabMode != "" {
 		global.NetworkInfraType = fabMode
@@ -916,7 +917,8 @@ func setAciGw(ctx *cli.Context) {
 	enf := ctx.String("enforce-policies")
 	comTen := ctx.String("include-common-tenant")
 
-	acigw, _ := getClient(ctx).AciGwGet("aciGw")
+	acigw, err := getClient(ctx).AciGwGet("aciGw")
+	errCheck(ctx, err)
 	if acigw == nil {
 		acigw = &contivClient.AciGw{}
 		acigw.Name = "aciGw"


### PR DESCRIPTION
PR contains following:
1) handling error in netctl gracefully if netmaster is not running
2) Turning of guest addition updates for netplugin boxes since its already installed. Hit this issue on 5.1 vbox on mac.