### PR TITLE
Remove fabric mode default

### DIFF
--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -430,7 +430,6 @@ var Commands = []cli.Command{
 					cli.StringFlag{
 						Name:  "fabric-mode, f",
 						Usage: "Fabric mode (aci, aci-opflex or default)",
-						Value: "default",
 					},
 					cli.StringFlag{
 						Name:  "vlan-range, v",


### PR DESCRIPTION
Fixes #737 

Since global set will always be an update call. We dont need to set default.