### PR TITLE
node_test.go: avoid scp fingerprint prompt

### DIFF
--- a/test/systemtests/node_test.go
+++ b/test/systemtests/node_test.go
@@ -84,7 +84,7 @@ func (s *systemtestSuite) copyBinary(fileName string) error {
 	destFile := s.basicInfo.BinPath + "/" + fileName
 	for i := 1; i < len(s.nodes); i++ {
 		logrus.Infof("Copying %s binary to IP= %s and Directory = %s", srcFile, hostIPs[i], destFile)
-		s.nodes[0].tbnode.RunCommand("scp -i " + s.basicInfo.KeyFile + " " + srcFile + " " + hostIPs[i] + ":" + destFile)
+		s.nodes[0].tbnode.RunCommand("scp -oStrictHostKeyChecking=no -i " + s.basicInfo.KeyFile + " " + srcFile + " " + hostIPs[i] + ":" + destFile)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes an issue related to copying files via scp. scp will try to prompt the user to say if they trust the fingerprint of the host. This happens when the ssh and scp commands have never been used to connect to that host from the host which initiates the connection.