### PR TITLE
install/v2plugin/Dockerfile: make a few tweaks

### DIFF
--- a/install/v2plugin/Dockerfile
+++ b/install/v2plugin/Dockerfile
@@ -1,11 +1,13 @@
-# Docker v2plugin container with OVS / netplugin / netmaster 
+# Docker v2plugin container with OVS / netplugin / netmaster
 
 FROM alpine:3.5
-MAINTAINER Cisco Contiv (http://contiv.github.io/)
+MAINTAINER Cisco Contiv (https://contiv.github.io/)
 
-RUN mkdir -p /run/docker/plugins /etc/openvswitch /var/run/contiv/log \
-    && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
-    && apk update && apk add openvswitch=2.5.0-r0 iptables
+RUN mkdir -p /run/docker/plugins \
+ && mkdir -p /etc/openvswitch \
+ && mkdir -p /var/run/contiv/log \
+ && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
+ && apk --no-cache add openvswitch=2.5.0-r0 iptables
 
 COPY netplugin netmaster netctl startcontiv.sh /
 


### PR DESCRIPTION
This PR makes a few small changes to the v2plugin Dockerfile.

The addition of the `--no-cache` reduces the size of the final image slightly. Since we're using the Alpine Linux, this was small and cheap enough to make it worth implementing.