### PR TITLE
k8s-1.4 testing changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ test/systemtests/cfg.json
 .vagrant-state
 
 netplugin-version
+vagrant/k8s/export/.contiv.yaml*
+vagrant/k8s/contrib
+test/systemtests/cfg.json

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,8 @@ endif
 
 #kubernetes demo targets
 k8s-cluster:
+	cd vagrant/k8s/ && CONTIV_K8=1 ./setup_cluster.sh
+k8s-legacy-cluster:
 	cd vagrant/k8s/ && ./setup_cluster.sh
 k8s-l3-cluster:
 	CONTIV_L3=1 make k8s-cluster
@@ -131,17 +133,11 @@ k8s-demo-start:
 	cd vagrant/k8s/ && ./restart_cluster.sh && vagrant ssh k8master
 k8s-destroy:
 	cd vagrant/k8s/ && vagrant destroy -f
-k8s-sanity-cluster:
-	cd vagrant/k8s/ && ./setup_cluster.sh
-k8s-test:
-	export CONTIV_K8=1 && \
-	make k8s-sanity-cluster && \
-	cd vagrant/k8s/ && \
-	vagrant ssh k8master -c 'sudo -i bash -lc "cd /opt/gopath/src/github.com/contiv/netplugin && make run-build"' && \
-	./start_sanity_service.sh
-	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8'
-	CONTIV_K8=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|ACID|TestPolicy|TestTrigger"
+k8s-test: k8s-cluster
+	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8' -binpath contiv/bin
+	CONTIV_K8=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|TestPolicy"
 	cd vagrant/k8s && vagrant destroy -f
+
 # Mesos demo targets
 mesos-docker-demo:
 	cd vagrant/mesos-docker && \

--- a/install/k8s/cluster/bootstrap_centos.sh
+++ b/install/k8s/cluster/bootstrap_centos.sh
@@ -16,7 +16,12 @@ EOF
 
 setenforce 0
 
-yum install -y docker kubelet kubeadm kubectl kubernetes-cni
+# yum install -y docker kubelet kubeadm kubectl kubernetes-cni
+yum install -y docker ebtables \
+	https://fedorapeople.org/groups/kolla/kubeadm-1.6.0-0.alpha.0.2074.a092d8e0f95f52.x86_64.rpm \
+	https://fedorapeople.org/groups/kolla/kubectl-1.5.4-0.x86_64.rpm \
+	https://fedorapeople.org/groups/kolla/kubelet-1.5.4-0.x86_64.rpm \
+	https://fedorapeople.org/groups/kolla/kubernetes-cni-0.3.0.1-0.07a8a2.x86_64.rpm
 
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet

