### PR TITLE
.gitignore: ignore OS generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,15 @@ install/v2plugin/config.json
 # netcontain temporary build files
 scripts/netContain/bin
 
+# OS specific files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
 # version
 version/version_gen.go
 


### PR DESCRIPTION
This PR adds some OS specific files to .gitignore. This will make it easier for other contributors and for everyone to avoid adding these files by accident.