### PR TITLE
k8s setup with l3 demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ endif
 #kubernetes demo targets
 k8s-cluster:
 	cd vagrant/k8s/ && ./setup_cluster.sh
+k8s-l3-cluster:
+	CONTIV_L3=1 make k8s-cluster
 k8s-demo:
 	cd vagrant/k8s/ && ./copy_demo.sh
 k8s-demo-start:

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -10,6 +10,9 @@ require 'fileutils'
 # netplugin_synced_gopath="/opt/golang"
 gopath_folder="/opt/gopath"
 
+http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
+https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
+
 # python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))
 token = "d900e1.8a392798f13b33a4"
 master_ip = "192.168.2.10"
@@ -36,6 +39,14 @@ def create_etc_hosts(cluster)
 
   etc_file.close
 end
+
+provision_quagga = <<SCRIPT
+## setup the environment file. Export the env-vars passed as args to 'vagrant up'
+echo Args passed: [[ $@ ]]
+echo "export http_proxy='$1'" >> /etc/profile.d/envvar.sh
+echo "export https_proxy='$2'" >> /etc/profile.d/envvar.sh
+source /etc/profile.d/envvar.sh
+SCRIPT
 
 # method to read the cluster config file
 def read_cluster_config
@@ -89,6 +100,47 @@ Vagrant.configure(2) do |config|
     config.registration.username = ENV['CONTIV_RHEL_USER']
     config.registration.password = ENV['CONTIV_RHEL_PASSWD']
   end
+  if ENV['CONTIV_L3'] then
+      config.vm.define "quagga1" do |quagga1|
+
+        quagga1.vm.box = "contiv/quagga1"
+        quagga1.vm.box_version = "0.0.1"
+        quagga1.vm.host_name = "quagga1"
+        quagga1.vm.network :private_network, ip: "192.168.2.51", virtualbox__intnet: "true", auto_config: false
+        quagga1.vm.network "private_network",
+                         ip: "80.1.1.200",
+                         virtualbox__intnet: "contiv_orange"
+        quagga1.vm.network "private_network",
+                         ip: "70.1.1.2",
+                         virtualbox__intnet: "contiv_blue"
+        quagga1.vm.provision "shell" do |s|
+          s.inline = provision_quagga
+          s.args = [http_proxy, https_proxy]
+        end
+      end
+      config.vm.define "quagga2" do |quagga2|
+
+        quagga2.vm.box = "contiv/quagga2"
+        quagga2.vm.box_version = "0.0.1"
+        quagga2.vm.host_name = "quagga2"
+        quagga2.vm.network :private_network, ip: "192.168.2.52", virtualbox__intnet: "true", auto_config: false
+        quagga2.vm.network "private_network",
+                         ip: "70.1.1.1",
+                         virtualbox__intnet: "contiv_blue"
+        quagga2.vm.network "private_network",
+                         ip: "60.1.1.200",
+                         virtualbox__intnet: "contiv_green"
+        quagga2.vm.network "private_network",
+                         ip: "50.1.1.200",
+                         virtualbox__intnet: "contiv_yellow"
+
+        quagga2.vm.provision "shell" do |s|
+          s.inline = provision_quagga
+          s.args = [http_proxy, https_proxy]
+        end
+      end
+   end
+
   #config.ssh.password = 'vagrant'
   config.ssh.insert_key = false
   config.ssh.private_key_path = "./../../scripts/insecure_private_key"
@@ -134,20 +186,32 @@ Vagrant.configure(2) do |config|
             # Add it as rhel7 vagrant box add rhel-cdk-kubernetes-7.2-29.x86_64.vagrant-virtualbox.box --name=rhel7
             c.vm.box = "rhel7"
           else
-            c.vm.box = "centos/7"
-            c.vm.box_version = "1611.01"
+            c.vm.box = "contiv/k8s-centos"
+            c.vm.box_version = "0.0.7"
           end
 	    c.vm.provision "shell" do |s|
                s.inline = provision_master
                s.args = [ENV["http_proxy"] || "", ENV["https_proxy"] || ""]
             end 
 	end
-
+	network_name = "contiv_purple"
+	if ENV['CONTIV_L3'] then
+	   if vm_name == "k8node-03" then
+             network_name = "contiv_orange"
+           end
+	   if vm_name == "k8node-01" then
+              network_name = "contiv_yellow"
+           end
+	   if vm_name == "k8node-02" then
+              network_name = "contiv_green"
+           end
+        end
+	
         # configure ip address etc
         c.vm.hostname = vm_name
