### PR TITLE
systemtests improvements - speed up test setup & cleanup on Vagrant

### DIFF
--- a/test/systemtests/init_test.go
+++ b/test/systemtests/init_test.go
@@ -121,11 +121,28 @@ func (s *systemtestSuite) SetUpTest(c *C) {
 }
 
 func (s *systemtestSuite) TearDownTest(c *C) {
-	for _, node := range s.nodes {
-		c.Check(node.checkForNetpluginErrors(), IsNil)
-		c.Assert(node.exec.rotateNetpluginLog(), IsNil)
-		c.Assert(node.exec.rotateNetmasterLog(), IsNil)
+
+	errors := s.parallelExec(func(node *node) error {
+		return node.checkForNetpluginErrors()
+	})
+	for _, err := range errors {
+		c.Check(err, IsNil)
 	}
+
+	errors = s.parallelExec(func(node *node) error {
+		return node.exec.rotateNetpluginLog()
+	})
+	for _, err := range errors {
+		c.Assert(err, IsNil)
+	}
+
+	errors = s.parallelExec(func(node *node) error {
+		return node.exec.rotateNetmasterLog()
+	})
+	for _, err := range errors {
+		c.Assert(err, IsNil)
+	}
+
 	logrus.Infof("============================= %s completed ==========================", c.TestName())
 }
 


### PR DESCRIPTION
This PR speeds up the setup and tear down of the tests. These changes reduce the execution of the system tests by about  30-40 minutes for the regular test suite.