--- a/install/k8s/contiv/contiv_devtest.yaml
+++ b/install/k8s/contiv/contiv_devtest.yaml
@@ -1,0 +1,275 @@
+---
+# This ConfigMap is used to configure a self-hosted Contiv installation.
+# It can be used with an external cluster store(etcd or consul) or used
+# with the etcd instance being installed as contiv-etcd
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: contiv-config
+  namespace: kube-system
+data:
+  # The location of your cluster store. This is set to the
+  # avdertise-client value below from the contiv-etcd service.
+  # Change it to an external etcd/consul instance if required.
+  cluster_store: "etcd://__NETMASTER_IP__:6666"
+  # The CNI network configuration to install on each node.
+  cni_config: |-
+    {
+      "cniVersion": "0.1.0",
+      "name": "contiv-net",
+      "type": "contivk8s"
+    }
+  config: |-
+    {
+       "K8S_API_SERVER": "https://__NETMASTER_IP__:6443",
+       "K8S_CA": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+       "K8S_KEY": "",
+       "K8S_CERT": "",
+       "K8S_TOKEN": ""
+    }
+---
+
+# This manifest installs the Contiv etcd on the kubeadm master. 
+# If using an external etcd instance, this can be deleted. This uses a DaemonSet
+# to force it to run on the master even when the master isn't schedulable, and uses
+# nodeSelector to ensure it only runs on the master.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contiv-etcd
+  namespace: kube-system
+  labels:
+    k8s-app: contiv-etcd
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: contiv-etcd
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # Only run this pod on the master.
+      nodeSelector:
+        kubeadm.alpha.kubernetes.io/role: master
+      hostNetwork: true
+      containers:
+        - name: contiv-etcd
+          image: gcr.io/google_containers/etcd:2.2.1
+          command: ["/bin/sh","-c"]
+          args: ["/usr/local/bin/etcd --name=contiv --data-dir=/var/etcd/contiv-data --advertise-client-urls=http://__NETMASTER_IP__:6666 --listen-client-urls=http://0.0.0.0:6666 --listen-peer-urls=http://0.0.0.0:6667"]
+          volumeMounts:
+            - name: var-etcd
+              mountPath: /var/etcd
+      volumes:
+        - name: var-etcd
+          hostPath:
+            path: /var/etcd
+
+---
+# This manifest installs contiv-netplugin container, as well
+# as the Contiv CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: contiv-netplugin
+  namespace: kube-system
+  labels:
+    k8s-app: contiv-netplugin
+spec:
+  selector:
+    matchLabels:
+      k8s-app: contiv-netplugin
+  template:
+    metadata:
+      labels:
+        k8s-app: contiv-netplugin
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        # Runs netplugin container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: contiv-netplugin
+          image: contiv/netplugin:k8s_devtest
+          args:
+            - -pkubernetes
+          env:
+            - name: VLAN_IF
+              value: __VLAN_IF__
+            - name: VTEP_IP
+              valueFrom:
+                 fieldRef:
+                    fieldPath: status.podIP
+            - name: CONTIV_ETCD
+              valueFrom:
+                configMapKeyRef:
+                  name: contiv-config
+                  key: cluster_store
+            - name: CONTIV_CNI_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: contiv-config
+                  key: cni_config
+            - name: CONTIV_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: contiv-config
+                  key: config
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /etc/openvswitch
+              name: etc-openvswitch
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: false
+            - mountPath: /var/run
+              name: var-run
+              readOnly: false
+            - mountPath: /var/contiv
+              name: var-contiv
+              readOnly: false
+            - mountPath: /etc/kubernetes/pki
+              name: etc-kubernetes-pki
+              readOnly: false
+            - mountPath: /etc/kubernetes/ssl
+              name: etc-kubernetes-ssl
+              readOnly: false
+            - mountPath: /opt/cni/bin
+              name: cni-bin-dir
+              readOnly: false
+            - mountPath: /etc/cni/net.d/
+              name: etc-cni-dir
+              readOnly: false
+            - mountPath: /contiv/bin
+              name: contiv-bin-dir
+              readOnly: false
+      volumes:
+        # Used by contiv-netplugin
+        - name: etc-openvswitch
+          hostPath:
+            path: /etc/openvswitch
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run
+          hostPath:
+            path: /var/run
+        - name: var-contiv
+          hostPath:
+            path: /var/contiv
+        - name: etc-kubernetes-pki
+          hostPath:
+            path: /etc/kubernetes/pki
+        - name: etc-kubernetes-ssl
+          hostPath:
+            path: /etc/kubernetes/ssl
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: etc-cni-dir
+          hostPath:
+            path: /etc/cni/net.d/
+        - name: contiv-bin-dir
+          hostPath:
+            path: /opt/gopath/bin
+---
+
+# This manifest deploys the Contiv API Server on Kubernetes.
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: contiv-netmaster
+  namespace: kube-system
+  labels:
+    k8s-app: contiv-netmaster
+spec:
+  # The netmaster should have 1, 3, 5 nodes of which one is active at any given time.
+  # More nodes are desired in a production environment for HA.
+  replicas: 1
+  template:
+    metadata:
+      name: contiv-netmaster
+      namespace: kube-system
+      labels:
+        k8s-app: contiv-netmaster
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # Only run this pod on the master.
+      nodeSelector:
+        kubeadm.alpha.kubernetes.io/role: master
+      # The netmaster must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: contiv-netmaster
+          image: contiv/netplugin:k8s_devtest
+          args:
+            - -m
+            - -pkubernetes
+          env:
+            - name: CONTIV_ETCD
+              valueFrom:
+                configMapKeyRef:
+                  name: contiv-config
+                  key: cluster_store
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /etc/openvswitch
+              name: etc-openvswitch
+              readOnly: false
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: false
+            - mountPath: /var/run
+              name: var-run
+              readOnly: false
+            - mountPath: /var/contiv
+              name: var-contiv
+              readOnly: false
+            - mountPath: /etc/kubernetes/ssl
+              name: etc-kubernetes-ssl
+              readOnly: false
+            - mountPath: /opt/cni/bin
+              name: cni-bin-dir
+              readOnly: false
+            - mountPath: /contiv/bin
+              name: contiv-bin-dir
+              readOnly: false
+      volumes:
+        # Used by contiv-netmaster
+        - name: etc-openvswitch
+          hostPath:
+            path: /etc/openvswitch
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run
+          hostPath:
+            path: /var/run
+        - name: var-contiv
+          hostPath:
+            path: /var/contiv
+        - name: etc-kubernetes-ssl
+          hostPath:
+            path: /etc/kubernetes/ssl
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: contiv-bin-dir
+          hostPath:
+            path: /opt/gopath/bin
+---

--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -30,5 +30,4 @@ RUN apt-get update \
 COPY ./bin /contiv/bin/
 COPY ./scripts /contiv/scripts/
 
-
 ENTRYPOINT ["/contiv/scripts/contivNet.sh"]

