### PR TITLE
netmaster listen and control port fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -393,6 +393,10 @@ SCRIPT
                 node.vm.network "forwarded_port", guest: 9999, host: 9999
                 node.vm.network "forwarded_port", guest: 80, host: 9998
             end
+            fwd_port1 = 8880 + n
+            fwd_port2 = 9990 + n
+            node.vm.network "forwarded_port", guest: fwd_port1, host: fwd_port1
+            node.vm.network "forwarded_port", guest: fwd_port2, host: fwd_port2
         end
     end
 end

--- a/netmaster/daemon/utils.go
+++ b/netmaster/daemon/utils.go
@@ -75,8 +75,8 @@ func initStateDriver(clusterStore string) (core.StateDriver, error) {
 	return utils.NewStateDriver(stateStore, &instInfo)
 }
 
-// getLocalAddr gets local address to be used
-func getLocalAddr() (string, error) {
+// GetLocalAddr gets local address to be used
+func GetLocalAddr() (string, error) {
 	// get the ip address by local hostname
 	localIP, err := netutils.GetMyAddr()
 	if err == nil && netutils.IsAddrLocal(localIP) {
@@ -91,7 +91,7 @@ func getLocalAddr() (string, error) {
 func slaveProxyHandler(w http.ResponseWriter, r *http.Request) {
 	log.Infof("proxy handler for %q ", r.URL.Path)
 
-	localIP, err := getLocalAddr()
+	localIP, err := GetLocalAddr()
 	if err != nil {
 		log.Fatalf("Error getting local IP address. Err: %v", err)
 	}

--- a/netmaster/daemon/utils.go
+++ b/netmaster/daemon/utils.go
@@ -110,7 +110,7 @@ func slaveProxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// build the proxy url
-	url, _ := url.Parse(fmt.Sprintf("http://%s:9999", masterNode))
+	url, _ := url.Parse(fmt.Sprintf("http://%s", masterNode))
 
 	// Create a proxy for the URL
 	proxy := httputil.NewSingleHostReverseProxy(url)

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -33,6 +33,7 @@ type cliOpts struct {
 	pluginName   string
 	clusterStore string
 	listenURL    string
+	controlURL   string
 	clusterMode  string
 	version      bool
 }
@@ -62,10 +63,14 @@ func parseOpts(opts *cliOpts) error {
 		"cluster-store",
 		"etcd://127.0.0.1:2379",
 		"Etcd or Consul cluster store url.")
+	flagSet.StringVar(&opts.controlURL,
+		"control-url",
+		":9999",
+		"URL for control protocol")
 	flagSet.StringVar(&opts.listenURL,
 		"listen-url",
 		":9999",
-		"Url to listen http requests on")
+		"URL to listen http requests on")
 	flagSet.StringVar(&opts.clusterMode,
 		"cluster-mode",
 		"docker",
@@ -113,6 +118,7 @@ func main() {
 	// create master daemon
 	d := &daemon.MasterDaemon{
 		ListenURL:    opts.listenURL,
+		ControlURL:   opts.controlURL,
 		ClusterStore: opts.clusterStore,
 		ClusterMode:  opts.clusterMode,
 	}

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -19,6 +19,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -37,6 +39,11 @@ type cliOpts struct {
 	clusterMode  string
 	version      bool
 }
+
+const (
+	defaultListenPort  = ":9999"
+	defaultControlPort = ":9999"
+)
 
 var flagSet *flag.FlagSet
 
@@ -65,11 +72,11 @@ func parseOpts(opts *cliOpts) error {
 		"Etcd or Consul cluster store url.")
 	flagSet.StringVar(&opts.controlURL,
 		"control-url",
-		":9999",
+		defaultControlPort,
 		"URL for control protocol")
 	flagSet.StringVar(&opts.listenURL,
 		"listen-url",
-		":9999",
+		defaultListenPort,
 		"URL to listen http requests on")
 	flagSet.StringVar(&opts.clusterMode,
 		"cluster-mode",
@@ -84,6 +91,7 @@ func parseOpts(opts *cliOpts) error {
 }
 
 func execOpts(opts *cliOpts) {
+	var err error
 
 	if opts.help {
 		fmt.Fprintf(os.Stderr, "Usage: %s [OPTION]...\n", os.Args[0])
@@ -101,6 +109,49 @@ func execOpts(opts *cliOpts) {
 	if opts.debug {
 		log.SetLevel(log.DebugLevel)
 	}
+
+	// Validate listen and control URL options
+	listenURL := strings.Split(opts.listenURL, ":")
+	controlURL := strings.Split(opts.controlURL, ":")
+	if len(listenURL) != 2 {
+		log.Fatalf("Listen URL not in proper format. Valid format: [IP]:Port")
+	}
+	if len(controlURL) != 2 || (strings.Compare(controlURL[0], "0.0.0.0") == 0) {
+		log.Fatalf("Control URL not in proper format. Valid format: IP:Port")
+	}
+
+	listenIP := listenURL[0]
+	listenPort, err := strconv.Atoi(listenURL[1])
+	if err != nil {
+		log.Fatalf("Listen URL port not in valid format. Err: %+v", err)
+	}
+	log.Infof("Listen IP:Port %s:%d", listenIP, listenPort)
+
+	controlIP := controlURL[0]
+	controlPort, err := strconv.Atoi(controlURL[1])
+	if err != nil {
+		log.Fatalf("Control URL port not in valid format. Err: %+v", err)
+	}
+	if len(controlIP) == 0 {
+		if strings.Compare(opts.controlURL, defaultControlPort) != 0 {
+			// Case: If --control-url :XXXX, and :XXXX is not defaultControlPort; we error out
+			log.Fatalf("Control URL not in proper format. Valid format: IP:Port")
+		}
+		if len(listenIP) != 0 && (strings.Compare(listenIP, "0.0.0.0") != 0) && (controlPort == listenPort) {
+			// Case: --listen-url A.B.C.D:XXXX and --control-url :XXXX
+			controlIP = listenIP
+		} else {
+			// Case: [--listen-url A.B.C.D:XXXX] --control-url defaultControlPort
+			// Get the address to be used for local communication
+			controlIP, err = daemon.GetLocalAddr()
+			if err != nil {
+				log.Fatalf("Error getting local IP address for Control URL. Err: %v", err)
+			}
+			controlURL[1] = listenURL[1]
+		}
+		opts.controlURL = controlIP + ":" + controlURL[1]
+	}
+	log.Infof("Control IP:Port %s:%s", controlIP, controlURL[1])
 
 	docknet.UpdatePluginName(opts.pluginName)
 }

--- a/netplugin/cluster/cluster.go
+++ b/netplugin/cluster/cluster.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -148,7 +149,7 @@ func MasterPostReq(path string, req interface{}, resp interface{}) error {
 	// first find the holder of master lock
 	masterNode, err := getMasterLockHolder()
 	if err == nil {
-		url := "http://" + masterNode + ":9999" + path
+		url := "http://" + masterNode + path
 		log.Infof("Making REST request to url: %s", url)
 
 		// Make the REST call to master
@@ -172,7 +173,8 @@ func MasterPostReq(path string, req interface{}, resp interface{}) error {
 
 	// Walk all netmasters and see if any of them respond
 	for _, master := range MasterDB {
-		url := "http://" + master.HostAddr + ":9999" + path
+		masterPort := strconv.Itoa(master.Port)
+		url := "http://" + master.HostAddr + ":" + masterPort + path
 
 		log.Infof("Making REST request to url: %s", url)
 

--- a/scripts/python/api/tnode.py
+++ b/scripts/python/api/tnode.py
@@ -102,7 +102,15 @@ class Node:
     # Start netmaster process
     def startNetmaster(self):
         ssh_object = self.sshConnect(self.username, self.password)
-        command = "GOPATH=/opt/gopath " + self.binpath + "/netmaster -cluster-store " + os.environ["CONTIV_CLUSTER_STORE"] + " > /tmp/netmaster.log 2>&1"
+        listenUrlArg = ""
+        listenPort = os.environ["CONTIV_NETMASTER_LISTEN_PORT"]
+        if not listenPort:
+            listenUrlArg = " --listen-url " + os.environ["CONTIV_NETMASTER_LISTEN_IP"] + ":" + listenPort
+        ctrlUrlArg = ""
+        ctrlPort = os.environ["CONTIV_NETMASTER_CONTROL_PORT"]
+        if not ctrlPort:
+            ctrlUrlArg = " --control-url " + os.environ["CONTIV_NETMASTER_CONTROL_IP"] + ":" + ctrlPort
+        command = "GOPATH=/opt/gopath " + self.binpath + "/netmaster " + listenUrlArg + ctrlUrlArg + " -cluster-store " + os.environ["CONTIV_CLUSTER_STORE"] + " > /tmp/netmaster.log 2>&1"
         self.nmThread = threading.Thread(target=ssh_exec_thread, args=(ssh_object, command))
         # npThread.setDaemon(True)
         self.nmThread.start()

--- a/test/integration/npcluster_test.go
+++ b/test/integration/npcluster_test.go
@@ -55,6 +55,7 @@ func NewNPCluster(its *integTestSuite) (*NPCluster, error) {
 	// create master daemon
 	md := &daemon.MasterDaemon{
 		ListenURL:    ":9999",
+		ControlURL:   ":9999",
 		ClusterStore: its.clusterStore,
 		ClusterMode:  "test",
 	}

--- a/test/systemtests/docker_test.go
+++ b/test/systemtests/docker_test.go
@@ -428,7 +428,7 @@ func (d *docker) cleanupContainers() error {
 }
 
 func (d *docker) startNetplugin(args string) error {
-	cmd := "sudo " + d.node.suite.basicInfo.BinPath + "/netplugin -plugin-mode docker -vlan-if " + d.node.suite.hostInfo.HostDataInterfaces + " --cluster-store " + d.node.suite.basicInfo.ClusterStore + " " + args + "&> /tmp/netplugin.log"
+	cmd := "sudo " + d.node.suite.basicInfo.BinPath + "/netplugin -plugin-mode docker -vlan-if " + d.node.suite.hostInfo.HostDataInterfaces + " --cluster-store " + d.node.suite.basicInfo.ClusterStore + " " + args + " &> /tmp/netplugin.log"
 	logrus.Infof("Starting netplugin on %s with command: %s", d.node.Name(), cmd)
 	return d.node.tbnode.RunCommandBackground(cmd)
 }
@@ -443,8 +443,8 @@ func (d *docker) stopNetmaster() error {
 	return d.node.tbnode.RunCommand("sudo pkill netmaster")
 }
 
-func (d *docker) startNetmaster() error {
-	cmd := d.node.suite.basicInfo.BinPath + "/netmaster" + " --cluster-store " + d.node.suite.basicInfo.ClusterStore + " &> /tmp/netmaster.log"
+func (d *docker) startNetmaster(args string) error {
+	cmd := d.node.suite.basicInfo.BinPath + "/netmaster" + " --cluster-store " + d.node.suite.basicInfo.ClusterStore + " " + args + " &> /tmp/netmaster.log"
 	logrus.Infof("Starting netmaster on %s with command: %s", d.node.Name(), cmd)
 	return d.node.tbnode.RunCommandBackground(cmd)
 }

--- a/test/systemtests/k8setup_test.go
+++ b/test/systemtests/k8setup_test.go
@@ -452,13 +452,14 @@ func (k *kubernetes) stopNetmaster() error {
 	return k.node.tbnode.RunCommand("sudo pkill netmaster")
 }
 
-func (k *kubernetes) startNetmaster() error {
+func (k *kubernetes) startNetmaster(args string) error {
 	if k.node.Name() != "k8master" {
 		return nil
 	}
 	logrus.Infof("Starting netmaster on %s", k.node.Name())
-	return k.node.tbnode.RunCommandBackground(k.node.suite.basicInfo.BinPath + "/netmaster" + " --cluster-store " + k.node.suite.basicInfo.ClusterStore + " " + "--cluster-mode kubernetes &> /tmp/netmaster.log")
+	return k.node.tbnode.RunCommandBackground(k.node.suite.basicInfo.BinPath + "/netmaster" + " --cluster-store " + k.node.suite.basicInfo.ClusterStore + " " + "--cluster-mode kubernetes " + args + " &> /tmp/netmaster.log")
 }
+
 func (k *kubernetes) cleanupMaster() {
 	if k.node.Name() != "k8master" {
 		return

--- a/test/systemtests/node_test.go
+++ b/test/systemtests/node_test.go
@@ -98,8 +98,8 @@ func (n *node) stopNetmaster() error {
 	return n.exec.stopNetmaster()
 }
 
-func (n *node) startNetmaster() error {
-	return n.exec.startNetmaster()
+func (n *node) startNetmaster(args string) error {
+	return n.exec.startNetmaster(args)
 }
 
 func (n *node) cleanupSlave() {

--- a/test/systemtests/scheduler_test.go
+++ b/test/systemtests/scheduler_test.go
@@ -8,7 +8,7 @@ type systemTestScheduler interface {
 	runContainer(spec containerSpec) (*container, error)
 	stop(c *container) error
 	start(c *container) error
-	startNetmaster() error
+	startNetmaster(args string) error
 	stopNetmaster() error
 	stopNetplugin() error
 	startNetplugin(args string) error
@@ -47,5 +47,5 @@ type systemTestScheduler interface {
 	startIperfServer(containers *container) error
 	startIperfClient(containers *container, ip, limit string, isErr bool) error
 	tcFilterShow(bw string) error
-	verifyUplinkState(n *node,uplinks []string) error
+	verifyUplinkState(n *node, uplinks []string) error
 }

--- a/test/systemtests/service_test.go
+++ b/test/systemtests/service_test.go
@@ -698,8 +698,10 @@ func (s systemtestSuite) testServiceTriggerNetmasterSwitchover(c *C, encap strin
 				}
 			}
 
-			leaderIP, err := s.clusterStoreGet("/contiv.io/lock/netmaster/leader")
+			leaderURL, err := s.clusterStoreGet("/contiv.io/lock/netmaster/leader")
 			c.Assert(err, IsNil)
+
+			leaderIP := strings.Split(leaderURL, ":")[0]
 
 			for _, node := range s.nodes {
 				res, err := node.getIPAddr("eth1")
@@ -716,8 +718,10 @@ func (s systemtestSuite) testServiceTriggerNetmasterSwitchover(c *C, encap strin
 
 			for x := 0; x < 15; x++ {
 				logrus.Info("Waiting 5s for leader to change...")
-				newLeaderIP, err := s.clusterStoreGet("/contiv.io/lock/netmaster/leader")
+				newLeaderURL, err := s.clusterStoreGet("/contiv.io/lock/netmaster/leader")
 				c.Assert(err, IsNil)
+
+				newLeaderIP := strings.Split(newLeaderURL, ":")[0]
 
 				for _, node := range s.nodes {
 					res, err := node.getIPAddr("eth1")
@@ -733,7 +737,7 @@ func (s systemtestSuite) testServiceTriggerNetmasterSwitchover(c *C, encap strin
 				time.Sleep(5 * time.Second)
 			}
 		finished:
-			c.Assert(oldLeader.startNetmaster(), IsNil)
+			c.Assert(oldLeader.startNetmaster(""), IsNil)
 			time.Sleep(10 * time.Second)
 
 			for tenant, serviceContainers := range servicesPerTenant {

--- a/test/systemtests/swarm_test.go
+++ b/test/systemtests/swarm_test.go
@@ -406,9 +406,9 @@ func (w *swarm) stopNetmaster() error {
 	return w.node.tbnode.RunCommand("sudo pkill netmaster")
 }
 
-func (w *swarm) startNetmaster() error {
+func (w *swarm) startNetmaster(args string) error {
 	logrus.Infof("Starting netmaster on %s", w.node.Name())
-	return w.node.tbnode.RunCommandBackground("sudo " + w.node.suite.basicInfo.BinPath + "/netmaster" + " --cluster-store " + w.node.suite.basicInfo.ClusterStore + " &> /tmp/netmaster.log")
+	return w.node.tbnode.RunCommandBackground("sudo " + w.node.suite.basicInfo.BinPath + "/netmaster" + " --cluster-store " + w.node.suite.basicInfo.ClusterStore + " " + args + " &> /tmp/netmaster.log")
 }
 func (w *swarm) cleanupMaster() {
 	logrus.Infof("Cleaning up master on %s", w.node.Name())

--- a/test/systemtests/util_test.go
+++ b/test/systemtests/util_test.go
@@ -1336,7 +1336,7 @@ func (s *systemtestSuite) SetUpTestBaremetal(c *C) {
 	time.Sleep(15 * time.Second)
 
 	for _, node := range s.nodes {
-		c.Assert(node.startNetmaster(), IsNil)
+		c.Assert(node.startNetmaster(""), IsNil)
 		time.Sleep(1 * time.Second)
 		c.Assert(node.exec.runCommandUntilNoNetmasterError(), IsNil)
 	}
@@ -1398,7 +1398,7 @@ func (s *systemtestSuite) SetUpTestVagrant(c *C) {
 	time.Sleep(15 * time.Second)
 
 	errors = s.parallelExec(func(node *node) error {
-		return node.startNetmaster()
+		return node.startNetmaster("")
 	})
 	for _, err := range errors {
 		c.Assert(err, IsNil)


### PR DESCRIPTION
Changes included:
- introduce a control_url cmd line arg for netmaster for control pkts
- listen_url is used for any external communication

If no listen_url/control_url is specified, netmaster listens on :9999 by default
If no IP is mentioned in control_url, local_IP:control_url is used for netplugin->netmaster control communication

