### PR TITLE
Fixing ovs version in container

### DIFF
--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -1,5 +1,5 @@
 ##
-#Copyright 2014 Cisco Systems Inc. All rights reserved.
+#Copyright 2017 Cisco Systems Inc. All rights reserved.
 #
 #Licensed under the Apache License, Version 2.0 (the "License");
 #you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 
 # One Container for OVS / netplugin / netmaster 
 
-FROM ubuntu:15.10
+FROM ubuntu:16.04
 
 MAINTAINER Rajesh Nataraja <rajenata@cisco.com>
 
@@ -26,7 +26,7 @@ MAINTAINER Rajesh Nataraja <rajenata@cisco.com>
 
 # Install the Open vSwitch package on this ubuntu container.
 RUN apt update
-RUN apt --assume-yes  install openvswitch-switch
+RUN apt --assume-yes  install openvswitch-switch=2.5.0-0ubuntu1
 RUN apt --assume-yes  install net-tools iptables
 
 # Copy the Net Plugin Binaries  and the Scripts required to 

--- a/scripts/netContain/contivNet.sh
+++ b/scripts/netContain/contivNet.sh
@@ -10,6 +10,7 @@ cmode="bridge"
 netmaster=false
 netplugin=true
 vlan_if="$VLAN_IF"
+debug=""
 
 #This needs to be fixed, we cant rely on the value being supplied from 
 # parameters, just explosion of parameters is not a great solution
@@ -20,7 +21,7 @@ vlan_if="$VLAN_IF"
 #fixed as well. netplugin should have OVS locally. 
 echo "0.0.0.0 localhost" >> /etc/hosts
 
-while getopts ":xmp:v:i:f:c:" opt; do
+while getopts ":xmp:v:i:f:c:d" opt; do
     case $opt in
        m) 
           netmaster=true
@@ -45,6 +46,9 @@ while getopts ":xmp:v:i:f:c:" opt; do
           ;;
        x)
           reinit=true
+          ;;
+       d)
+          debug="-debug"
           ;;
        :)
           echo "An argument required for $OPTARG was not passed"
@@ -89,9 +93,9 @@ if [ $netmaster == true ]; then
    mkdir -p /var/contiv/log/
    while [ true ]; do
        if [ "$cstore" != "" ]; then
-           /contiv/bin/netmaster  -cluster-mode $plugin -cluster-store $cstore &> /var/contiv/log/netmaster.log
+           /contiv/bin/netmaster $debug -cluster-mode $plugin -cluster-store $cstore &> /var/contiv/log/netmaster.log
        else
-           /contiv/bin/netmaster -cluster-mode $plugin  &> /var/contiv/log/netmaster.log
+           /contiv/bin/netmaster $debug -cluster-mode $plugin  &> /var/contiv/log/netmaster.log
        fi
        echo "CRITICAL : Net Master has exited, Respawn in 5"
        sleep 5
@@ -111,7 +115,7 @@ if [ $netplugin == true ]; then
        if [ "$vlan_if" != "" ]; then
            vlan_if_param="-vlan-if"
        fi
-       /contiv/bin/netplugin $cstore_param $cstore $vtep_ip_param $vtep_ip $vlan_if_param $vlan_if -plugin-mode $plugin &> /var/contiv/log/netplugin.log
+       /contiv/bin/netplugin $debug $cstore_param $cstore $vtep_ip_param $vtep_ip $vlan_if_param $vlan_if -plugin-mode $plugin &> /var/contiv/log/netplugin.log
        echo "CRITICAL : Net Plugin has exited, Respawn in 5"
        sleep 5
    done &


### PR DESCRIPTION
We have only tested with ovs 2.3 and 2.5, so hardcoding the later
version here. We need to update this as our test matrix changes.
Also adding -d flag to allow debug messages for netplugin and netmaster.
Ubuntu 16 upgrade is required to get the newer ovs version.