--- a/scripts/netContain/contivNet.sh
+++ b/scripts/netContain/contivNet.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+#Initialize complete contiv container. Start OVS and Net Plugin
+
+cstore="$CONTIV_ETCD"
+vtep_ip="$VTEP_IP"
+vlan_if="$VLAN_IF"
+
+set -euo pipefail
+
+reinit=false
+plugin="docker"
+netmaster=false
+netplugin=true
+debug=""
+cleanup=false
+cstore_param=""
+vtep_ip_param=""
+vlan_if_param=""
+
+touch /tmp/restart_netmaster
+touch /tmp/restart_netplugin
+
+#This needs to be fixed, we cant rely on the value being supplied from 
+# parameters, just explosion of parameters is not a great solution
+#export no_proxy="0.0.0.0, 172.28.11.253" 
+#echo "192.168.2.10 netmaster" > /etc/hosts
+
+#Needed for Netplugin to connect with OVS, This needs to be 
+#fixed as well. netplugin should have OVS locally. 
+echo "0.0.0.0 localhost" >> /etc/hosts
+
+while getopts ":xmp:v:i:c:dr" opt; do
+    case $opt in
+       m)
+          netmaster=true
+          netplugin=false
+          ;;
+       v)
+          vtep_ip=$OPTARG
+          netplugin=true
+          ;;
+       i)
+          vlan_if=$OPTARG
+          netplugin=true
+          ;;
+       c)
+          cstore=$OPTARG
+          ;;
+       p)
+          plugin=$OPTARG
+          ;;
+       r)
+          cleanup=true
+          ;;
+       x)
+          reinit=true
+          ;;
+       d)
+          debug="-debug"
+          ;;
+       :)
+          echo "An argument required for $OPTARG was not passed"
+          ;;
+       ?)
+          echo "Invalid option supplied"
+          ;;
+     esac
+done
+
+if [ $cleanup == true ] || [ $reinit == true ]; then
+    ovs-vsctl del-br contivVlanBridge || true
+    ovs-vsctl del-br contivVxlanBridge || true
+    ovs-vsctl del-br contivHostBridge || true
+    for p in $(ifconfig  | grep vport | awk '{print $1}'); do
+        ip link delete $p type veth;
+    done
+    rm -f /opt/cni/bin/contivk8s || true
+    rm -f /etc/cni/net.d/1-contiv.conf || true
+fi
+
+if [ $cleanup == true ]; then
+  exit 0
+fi
+
+if [ $netplugin == false ] && [ $netmaster == false ]; then
+   echo "Neither Netmaster or Net Plugin Options Specificed"
+   exit 1
+fi
+
+
+if [ $netplugin == true ]; then
+    echo "Initializing OVS"
+    /contiv/scripts/ovsInit.sh
+    echo "Initialized OVS"
+fi
+
+if [ $reinit == true ]; then
+    ovs-vsctl list-br | grep contiv | xargs -I % ovs-vsctl del-br % > /dev/null 2>&1
+fi
+
+mkdir -p /opt/contiv/
+mkdir -p /var/contiv/log/
+
+if  [ $netplugin == true ] && [ "$plugin" == "kubernetes" ]; then
+    mkdir -p /opt/cni/bin
+    cp /contiv/bin/contivk8s /opt/cni/bin/
+    mkdir -p  /opt/contiv/config
+    mkdir -p /var/contiv/config
+    echo ${CONTIV_CONFIG} > /var/contiv/config/contiv.json
+    cp /var/contiv/config/contiv.json /opt/contiv/config/contiv.json
+    mkdir -p /etc/cni/net.d/
+    echo ${CONTIV_CNI_CONFIG} > /etc/cni/net.d/1-contiv.conf
+fi
+
+if [ $netmaster == true ]; then
+   echo "Starting Netmaster "
+   mkdir -p /var/contiv/log/
+   while [ true ]; do
+       if [ -f /tmp/restart_netmaster ]; then
+           if [ "$cstore" != "" ]; then
+               /contiv/bin/netmaster $debug -cluster-mode $plugin -cluster-store $cstore &> /var/contiv/log/netmaster.log
+           else
+               /contiv/bin/netmaster $debug -cluster-mode $plugin &> /var/contiv/log/netmaster.log
+           fi
+           echo "CRITICAL : Netmaster has exited. Trying to respawn in 5s"
+       fi
+       sleep 5
+   done
+elif [ $netplugin == true ]; then
+   echo "Starting Netplugin "
+   modprobe openvswitch
+   mkdir -p /var/contiv/log/
+   while true; do
+       if [ -f /tmp/restart_netplugin ]; then
+           if [ "$cstore" != "" ]; then
+               cstore_param="-cluster-store"
+           fi
+           if [ "$vtep_ip" != "" ]; then
+               vtep_ip_param="-vtep-ip"
+           fi
+           if [ "$vlan_if" != "" ]; then
+               vlan_if_param="-vlan-if"
+           fi
+           /contiv/bin/netplugin $debug $cstore_param $cstore $vtep_ip_param $vtep_ip $vlan_if_param $vlan_if -plugin-mode $plugin &> /var/contiv/log/netplugin.log
+           echo "CRITICAL : Netplugin has exited. Trying to respawn in 5s"
+       fi
+       sleep 5
+   done
+fi

--- a/scripts/netContain/scripts/contivNet.sh
+++ b/scripts/netContain/scripts/contivNet.sh
@@ -13,6 +13,8 @@ netmaster=false
 netplugin=true
 debug=""
 cleanup=false
+listen_url_param=""
+control_url_param=""
 cstore_param=""
 vtep_ip_param=""
 vlan_if_param=""
@@ -34,6 +36,12 @@ while getopts ":xmp:v:i:c:dr" opt; do
 		m)
 			netmaster=true
 			netplugin=false
+			;;
+		l)
+			listen_url=$OPTARG
+			;;
+		t)
+			ctrl_url=$OPTARG
 			;;
 		v)
 			vtep_ip=$OPTARG
@@ -126,7 +134,6 @@ if [ $netmaster == true ]; then
 elif [ $netplugin == true ]; then
 	echo "Starting netplugin"
 	modprobe openvswitch
-	mkdir -p /var/contiv/log/
 
 	while true; do
 		if [ -f /tmp/restart_netplugin ]; then

--- a/scripts/netContain/scripts/contivNet.sh
+++ b/scripts/netContain/scripts/contivNet.sh
@@ -17,6 +17,9 @@ cstore_param=""
 vtep_ip_param=""
 vlan_if_param=""
 
+touch /tmp/restart_netmaster
+touch /tmp/restart_netplugin
+
 #This needs to be fixed, we cant rely on the value being supplied from
 # parameters, just explosion of parameters is not a great solution
 #export no_proxy="0.0.0.0, 172.28.11.253"
@@ -65,8 +68,7 @@ while getopts ":xmp:v:i:c:dr" opt; do
 done
 
 if [ $cleanup == true ] || [ $reinit == true ]; then
