### PR TITLE
fix release_image.sh & run build_image.sh on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,9 @@ all: build unit-test system-test ubuntu-tests
 # sandbox specific(vagrant, docker-in-docker)
 all-CI: stop clean start
 	make ssh-build
-	vagrant ssh netplugin-node1 -c 'sudo -i bash -lc "source /etc/profile.d/envvar.sh && cd /opt/gopath/src/github.com/contiv/netplugin && make host-unit-test"'
-	vagrant ssh netplugin-node1 -c 'sudo -i bash -lc "source /etc/profile.d/envvar.sh && cd /opt/gopath/src/github.com/contiv/netplugin && make host-integ-test"'
+	vagrant ssh netplugin-node1 -c 'sudo -i bash -lc "source /etc/profile.d/envvar.sh \
+		&& cd /opt/gopath/src/github.com/contiv/netplugin \
+		&& make host-unit-test host-integ-test host-build-docker-image"'
 	make system-test
 
 test: build unit-test system-test ubuntu-tests
@@ -81,6 +82,10 @@ run-build: deps checks clean
 	cd ${GOPATH}/src/github.com/contiv/netplugin && version/generate_version ${USE_RELEASE} && \
 	cd $(GOPATH)/src/github.com/contiv/netplugin && \
 	GOGC=1500 go install -v $(TO_BUILD)
+
+build-docker-image: start
+	vagrant ssh netplugin-node1 -c 'bash -lc "source /etc/profile.d/envvar.sh && cd /opt/gopath/src/github.com/contiv/netplugin && make host-build-docker-image"'
+
 
 ifdef NET_CONTAINER_BUILD
 install-shell-completion:
@@ -230,6 +235,9 @@ start-aci-gw:
 	@echo dev: starting aci gw...
 	docker pull contiv/aci-gw:11-28-2016.1.3_2i
 	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw contiv/aci-gw:11-28-2016.1.3_2i
+
+host-build-docker-image:
+	./scripts/netContain/build_image.sh
 
 host-cleanup:
 	@echo dev: cleaning up services...

--- a/scripts/netContain/release_image.sh
+++ b/scripts/netContain/release_image.sh
@@ -63,8 +63,12 @@ else
 	docker login -u $docker_user -p $docker_password
 fi
 
+mkdir bin || true
 wget https://github.com/contiv/netplugin/releases/download/$contiv_version/netplugin-$contiv_version.tar.bz2
-tar xvfj netplugin-$contiv_version.tar.bz2
+tar xvfj netplugin-$contiv_version.tar.bz2 -C bin
+# remove the contrib directory, we don't need it in the image
+rm -rf bin/contrib || true
+
 if [ "$?" != "0" ]; then
 	error_ret "FAILED: Error getting contiv version $contiv_version"
 fi


### PR DESCRIPTION
This PR makes the following changes:
- it fixes one isssue in `release_image.sh`
This is related related to the new Dockerfile which expects the binaries to be in bin, not in ./.
- it adds the build-docker-image target to the Makefile to test `netcontain/build_image.sh`

Closes #790