### PR TITLE
fix k8s-test & cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 DEFAULT_DOCKER_VERSION := 1.12.6
 SHELL := /bin/bash
-EXCLUDE_DIRS := bin docs Godeps scripts test vagrant vendor install
+EXCLUDE_DIRS := bin docs Godeps scripts test vagrant vendor install 
 PKG_DIRS := $(filter-out $(EXCLUDE_DIRS),$(subst /,,$(sort $(dir $(wildcard */)))))
 TO_BUILD := ./netplugin/ ./netmaster/ ./netctl/netctl/ ./mgmtfn/k8splugin/contivk8s/ ./mgmtfn/mesosplugin/netcontiv/
 HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(which go); fi`
@@ -134,7 +134,7 @@ k8s-test:
 	cd vagrant/k8s/ && CONTIV_K8=1 vagrant ssh k8master -c 'sudo -i bash -lc "cd /opt/gopath/src/github.com/contiv/netplugin && make run-build"'
 	CONTIV_K8=1 cd vagrant/k8s/ && ./start_sanity_service.sh
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8'
-	CONTIV_K8=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|Basic|Network|Policy|TestTrigger|ACIM|HostBridge|Netprofile" 
+	CONTIV_K8=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|TestPolicy|TestTrigger"   
 	cd vagrant/k8s && vagrant destroy -f 
 # Mesos demo targets
 mesos-docker-demo:

--- a/test/systemtests/docker_test.go
+++ b/test/systemtests/docker_test.go
@@ -786,3 +786,35 @@ func (d *docker) reloadNode(n *node) error {
 func (d *docker) getMasterIP() (string, error) {
 	return d.node.getIPAddr("eth1")
 }
+
+func (d *docker) verifyUplinkState(n *node, uplinks []string) error {
+	var err error
+	var portName string
+	var cmd, output string
+
+	if len(uplinks) > 1 {
+		portName = "uplinkPort"
+	} else {
+		portName = uplinks[0]
+	}
+
+	// Verify port state
+	cmd = fmt.Sprintf("sudo ovs-vsctl find Port name=%s", portName)
+	output, err = n.runCommand(cmd)
+	if err != nil || !(strings.Contains(string(output), portName)) {
+		err = fmt.Errorf("Lookup failed for uplink Port %s. Err: %+v", portName, err)
+		return err
+	}
+
+	// Verify Interface state
+	for _, uplink := range uplinks {
+		cmd = fmt.Sprintf("sudo ovs-vsctl find Interface name=%s", uplink)
+		output, err = n.runCommand(cmd)
+		if err != nil || !(strings.Contains(string(output), uplink)) {
+			err = fmt.Errorf("Lookup failed for uplink interface %s for uplink cfg:%+v. Err: %+v", uplink, uplinks, err)
+			return err
+		}
+	}
+
+	return err
+}

--- a/test/systemtests/k8setup_test.go
+++ b/test/systemtests/k8setup_test.go
@@ -795,3 +795,39 @@ func (k *kubernetes) reloadNode(n *node) error {
 func (k *kubernetes) getMasterIP() (string, error) {
 	return k8master.getIPAddr("eth1")
 }
+
+func (k *kubernetes) verifyUplinkState(n *node, uplinks []string) error {
+	var err error
+	var portName string
+	var cmd, output string
+
+	if n.Name() == "k8master" {
+		return nil
+	}
+
+	if len(uplinks) > 1 {
+		portName = "uplinkPort"
+	} else {
+		portName = uplinks[0]
+	}
+
+	// Verify port state
+	cmd = fmt.Sprintf("sudo ovs-vsctl find Port name=%s", portName)
+	output, err = n.runCommand(cmd)
+	if err != nil || !(strings.Contains(string(output), portName)) {
+		err = fmt.Errorf("Lookup failed for uplink Port %s. Err: %+v", portName, err)
+		return err
+	}
+
+	// Verify Interface state
+	for _, uplink := range uplinks {
+		cmd = fmt.Sprintf("sudo ovs-vsctl find Interface name=%s", uplink)
+		output, err = n.runCommand(cmd)
+		if err != nil || !(strings.Contains(string(output), uplink)) {
+			err = fmt.Errorf("Lookup failed for uplink interface %s for uplink cfg:%+v. Err: %+v", uplink, uplinks, err)
+			return err
+		}
+	}
+
+	return err
+}

--- a/test/systemtests/node_test.go
+++ b/test/systemtests/node_test.go
@@ -111,35 +111,7 @@ func (n *node) cleanupMaster() {
 }
 
 func (n *node) verifyUplinkState(uplinks []string) error {
-	var err error
-	var portName string
-	var cmd, output string
-
-	if len(uplinks) > 1 {
-		portName = "uplinkPort"
-	} else {
-		portName = uplinks[0]
-	}
-
-	// Verify port state
-	cmd = fmt.Sprintf("sudo ovs-vsctl find Port name=%s", portName)
-	output, err = n.runCommand(cmd)
-	if err != nil || !(strings.Contains(string(output), portName)) {
-		err = fmt.Errorf("Lookup failed for uplink Port %s. Err: %+v", portName, err)
-		return err
-	}
-
-	// Verify Interface state
-	for _, uplink := range uplinks {
-		cmd = fmt.Sprintf("sudo ovs-vsctl find Interface name=%s", uplink)
-		output, err = n.runCommand(cmd)
-		if err != nil || !(strings.Contains(string(output), uplink)) {
-			err = fmt.Errorf("Lookup failed for uplink interface %s for uplink cfg:%+v. Err: %+v", uplink, uplinks, err)
-			return err
-		}
-	}
-
-	return err
+	return n.exec.verifyUplinkState(n, uplinks)
 }
 
 func (n *node) runCommand(cmd string) (string, error) {

--- a/test/systemtests/scheduler_test.go
+++ b/test/systemtests/scheduler_test.go
@@ -47,4 +47,5 @@ type systemTestScheduler interface {
 	startIperfServer(containers *container) error
 	startIperfClient(containers *container, ip, limit string, isErr bool) error
 	tcFilterShow(bw string) error
+	verifyUplinkState(n *node,uplinks []string) error
 }

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -224,8 +224,7 @@ Vagrant.configure(2) do |config|
         c.vm.hostname = vm_name
         c.vm.network :private_network, ip: member_info["contiv_control_ip"], virtualbox__intnet: "true"
         c.vm.network :private_network, ip: member_info["contiv_network_ip"], virtualbox__intnet: network_name, auto_config: false
-        c.vm.network :private_network, ip: "0.0.0.0", virtualbox__intnet: "contiv_purple", auto_config: false
-	c.vm.provider "virtualbox" do |v|
+        c.vm.provider "virtualbox" do |v|
 
                 if vm_name == "k8master" then
                   v.memory = 2048

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -224,7 +224,8 @@ Vagrant.configure(2) do |config|
         c.vm.hostname = vm_name
         c.vm.network :private_network, ip: member_info["contiv_control_ip"], virtualbox__intnet: "true"
         c.vm.network :private_network, ip: member_info["contiv_network_ip"], virtualbox__intnet: network_name, auto_config: false
-        c.vm.provider "virtualbox" do |v|
+        c.vm.network :private_network, ip: "0.0.0.0", virtualbox__intnet: "contiv_purple", auto_config: false
+	c.vm.provider "virtualbox" do |v|
 
                 if vm_name == "k8master" then
                   v.memory = 2048

--- a/vagrant/k8s/setup_cluster.sh
+++ b/vagrant/k8s/setup_cluster.sh
@@ -53,8 +53,9 @@ function GetContiv {
 function GetContrib {
 	pushd .
 	if [ -f $top_dir/contrib ]; then
-    		echo "netplugin-$contivVer.tar.bz2 found, not fetching."
+    		echo "contrib found, not fetching."
   	else
+		echo "Fetching contrib....."
 		git clone https://github.com/jojimt/contrib -b contiv 
   	fi
 	popd
@@ -93,12 +94,6 @@ fi
 
 if [ "$legacyInstall" == 1 ] && [ "$k8_sanity" == "" ]; then
    GetContiv
-fi
-
-if [ "$legacyInstall" == 1 ] && [ "$k8_sanity" == "1" ]; then
-   if [ ! -f ./contrib ]; then
-      git clone https://github.com/jojimt/contrib -b contiv
-   fi
 fi
 
 # exit on any error


### PR DESCRIPTION
The PR is follow up to #739 
1) Makefile changes that was missed from being committed as a part #739 which was causing the test run on all the test cases. 
2) typo fix in the script to run k8 sanity.
These are the only 2 minor fixes needed to run k8s sanity

New test case:  
1) contains fix for a new test case for bonded uplink to adapt to k8s,docker and swarm testing environments.

