### PR TITLE
Fix: Netplugin Netmaster bring up scenarios

### DIFF
--- a/netplugin/cluster/cluster.go
+++ b/netplugin/cluster/cluster.go
@@ -55,7 +55,8 @@ func masterKey(srvInfo objdb.ServiceInfo) string {
 func addMaster(netplugin *plugin.NetPlugin, srvInfo objdb.ServiceInfo) error {
 	// save it in db
 	MasterDB[masterKey(srvInfo)] = &srvInfo
-
+	netplugin.Lock()
+	defer netplugin.Unlock()
 	// tell the plugin about the master
 	return netplugin.AddMaster(core.ServiceInfo{
 		HostAddr: srvInfo.HostAddr,
@@ -67,6 +68,9 @@ func addMaster(netplugin *plugin.NetPlugin, srvInfo objdb.ServiceInfo) error {
 func deleteMaster(netplugin *plugin.NetPlugin, srvInfo objdb.ServiceInfo) error {
 	// delete from the db
 	delete(MasterDB, masterKey(srvInfo))
+
+	netplugin.Lock()
+	defer netplugin.Unlock()
 
 	// tel plugin about it
 	return netplugin.DeleteMaster(core.ServiceInfo{
@@ -280,10 +284,12 @@ func peerDiscoveryLoop(netplugin *plugin.NetPlugin, objClient objdb.API, ctrlIP,
 				log.Infof("Node add event for {%+v}", nodeInfo)
 
 				// add the node
+				netplugin.Lock()
 				err := netplugin.AddPeerHost(core.ServiceInfo{
 					HostAddr: nodeInfo.HostAddr,
 					Port:     vxlanUDPPort,
 				})
+				netplugin.Unlock()
 				if err != nil {
 					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)
 				}
@@ -291,10 +297,12 @@ func peerDiscoveryLoop(netplugin *plugin.NetPlugin, objClient objdb.API, ctrlIP,
 				log.Infof("Node delete event for {%+v}", nodeInfo)
 
 				// remove the node
+				netplugin.Lock()
 				err := netplugin.DeletePeerHost(core.ServiceInfo{
 					HostAddr: nodeInfo.HostAddr,
 					Port:     vxlanUDPPort,
 				})
+				netplugin.Unlock()
 				if err != nil {
 					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)
 				}


### PR DESCRIPTION
This fixes scenarios in deployments when the driver is in init stages and new events occur.
For eg:  global mode changes and new netmaster node / new netplugin gets added or deleted from the cluster