### PR TITLE
Vagrantfile: bump Go to 1.7.5

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ BEGIN {
 }
 
 # netplugin_synced_gopath="/opt/golang"
-go_version = ENV["GO_VERSION"] || "1.7.4"
+go_version = ENV["GO_VERSION"] || "1.7.5"
 docker_version = ENV["CONTIV_DOCKER_VERSION"] || "1.12.6"
 gopath_folder="/opt/gopath"
 http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''


### PR DESCRIPTION
This bumps Go to the just released Go 1.7.5.

The changelog can be seen here: https://github.com/golang/go/issues?q=milestone%3AGo1.7.5