### PR TITLE
Fix https://github.com/contiv/netplugin/issues/753

### DIFF
--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -925,8 +925,7 @@ func setAciGw(ctx *cli.Context) {
 	enf := ctx.String("enforce-policies")
 	comTen := ctx.String("include-common-tenant")
 
-	acigw, err := getClient(ctx).AciGwGet("aciGw")
-	errCheck(ctx, err)
+	acigw, _ := getClient(ctx).AciGwGet("aciGw")
 	if acigw == nil {
 		acigw = &contivClient.AciGw{}
 		acigw.Name = "aciGw"


### PR DESCRIPTION
Need to allow aciGW to be created even when it is not already present because we don't create one by default.