### PR TITLE
systemtests: fixes and improvements

### DIFF
--- a/test/systemtests/basic_test.go
+++ b/test/systemtests/basic_test.go
@@ -167,16 +167,16 @@ func (s *systemtestSuite) testBasicSvcDiscovery(c *C, encap string) {
 		logrus.Infof("Creating epg: %s", group2.GroupName)
 		c.Assert(s.cli.EndpointGroupPost(group2), IsNil)
 
-                // create DNS container
-                dnsContainer, err := s.runContainersOnNode(1, "private", "default", "", s.nodes[0])
-                c.Assert(err, IsNil)
-                dnsIpAddr := dnsContainer[0].eth0.ip
+		// create DNS container
+		dnsContainer, err := s.runContainersOnNode(1, "private", "default", "", s.nodes[0])
+		c.Assert(err, IsNil)
+		dnsIpAddr := dnsContainer[0].eth0.ip
 
 		containers1, err := s.runContainersWithDNS(s.basicInfo.Containers, "default", "private",
-                        fmt.Sprintf("svc1%d", i), dnsIpAddr)
+			fmt.Sprintf("svc1%d", i), dnsIpAddr)
 		c.Assert(err, IsNil)
 		containers2, err := s.runContainersWithDNS(s.basicInfo.Containers, "default", "private",
-                        fmt.Sprintf("svc2%d", i), dnsIpAddr)
+			fmt.Sprintf("svc2%d", i), dnsIpAddr)
 		c.Assert(err, IsNil)
 
 		containers := append(containers1, containers2...)
@@ -194,7 +194,7 @@ func (s *systemtestSuite) testBasicSvcDiscovery(c *C, encap string) {
 		c.Assert(s.pingTestByName(containers, fmt.Sprintf("svc2%d", i)), IsNil)
 
 		// cleanup
-                c.Assert(s.removeContainers(dnsContainer), IsNil)
+		c.Assert(s.removeContainers(dnsContainer), IsNil)
 		c.Assert(s.removeContainers(containers), IsNil)
 		c.Assert(s.cli.EndpointGroupDelete(group1.TenantName, group1.GroupName), IsNil)
 		c.Assert(s.cli.EndpointGroupDelete(group2.TenantName, group2.GroupName), IsNil)

--- a/test/systemtests/init_test.go
+++ b/test/systemtests/init_test.go
@@ -3,12 +3,14 @@ package systemtests
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+	. "testing"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/contiv/contivmodel/client"
 	"github.com/contiv/remotessh"
 	. "gopkg.in/check.v1"
-	"os"
-	. "testing"
 )
 
 type systemtestSuite struct {
@@ -136,6 +138,9 @@ func (s *systemtestSuite) TearDownSuite(c *C) {
 	for _, node := range s.nodes {
 		logrus.Infof("Checking for errors on %v", node.Name())
 		out, _ := node.runCommand(`for i in /tmp/net*; do grep "error\|fatal\|panic" $i; done`)
+		if strings.Contains(out, "No such file or directory") {
+			continue
+		}
 		if out != "" {
 			logrus.Errorf("Errors in logfiles on %s: \n", node.Name())
 			fmt.Printf("%s\n==========================\n\n", out)

--- a/test/systemtests/util_test.go
+++ b/test/systemtests/util_test.go
@@ -310,10 +310,10 @@ func (s *systemtestSuite) runContainersWithDNS(num int, tenantName, networkName,
 
 	errChan := make(chan error)
 
-        if len(dnsServer) <= 0 {
-           logrus.Errorf("no dns specified")
-           return nil, fmt.Errorf("no dns")
-        }
+	if len(dnsServer) <= 0 {
+		logrus.Errorf("no dns specified")
+		return nil, fmt.Errorf("no dns")
+	}
 
 	docknetName := fmt.Sprintf("%s/%s", networkName, tenantName)
 	if tenantName == "default" {


### PR DESCRIPTION
This PR makes the following changes:
- the first commit fixes some issues picked up by gofmt in the system tests
- the second commit fixes errors related to not finding any log files without any errors in them and logging an error about the absence of the logs
```
time="2017-02-17T18:41:43-08:00" level=error msg="Errors in logfiles on netplugin-node1: \n"
grep: /tmp/net*: No such file or directory

==========================
```
- the third commit parallelizes the cleanupSlave and the cleanupMaster scripts
The vport interface cleanup script was invalid because the command wasn't properly quoted to be run via the resulting command: ```bash -lc 'for p in `ifconfig  | grep vport | awk '{print $1}'`; do sudo ip link delete $p type veth; done'```.