-	ovs-vsctl del-br contivVlanBridge || true
-	ovs-vsctl del-br contivVxlanBridge || true
+	ovs-vsctl list-br | grep contiv | xargs -I % ovs-vsctl del-br % > /dev/null 2>&1
 	for p in $(ifconfig | grep vport | awk '{print $1}'); do
 		ip link delete $p type veth
 	done
@@ -106,15 +108,19 @@ if [ "$plugin" == "kubernetes" ]; then
    fi
 fi
 
+set +eo pipefail
+
 if [ $netmaster == true ]; then
 	echo "Starting netmaster "
 	while true; do
-		if [ "$cstore" != "" ]; then
-			/contiv/bin/netmaster $debug -cluster-mode $plugin -cluster-store $cstore &>/var/contiv/log/netmaster.log
-		else
-			/contiv/bin/netmaster $debug -cluster-mode $plugin &>/var/contiv/log/netmaster.log
+		if [ -f /tmp/restart_netmaster ]; then
+			if [ "$cstore" != "" ]; then
+				/contiv/bin/netmaster $debug -cluster-mode $plugin -cluster-store $cstore &>/var/contiv/log/netmaster.log
+			else
+				/contiv/bin/netmaster $debug -cluster-mode $plugin &>/var/contiv/log/netmaster.log
+			fi
+			echo "CRITICAL : Netmaster has exited. Trying to respawn in 5s"
 		fi
-		echo "CRITICAL: netmaster has exited, Respawn in 5"
 		sleep 5
 	done
 elif [ $netplugin == true ]; then
@@ -123,17 +129,19 @@ elif [ $netplugin == true ]; then
 	mkdir -p /var/contiv/log/
 
 	while true; do
-		if [ "$cstore" != "" ]; then
-			cstore_param="-cluster-store"
+		if [ -f /tmp/restart_netplugin ]; then
+			if [ "$cstore" != "" ]; then
+				cstore_param="-cluster-store"
+			fi
+			if [ "$vtep_ip" != "" ]; then
+				vtep_ip_param="-vtep-ip"
+			fi
+			if [ "$vlan_if" != "" ]; then
+				vlan_if_param="-vlan-if"
+			fi
+			/contiv/bin/netplugin $debug $cstore_param $cstore $vtep_ip_param $vtep_ip $vlan_if_param $vlan_if -plugin-mode $plugin &>/var/contiv/log/netplugin.log
+			echo "CRITICAL : Netplugin has exited. Trying to respawn in 5s"
 		fi
-		if [ "$vtep_ip" != "" ]; then
-			vtep_ip_param="-vtep-ip"
-		fi
-		if [ "$vlan_if" != "" ]; then
-			vlan_if_param="-vlan-if"
-		fi
-		/contiv/bin/netplugin $debug $cstore_param $cstore $vtep_ip_param $vtep_ip $vlan_if_param $vlan_if -plugin-mode $plugin &>/var/contiv/log/netplugin.log
-		echo "CRITICAL: netplugin has exited, Respawn in 5"
 		sleep 5
 	done
 fi

--- a/scripts/python/createcfg.py
+++ b/scripts/python/createcfg.py
@@ -10,6 +10,7 @@ parser.add_argument("-swarm_var", default='', help="Swarm host variable")
 parser.add_argument("-platform", default='vagrant', help="Vagrant/baremetal")
 parser.add_argument("-product", default='netplugin', help="netplugin/volplugin")
 parser.add_argument("-contiv_l3", default='', help="Running in L3 mode")
+parser.add_argument("-contiv_k8", default=0, help="Running in K8s mode")
 parser.add_argument("-key_file", default="/home/admin/.ssh/id_rsa", help="file path of key_file")
 parser.add_argument("-binpath", default="/opt/gopath/bin", help="GOBIN path")
 parser.add_argument("-hostips", default="192.168.2.10,192.168.2.11,192.168.2.12", help="Host IPs in the system")