-        c.vm.network :private_network, ip: member_info["contiv_control_ip"]
-        c.vm.network :private_network, ip: member_info["contiv_network_ip"], virtualbox__intnet: "true", auto_config: false
-                    c.vm.provider "virtualbox" do |v|
+        c.vm.network :private_network, ip: member_info["contiv_control_ip"], virtualbox__intnet: "true"
+        c.vm.network :private_network, ip: member_info["contiv_network_ip"], virtualbox__intnet: network_name, auto_config: false
+        c.vm.provider "virtualbox" do |v|
 
                 if vm_name == "k8master" then
                   v.memory = 2048


### PR DESCRIPTION
$ cd $GOPATH/src/github.com/contiv/netplugin

Step 1: Bring up k8s vms with quagga routers

$ make k8s-l3-cluster
$ cd vagrant/k8s/
$ CONTIV_L3=1 vagrant status
  Current machine states:

  quagga1                   running (virtualbox)
  quagga2                   running (virtualbox)
  k8master                  running (virtualbox)
  k8node-01                 running (virtualbox)
  k8node-02                 running (virtualbox)
  k8node-03                 running (virtualbox)

Step 2: Configure the cluster in routing mode and apply bgp configs

$ vagrant ssh k8master
[vagrant@k8master ~]$ sudo docker ps | grep netmaster
**ce47e6f4164e        contiv/netplugin:v1.0.0-alpha-01-28-2017.10-23-11.UTC           "/contiv/scripts/cont"   21 minutes ago      Up 21 minutes                           k8s_contiv-netmaster.5492bf0c_contiv-netmaster-14xc8_kube-system_fc20e1da-f23f-11e6-801c-525400225b53_bce9822b**
0d76d5b1f1fe        gcr.io/google_containers/pause-amd64:3.0                        "/pause"                 22 minutes ago      Up 22 minutes                           k8s_POD.d8dbe16c_contiv-netmaste-14xc8_kube-system_fc20e1da-f23f-11e6-801c-525400225b53_ba6148f5

[vagrant@k8master ~]$ sudo docker exec -it ce47e6f4164e sh
\# cd contiv/bin
\# ./netctl global set - -fwd-mode routing
\# ./netctl bgp create k8node-01 --router-ip=50.1.1.2/24 --neighbor=50.1.1.200 --as=65002 --neighbor-as=500
\#  ./netctl bgp create k8node-02 --router-ip=60.1.1.1/24 --neighbor=60.1.1.200  --as=65002 --neighbor-as=500
\#  ./netctl bgp create k8node-03 --router-ip=80.1.1.2/24 --neighbor=80.1.1.200 --as=65002 --neighbor-as=500

Step3: Verify bgp connection is established
\# ./netctl bgp inspect k8node-01
netctl. Inspecting bgp: k8node-01
{
  "Config": {
    "key": "k8node-01",
    "as": "65002",
    "hostname": "k8node-01",
    "neighbor": "50.1.1.200",
    "neighbor-as": "500",
    "routerip": "50.1.1.2/24"
  },
  "Oper": {
    "adminStatus": "ADMIN_STATE_UP",
    "neighborStatus": "**established**",
    "numRoutes": 6,
    "routes": [
      "1.1.1.0/24",
      "10.0.2.0/24",
      "70.1.1.0/24",
      "60.1.1.0/24",
      "50.1.1.0/24",
      "80.1.1.0/24"
    ]
  }
}
\# ./netctl bgp inspect k8node-02
netctl. Inspecting bgp: k8node-02
{
  "Config": {
    "key": "k8node-02",
    "as": "65002",
    "hostname": "k8node-02",
    "neighbor": "60.1.1.200",
    "neighbor-as": "500",
    "routerip": "60.1.1.1/24"
  },
  "Oper": {
    "adminStatus": "ADMIN_STATE_UP",
    "neighborStatus": "**established**",
    "numRoutes": 8,
    "routes": [
      "70.1.1.0/24",
      "60.1.1.0/24",
      "50.1.1.0/24",
      "50.1.1.2/32",
      "80.1.1.0/24",
      "80.1.1.2/32",
      "1.1.1.0/24",
      "10.0.2.0/24"
    ]
  }
}
\# ./netctl bgp inspect k8node-03
netctl. Inspecting bgp: k8node-03
{
  "Config": {
    "key": "k8node-03",
    "as": "65002",
    "hostname": "k8node-03",
    "neighbor": "80.1.1.200",
    "neighbor-as": "500",
    "routerip": "80.1.1.2/24"
  },
  "Oper": {
    "adminStatus": "ADMIN_STATE_UP",
    "neighborStatus": "**established**",
    "numRoutes": 7,
    "routes": [
      "1.1.1.0/24",
      "10.0.2.0/24",
      "80.1.1.0/24",
      "70.1.1.0/24",
      "50.1.1.0/24",
      "60.1.1.0/24",
      "50.1.1.2/32"
    ]
  }
}
