### PR TITLE
check the ip address returned from nextClear() is in range

### DIFF
--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -363,7 +363,7 @@ func networkAllocAddress(nwCfg *mastercfg.CfgNetworkState, epgCfg *mastercfg.End
 		} else {
 			if epgCfg != nil && len(epgCfg.IPPool) > 0 { // allocate from epg network
 				log.Infof("allocating ip address from epg pool %s", epgCfg.IPPool)
-				ipAddrValue, found = epgCfg.EPGIPAllocMap.NextClear(0)
+				ipAddrValue, found = netutils.NextClear(epgCfg.EPGIPAllocMap, 0, nwCfg.SubnetLen)
 				if !found {
 					log.Errorf("auto allocation failed - address exhaustion in pool %s",
 						epgCfg.IPPool)
@@ -378,7 +378,7 @@ func networkAllocAddress(nwCfg *mastercfg.CfgNetworkState, epgCfg *mastercfg.End
 				}
 				epgCfg.EPGIPAllocMap.Set(ipAddrValue)
 			} else {
-				ipAddrValue, found = nwCfg.IPAllocMap.NextClear(0)
+				ipAddrValue, found = netutils.NextClear(nwCfg.IPAllocMap, 0, nwCfg.SubnetLen)
 				if !found {
 					log.Errorf("auto allocation failed - address exhaustion in subnet %s/%d",
 						nwCfg.SubnetIP, nwCfg.SubnetLen)

--- a/utils/netutils/netutils.go
+++ b/utils/netutils/netutils.go
@@ -994,6 +994,17 @@ func ListAllocatedIPs(allocMap bitset.BitSet, ipPool string, subnetIP string, su
 	return strings.Join(list, ", ")
 }
 
+// NextClear wrapper around Bitset to check max id
+func NextClear(allocMap bitset.BitSet, idx uint, subnetLen uint) (uint, bool) {
+	maxHosts := uint(1 << (32 - subnetLen))
+
+	value, found := allocMap.NextClear(idx)
+	if found && value >= maxHosts {
+		return 0, false
+	}
+	return value, found
+}
+
 // ListAvailableIPs returns a string of available IPs in a network
 func ListAvailableIPs(allocMap bitset.BitSet, subnetIP string, subnetLen uint) string {
 	idx := uint(0)
@@ -1002,7 +1013,7 @@ func ListAvailableIPs(allocMap bitset.BitSet, subnetIP string, subnetLen uint) s
 	inRange := false
 
 	for {
-		foundValue, found := allocMap.NextClear(idx)
+		foundValue, found := NextClear(allocMap, idx, subnetLen)
 		if !found {
 			break
 		}


### PR DESCRIPTION
This fixes the network inspect error message with subnets  < 64 addresses
fixes #766 