@@ -21,8 +22,10 @@ parser.add_argument("-containers", default=3, help="Number of containers for eac
 parser.add_argument("-iterations", default=3, help="Number of iterations for each test")
 parser.add_argument("-enableDNS", default=False, help="Enabling DNS")
 parser.add_argument("-contiv_cluster_store", default="etcd://localhost:2379", help="cluster info")
+parser.add_argument("-k8_contiv_cluster_store", default="etcd://192.168.2.10:6666", help="cluster info")
 parser.add_argument("-datainterfaces", default="eth2,eth3", help="Data interface")
 parser.add_argument("-l3_datainterfaces", default="eth2", help="Data interface")
+parser.add_argument("-k8_datainterfaces", default="eth2", help="Data interface")
 parser.add_argument("-mgmtinterface", default="eth1", help="Control interface")
 parser.add_argument("-vlan", default="1120-1150", help="vlan range")
 parser.add_argument("-vxlan", default="1-10000", help="vxlan range")
@@ -43,8 +46,11 @@ data['short'] = args.short
 data['containers'] = args.containers
 data['iterations'] = args.iterations
 data['enableDNS'] = args.enableDNS
-data['contiv_cluster_store'] = args.contiv_cluster_store
 data['contiv_l3'] = args.contiv_l3
+if args.scheduler == 'k8':
+    data['contiv_cluster_store'] = args.k8_contiv_cluster_store
+else:
+    data['contiv_cluster_store'] = args.contiv_cluster_store
 data['keyFile'] = args.key_file
 data['binpath'] = args.binpath
 data['hostips'] = args.hostips
@@ -53,6 +59,8 @@ if args.contiv_l3 == '':
     data['dataInterfaces'] = args.datainterfaces
 else:
     data['dataInterfaces'] = args.l3_datainterfaces
+if args.scheduler == 'k8':
+    data['dataInterfaces'] = args.k8_datainterfaces
 data['mgmtInterface'] = args.mgmtinterface
 data['vlan'] = args.vlan
 data['vxlan'] = args.vxlan

--- a/scripts/python/createcfg.py
+++ b/scripts/python/createcfg.py
@@ -10,7 +10,7 @@ parser.add_argument("-swarm_var", default='', help="Swarm host variable")
 parser.add_argument("-platform", default='vagrant', help="Vagrant/baremetal")
 parser.add_argument("-product", default='netplugin', help="netplugin/volplugin")
 parser.add_argument("-contiv_l3", default='', help="Running in L3 mode")
-parser.add_argument("-contiv_k8", default=0, help="Running in K8s mode")
+parser.add_argument("-contiv_k8s", default=0, help="Running in K8s mode")
 parser.add_argument("-key_file", default="/home/admin/.ssh/id_rsa", help="file path of key_file")
 parser.add_argument("-binpath", default="/opt/gopath/bin", help="GOBIN path")
 parser.add_argument("-hostips", default="192.168.2.10,192.168.2.11,192.168.2.12", help="Host IPs in the system")
@@ -22,10 +22,10 @@ parser.add_argument("-containers", default=3, help="Number of containers for eac
 parser.add_argument("-iterations", default=3, help="Number of iterations for each test")
 parser.add_argument("-enableDNS", default=False, help="Enabling DNS")
 parser.add_argument("-contiv_cluster_store", default="etcd://localhost:2379", help="cluster info")
-parser.add_argument("-k8_contiv_cluster_store", default="etcd://192.168.2.10:6666", help="cluster info")
+parser.add_argument("-k8s_contiv_cluster_store", default="etcd://192.168.2.10:6666", help="cluster info")
 parser.add_argument("-datainterfaces", default="eth2,eth3", help="Data interface")
 parser.add_argument("-l3_datainterfaces", default="eth2", help="Data interface")
-parser.add_argument("-k8_datainterfaces", default="eth2", help="Data interface")
+parser.add_argument("-k8s_datainterfaces", default="eth2", help="Data interface")
 parser.add_argument("-mgmtinterface", default="eth1", help="Control interface")
 parser.add_argument("-vlan", default="1120-1150", help="vlan range")
 parser.add_argument("-vxlan", default="1-10000", help="vxlan range")
@@ -47,8 +47,8 @@ data['containers'] = args.containers
 data['iterations'] = args.iterations
 data['enableDNS'] = args.enableDNS
 data['contiv_l3'] = args.contiv_l3
-if args.scheduler == 'k8':
-    data['contiv_cluster_store'] = args.k8_contiv_cluster_store
+if args.scheduler == 'k8s':
+    data['contiv_cluster_store'] = args.k8s_contiv_cluster_store
 else:
     data['contiv_cluster_store'] = args.contiv_cluster_store
 data['keyFile'] = args.key_file
@@ -59,8 +59,8 @@ if args.contiv_l3 == '':
     data['dataInterfaces'] = args.datainterfaces
 else:
     data['dataInterfaces'] = args.l3_datainterfaces
-if args.scheduler == 'k8':
-    data['dataInterfaces'] = args.k8_datainterfaces
+if args.scheduler == 'k8s':
+    data['dataInterfaces'] = args.k8s_datainterfaces
 data['mgmtInterface'] = args.mgmtinterface
 data['vlan'] = args.vlan
 data['vxlan'] = args.vxlan

--- a/test/systemtests/init_test.go
+++ b/test/systemtests/init_test.go
@@ -2,9 +2,7 @@ package systemtests
 
 import (
 	"flag"
-	"fmt"
 	"os"
-	"strings"
 	. "testing"
 
 	"github.com/Sirupsen/logrus"
@@ -117,7 +115,6 @@ func (s *systemtestSuite) SetUpTest(c *C) {
 	case "vagrant":
 		s.SetUpTestVagrant(c)
 	}
-
 }
 
 func (s *systemtestSuite) TearDownTest(c *C) {
@@ -149,19 +146,6 @@ func (s *systemtestSuite) TearDownTest(c *C) {
 func (s *systemtestSuite) TearDownSuite(c *C) {
 	for _, node := range s.nodes {
 		node.exec.cleanupContainers()
-	}
-
-	// Print all errors and fatal messages
-	for _, node := range s.nodes {
-		logrus.Infof("Checking for errors on %v", node.Name())
-		out, _ := node.runCommand(`for i in /tmp/net*; do grep "error\|fatal\|panic" $i; done`)
-		if strings.Contains(out, "No such file or directory") {
-			continue
-		}
-		if out != "" {
-			logrus.Errorf("Errors in logfiles on %s: \n", node.Name())
-			fmt.Printf("%s\n==========================\n\n", out)
-		}
 	}
 }
 

--- a/test/systemtests/k8setup_test.go
+++ b/test/systemtests/k8setup_test.go
@@ -935,7 +935,7 @@ func (k *kubernetes) reloadNode(n *node) error {
 	cmd := exec.Command("vagrant", "reload", n.Name())
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "VAGRANT_CWD="+topDir+"/src/github.com/contiv/netplugin/vagrant/k8s/")
-	cmd.Env = append(cmd.Env, "CONTIV_K8=1")
+	cmd.Env = append(cmd.Env, "CONTIV_K8S_USE_KUBEADM=1")
 	out, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/test/systemtests/network_test.go
+++ b/test/systemtests/network_test.go
@@ -380,6 +380,10 @@ func (s *systemtestSuite) TestNetworkAddDeleteTenantFwdModeChangeVXLAN(c *C) {
 	for i := 0; i < s.basicInfo.Iterations; i++ {
 		s.testNetworkAddDeleteTenant(c, "vxlan", fwdMode)
 		if fwdMode == "routing" {
+			if s.basicInfo.Scheduler == "k8" {
+				c.Assert(s.TearDownInfraNetwork(), IsNil)
+			}
+
 			c.Assert(s.cli.GlobalPost(&client.Global{FwdMode: "bridge",
 				Name:             "global",
 				NetworkInfraType: "default",
@@ -389,9 +393,15 @@ func (s *systemtestSuite) TestNetworkAddDeleteTenantFwdModeChangeVXLAN(c *C) {
 				PvtSubnet:        "172.19.0.0/16",
 			}), IsNil)
 			time.Sleep(60 * time.Second)
+			if s.basicInfo.Scheduler == "k8" {
+				c.Assert(s.SetupInfraNetwork(), IsNil)
+			}
 			s.testNetworkAddDeleteTenant(c, "vxlan", "bridge")
 			fwdMode = "bridge"
 		} else {
+			if s.basicInfo.Scheduler == "k8" {
+				c.Assert(s.TearDownInfraNetwork(), IsNil)
+			}
 			c.Assert(s.cli.GlobalPost(&client.Global{FwdMode: "routing",
 				Name:             "global",
 				NetworkInfraType: "default",
@@ -401,6 +411,9 @@ func (s *systemtestSuite) TestNetworkAddDeleteTenantFwdModeChangeVXLAN(c *C) {
 				PvtSubnet:        "172.19.0.0/16",
 			}), IsNil)
 			time.Sleep(60 * time.Second)
+			if s.basicInfo.Scheduler == "k8" {
+				c.Assert(s.SetupInfraNetwork(), IsNil)
+			}
 			s.testNetworkAddDeleteTenant(c, "vxlan", "routing")
 			fwdMode = "routing"
 		}

--- a/test/systemtests/node_test.go
+++ b/test/systemtests/node_test.go
@@ -138,6 +138,7 @@ func (n *node) checkForNetpluginErrors() error {
 
 func (n *node) runCommandWithTimeOut(cmd string, tick, timeout time.Duration) error {
 	runCmd := func() (string, bool) {
+		logrus.Debugf("Running cmd: %s", cmd)
 		if err := n.tbnode.RunCommand(cmd); err != nil {
 			return "", false
 		}

--- a/test/systemtests/policy_test.go
+++ b/test/systemtests/policy_test.go
@@ -389,7 +389,7 @@ func (s *systemtestSuite) testPolicyFeatures(c *C, encap string) {
 		NetworkName: "private",
 		Subnet:      "10.1.0.0/16",
 		Gateway:     "10.1.1.254",
-		PktTag:      1,
+		PktTag:      10,
 		Encap:       encap,
 	}
 	c.Assert(s.cli.NetworkPost(network), IsNil)
@@ -398,7 +398,7 @@ func (s *systemtestSuite) testPolicyFeatures(c *C, encap string) {
 		NetworkName: "dummy",
 		Subnet:      "20.1.0.0/16",
 		Gateway:     "20.1.1.254",
-		PktTag:      2,
+		PktTag:      20,
 		Encap:       encap,
 	}
 	c.Assert(s.cli.NetworkPost(dummyNet), IsNil)

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -7,15 +7,14 @@ require "rubygems"
 require "json"
 require 'fileutils'
 
-# netplugin_synced_gopath="/opt/golang"
 gopath_folder="/opt/gopath"
+master_ip = "192.168.2.10"
 
 http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
 https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
 
 # python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))
 token = "d900e1.8a392798f13b33a4"
-master_ip = "192.168.2.10"
 
 # method to create an etc_hosts file based on the cluster info
 def create_etc_hosts(cluster)
@@ -85,22 +84,10 @@ echo "export no_proxy='k8master,192.168.2.10,192.168.2.11,192.168.2.12,netmaster
 echo "export no_proxy='k8master,192.168.2.10,192.168.2.11,192.168.2.12,netmaster,localhost,127.0.0.1'" >> ~/.profile
 source /etc/profile.d/envvar.sh
 # Change ownership for gopath folder
-chown vagrant #{gopath_folder}
+chown -R vagrant #{gopath_folder}
 sudo yum install -y net-tools
-SCRIPT
-
-provision_master = <<SCRIPT
-echo "export https_proxy='$2'" >> /etc/profile.d/envvar.sh
-echo "export http_proxy='$1'" >> ~/.profile
-echo "export https_proxy='$2'" >> ~/.profile
-source /etc/profile.d/envvar.sh
-sudo -E bash
-go get github.com/tools/godep
-cd $GOPATH/src/github.com/tools
-go install ./godep
-sudo yum install -y net-tools
+sudo yum install -y go
 sudo yum install -y git
-#git config --global http.proxy $HTTP_PROXY
 SCRIPT
 
 # begin execution here
@@ -154,93 +141,63 @@ Vagrant.configure(2) do |config|
       end
    end
 
-  #config.ssh.password = 'vagrant'
   config.ssh.insert_key = false
   config.ssh.private_key_path = "./../../scripts/insecure_private_key"
   
   config.vm.synced_folder "./export", "/shared"
+  config.vm.synced_folder "./../../","/opt/gopath/src/github.com/contiv/netplugin"
+  config.vm.synced_folder "./../../bin","/opt/gopath/bin"
   cluster.each do |role, member_list|
     member_list.each do |member_info|
       config.vm.define vm_name = member_info["name"] do |c|
-         if ENV['CONTIV_K8'] == "1" then
-       	   c.vm.box_version = "0.0.4"
-           box_name = vm_name
-	    if  role == "master" then
-	      c.vm.box = "contiv/k8master"
-              c.vm.synced_folder "./../../","/opt/gopath/src/github.com/contiv/netplugin"
-	      c.vm.provision "shell" do |s|
-		s.inline = provision_k8
-                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
-              end
-	      c.vm.provision "shell" do |s|
-                s.inline = provision_master
-	        s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
-              end
-              c.vm.network "forwarded_port", guest: 9999, host: 9999
-       	   else
-	      if vm_name =="k8node-01" then
- 	      	c.vm.box = "contiv/k8node01"
- 	      else
- 		 if vm_name == "k8node-02" then
- 		    c.vm.box = "contiv/k8node02"
-                  else
-		    c.vm.box = "contiv/k8node03"
- 		 end
- 	      end	
-	   end
-	   c.vm.synced_folder "./../../bin","/opt/gopath/bin"
-	   c.vm.provision "shell" do |s|
-              s.inline = provision_k8
-               s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
-           end
-	else
-          if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "rhel7" then
-            # Download rhel7.2 box from https://access.redhat.com/downloads/content/293/ver=2/rhel---7/2.0.0/x86_64/product-software
-            # Add it as rhel7 vagrant box add rhel-cdk-kubernetes-7.2-29.x86_64.vagrant-virtualbox.box --name=rhel7
-            c.vm.box = "rhel7"
-          else
-            c.vm.box = "contiv/k8s-centos"
-            c.vm.box_version = "0.0.7"
-          end
+        if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "rhel7" then
+          # Download rhel7.2 box from https://access.redhat.com/downloads/content/293/ver=2/rhel---7/2.0.0/x86_64/product-software
+          # Add it as rhel7 vagrant box add rhel-cdk-kubernetes-7.2-29.x86_64.vagrant-virtualbox.box --name=rhel7
+          c.vm.box = "rhel7"
+        else
+          c.vm.box = "contiv/k8s-centos"
+          c.vm.box_version = "0.0.7"
+        end
 	    c.vm.provision "shell" do |s|
-               s.inline = provision_master
-               s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
-            end 
-	end
-	network_name = "contiv_purple"
-	if ENV['CONTIV_L3'] then
-	   if vm_name == "k8node-03" then
-             network_name = "contiv_orange"
-           end
-	   if vm_name == "k8node-01" then
-              network_name = "contiv_yellow"
-           end
-	   if vm_name == "k8node-02" then
-              network_name = "contiv_green"
-           end
+           s.inline = provision_k8
+           s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
+        end
+
+        network_name = "contiv_purple"
+        if ENV['CONTIV_L3'] then
+            if vm_name == "k8node-03" then
+                network_name = "contiv_orange"
+            end
+	        if vm_name == "k8node-01" then
+                network_name = "contiv_yellow"
+            end
+	        if vm_name == "k8node-02" then
+                network_name = "contiv_green"
+            end
         end
 	
         # configure ip address etc
         c.vm.hostname = vm_name
         c.vm.network :private_network, ip: member_info["contiv_control_ip"], virtualbox__intnet: "true"
         c.vm.network :private_network, ip: member_info["contiv_network_ip"], virtualbox__intnet: network_name, auto_config: false
-        c.vm.provider "virtualbox" do |v|
 
-                if vm_name == "k8master" then
-                  v.memory = 2048
-                else
-                  v.memory = 1024
-                end  
-                # make all nics 'virtio' to take benefit of builtin vlan tag
-                # support, which otherwise needs to be enabled in Intel drivers,
-                # which are used by default by virtualbox
-                v.customize ['modifyvm', :id, '--nictype1', 'virtio']
-                v.customize ['modifyvm', :id, '--nictype2', 'virtio']
-                v.customize ['modifyvm', :id, '--nictype3', 'virtio']
-                v.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
-                v.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
-                v.customize ['modifyvm', :id, '--paravirtprovider', "kvm"]
+        c.vm.provider "virtualbox" do |v|
+          if vm_name == "k8master" then
+            v.memory = 2048
+          else
+            v.memory = 1024
+          end  
+          # make all nics 'virtio' to take benefit of builtin vlan tag
+          # support, which otherwise needs to be enabled in Intel drivers,
+          # which are used by default by virtualbox
+          v.customize ['modifyvm', :id, '--nictype1', 'virtio']
+          v.customize ['modifyvm', :id, '--nictype2', 'virtio']
+          v.customize ['modifyvm', :id, '--nictype3', 'virtio']
+          v.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
+          v.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
+          v.customize ['modifyvm', :id, '--paravirtprovider', "kvm"]
         end # v
+
         # RHEL box that is available with the CDK comes with an older version
         # of k8s. Uninstall it and install openvswitch.
         if ENV['CONTIV_NODE_OS'] && ENV['CONTIV_NODE_OS'] == "rhel7" then
@@ -250,6 +207,7 @@ Vagrant.configure(2) do |config|
             yum install -y https://cisco.box.com/shared/static/zzmpe1zesdpf270k9pml40rlm4o8fs56.rpm
             EOS
         end
+
         c.vm.provision "shell", inline: <<-EOS
           sudo setenforce 0
           sudo systemctl stop firewalld
@@ -257,18 +215,21 @@ Vagrant.configure(2) do |config|
           #copy the etc_hosts file we created
           sudo cp /shared/.etc_hosts /etc/hosts
           EOS
-        if ENV['VAGRANT_USE_KUBEADM']
-          c.vm.provision :shell, path: '../../install/k8s/cluster/bootstrap_centos.sh'
-          if role == 'master'
-            # Install kubernetes on master
-            c.vm.provision :shell, path: '../../install/k8s/cluster/k8smaster_centos.sh', args: [token, member_info['contiv_control_ip'], 'v1.4.1']
-            # Now install contiv
-            c.vm.provision :shell, inline: install_contiv
-          else
-            # Install kubernetes on nodes
-            c.vm.provision :shell, path: '../../install/k8s/cluster/k8sworker_centos.sh', args: [token, master_ip]
-          end # if
-        end
+
+        c.vm.provision :shell, path: "../../install/k8s/cluster/bootstrap_centos.sh"
+        if  role == "master" then
+           c.vm.network "forwarded_port", guest: 9999, host: 9999
+           # Install kubernetes on master
+           # With the latest 1.4.4 kube*, kubeadm hangs frequently while waiting for the control plane to be available.
+           # So using v1.4.1 as per https://github.com/kubernetes/kubernetes/issues/33729 
+           c.vm.provision :shell, path: "../../install/k8s/cluster/k8smaster_centos.sh", args:[token, member_info["contiv_control_ip"], "v1.4.1"]
+           # Now install contiv
+           c.vm.provision :shell, inline: "kubectl apply -f /shared/.contiv.yaml"
+           c.vm.provision :shell, inline: "kubectl -n kube-system delete deployment kube-dns"
+        else
+           # Install kubernetes on nodes
+           c.vm.provision :shell, path: "../../install/k8s/cluster/k8sworker_centos.sh", args:[token, master_ip]
+        end # if role
       end # c
     end # member_info
   end #role

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -145,7 +145,7 @@ Vagrant.configure(2) do |config|
   config.ssh.private_key_path = "./../../scripts/insecure_private_key"
   
   config.vm.synced_folder "./export", "/shared"
-  config.vm.synced_folder "./../../","/opt/gopath/src/github.com/contiv/netplugin"
+  config.vm.synced_folder "./../../../../../","/opt/gopath/src"
   config.vm.synced_folder "./../../bin","/opt/gopath/bin"
   cluster.each do |role, member_list|
     member_list.each do |member_info|
@@ -234,4 +234,3 @@ Vagrant.configure(2) do |config|
     end # member_info
   end #role
 end #config
-#

--- a/vagrant/k8s/setup_cluster.sh
+++ b/vagrant/k8s/setup_cluster.sh
@@ -73,12 +73,8 @@ function GetContrib {
 top_dir=$(git rev-parse --show-toplevel | sed 's|/[^/]*$||')
 
 # kubernetes installation mechanism
-k8_sanity=${CONTIV_K8}
+k8_devtest=$CONTIV_K8
 legacyInstall=0
-
-if [ "$k8_sanity" == "1" ]; then
-    legacyInstall=1
-fi
 
 if [ "`printf "v1.4\n$k8sVer" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -g | head -n 1`" != "v1.4" ]; then
    legacyInstall=1
@@ -104,7 +100,11 @@ if [ "$legacyInstall" == 1 ]; then
    vagrant up
 else
    # Copy the contiv installation file to shared folder
-   cp -f ../../install/k8s/contiv/contiv.yaml ./export/.contiv.yaml
+   if [ "$k8_devtest" == 1 ]; then
+       cp -f ../../install/k8s/contiv/contiv_devtest.yaml ./export/.contiv.yaml
+   else
+       cp -f ../../install/k8s/contiv/contiv.yaml ./export/.contiv.yaml
+   fi
    # Replace __NETMASTER_IP__ and __VLAN_IF__
    sed -i.bak 's/__NETMASTER_IP__/192.168.2.10/g' ./export/.contiv.yaml
    sed -i.bak 's/__VLAN_IF__/eth2/g' ./export/.contiv.yaml

--- a/vagrant/k8s/setup_cluster.sh
+++ b/vagrant/k8s/setup_cluster.sh
@@ -88,7 +88,7 @@ else
    echo "Using kubeadm/kubectl installation"
 fi
 
-if [ "$legacyInstall" == 1 ] && [ "$k8_sanity" == "" ]; then
+if [ "$legacyInstall" == 1 ] && [ "$k8s_devtest" == "" ]; then
    GetContiv
 fi
 
@@ -114,7 +114,7 @@ fi
 ./vagrant_cluster.py
 
 
-if [ "$legacyInstall" == 1 ] && [ "$k8_sanity" == "" ]; then
+if [ "$legacyInstall" == 1 ] && [ "$k8s_devtest" == "" ]; then
 # run ansible
 ansible-playbook -i .contiv_k8s_inventory ./contrib/ansible/cluster.yml --skip-tags "contiv_restart" -e "networking=contiv contiv_fabric_mode=default localBuildOutput=$top_dir/k8s-$k8sVer/kubernetes/server/bin contiv_bin_path=$top_dir/contiv_bin contiv_demo=True"
 fi


### PR DESCRIPTION
PR includes the following changes:
- Vagrantfile changes to use kubeadm installation. Dependency on multiple vagrant boxes is removed with this change.
- New contiv_test.yaml file to mount local bin directory - allows testing local workspace changes
- Changes to contivNet.sh - allows explicitly stopping the netmaster/netplugin process and control testing of failure scenarios
- k8s testing changes in k8setup_test.go - Implements pod specific changes to run test cases
(Please NOTE: Expand test/systemtests/k8setup_test.go during review)