### PR TITLE
Fixed a bug where values read from .vagrant-state were being set as envvars with trailing newlines attached

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,9 @@ require 'fileutils'
 BEGIN {
   STATEFILE = ".vagrant-state"
 
+  # if there's a state file, set all the envvars in the current environment
   if File.exist?(STATEFILE)
-    File.open(STATEFILE).read.lines.map { |x| x.split("=", 2) }.each { |x,y| ENV[x] = y }
+    File.read(STATEFILE).lines.map { |x| x.split("=", 2) }.each { |x,y| ENV[x] = y.strip }
   end
 }
 


### PR DESCRIPTION
This PR fixes a bug I discovered where the inline shell provisioner in Vagrantfile can end up generating a bash script which has a newline in the middle of an `if` statement (where the Docker version is checked) if a Vagrant state file is present.  This causes the provisioning process to fail completely.