### PR TITLE
Vagrantfile: bump centos box to 0.10.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -215,7 +215,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.box_version = "0.7.0"
     else
         config.vm.box = "contiv/centos73"
-        config.vm.box_version = "0.10.0"
+        config.vm.box_version = "0.10.1"
     end
     config.vm.provider 'virtualbox' do |v|
         v.linked_clone = true if Vagrant::VERSION >= "1.8"


### PR DESCRIPTION
This PR bumps the vagrant box to the latest version. The new version makes the following changes & improvements:
- provides a fully updated CentOS system, including the latest kernel provided by the standard CentOS repositories and all security updates
- provides VirtualBox guest additions 5.1.16
- the box is only 633 MB now; the previous version was 709 MB

This box doesn't make any changes to the Docker, Go, etcd, consul and OVS versions. This should be 100% compatible with the previous version.