### PR TITLE
Makefile: run tar and clean-tar targets on the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ all-CI: stop clean start
 		&& cd /opt/gopath/src/github.com/contiv/netplugin \
 		&& make host-unit-test host-integ-test host-build-docker-image"'
 	make system-test
+	make tar clean-tar
 
 test: build unit-test system-test ubuntu-tests
 


### PR DESCRIPTION
This PR adds the `tar` and `clean-tar` targets to the CI. This ensures this test runs on the CI and would help catch potential issues with the tarballs which need to be released.