### PR TITLE
scripts/netContain/Dockerfile: install ovs 2.5.x

### DIFF
--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:16.04
 # ENV export https_proxy=https://proxy.localhost.com:8080
 
 RUN apt-get update \
- && apt-get install -y openvswitch-switch=2.5.0-0ubuntu1 \
+ && apt-get install -y openvswitch-switch=2.5.2-0ubuntu0.16.04.1 \
         net-tools \
         iptables \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR makes the netplugin Docker image use any OVS 2.5.x version found in the Ubuntu repositories. Previously released netplugin images aren't affected by this change.

It makes sense to install any 2.5.x version available. No new features are introduced as part of these maintenance releases. The bug fixes will be good to have.

This fixes the build of this image and it addresses the issue we have with the broken build on the CI.