### PR TITLE
scripts/python,vagrant/k8s: find python using env

### DIFF
--- a/scripts/python/api/etcd.py
+++ b/scripts/python/api/etcd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import urllib
 import urllib2

--- a/scripts/python/cleanup.py
+++ b/scripts/python/cleanup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # sanity tests
 import api.tnode

--- a/scripts/python/contivctl.py
+++ b/scripts/python/contivctl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import urllib
 import urllib2

--- a/scripts/python/createcfg.py
+++ b/scripts/python/createcfg.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # script to create the config JSON input for the system tests
 import os 
 import json

--- a/scripts/python/policyScale.py
+++ b/scripts/python/policyScale.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # sanity tests
 import api.tbed

--- a/scripts/python/startPlugin.py
+++ b/scripts/python/startPlugin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Start netplugin and netmaster
 import api.tbed

--- a/scripts/python/startSwarm.py
+++ b/scripts/python/startSwarm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Start netplugin and netmaster
 import api.tnode

--- a/vagrant/k8s/vagrant_cluster.py
+++ b/vagrant/k8s/vagrant_cluster.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python
 import os
 import sys
 import json


### PR DESCRIPTION
This PR fixes errors such as:
```
./setup_cluster.sh: ./vagrant_cluster.py: /usr/local/bin/python: bad interpreter: No such file or directory
make[1]: *** [k8s-sanity-cluster] Error 126
```