### PR TITLE
Removing non-json text because it creates invalid json output

### DIFF
--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -65,8 +65,6 @@ func inspectPolicy(ctx *cli.Context) {
 	tenant := ctx.String("tenant")
 	policy := ctx.Args()[0]
 
-	fmt.Printf("Inspeting policy: %s tenant: %s\n", policy, tenant)
-
 	pol, err := getClient(ctx).PolicyInspect(tenant, policy)
 	errCheck(ctx, err)
 
@@ -394,7 +392,6 @@ func inspectNetprofile(ctx *cli.Context) {
 
 	tenant := ctx.String("tenant")
 	netprofile := ctx.Args()[0]
-	fmt.Printf("Inspecting netprofile:%s for %s", netprofile, tenant)
 
 	profileList, err := getClient(ctx).NetprofileInspect(tenant, netprofile)
 	errCheck(ctx, err)
@@ -476,8 +473,6 @@ func inspectNetwork(ctx *cli.Context) {
 
 	tenant := ctx.String("tenant")
 	network := ctx.Args()[0]
-
-	fmt.Printf("Inspeting network: %s tenant: %s\n", network, tenant)
 
 	net, err := getClient(ctx).NetworkInspect(tenant, network)
 	errCheck(ctx, err)
@@ -578,8 +573,6 @@ func inspectTenant(ctx *cli.Context) {
 
 	tenant := ctx.Args()[0]
 
-	fmt.Printf("Inspecting tenant: %s  ", tenant)
-
 	ten, err := getClient(ctx).TenantInspect(tenant)
 	errCheck(ctx, err)
 
@@ -626,8 +619,6 @@ func inspectEndpoint(ctx *cli.Context) {
 
 	epid := ctx.Args()[0]
 
-	fmt.Printf("Inspecting endpoint: %s\n", epid)
-
 	net, err := getClient(ctx).EndpointInspect(epid)
 	errCheck(ctx, err)
 
@@ -672,8 +663,6 @@ func inspectEndpointGroup(ctx *cli.Context) {
 
 	tenant := ctx.String("tenant")
 	endpointGroup := ctx.Args()[0]
-
-	fmt.Printf("Inspeting endpointGroup: %s tenant: %s\n", endpointGroup, tenant)
 
 	epg, err := getClient(ctx).EndpointGroupInspect(tenant, endpointGroup)
 	errCheck(ctx, err)
@@ -844,8 +833,6 @@ func inspectBgp(ctx *cli.Context) {
 
 	hostname := ctx.Args()[0]
 
-	fmt.Printf("netctl. Inspecting bgp: %s\n", hostname)
-
 	bgp, err := getClient(ctx).BgpInspect(hostname)
 	errCheck(ctx, err)
 
@@ -882,8 +869,6 @@ func inspectGlobal(ctx *cli.Context) {
 	if len(ctx.Args()) != 0 {
 		errExit(ctx, exitHelp, "More arguments than required", true)
 	}
-
-	fmt.Printf("Inspecting global\n")
 
 	ginfo, err := getClient(ctx).GlobalInspect("global")
 	errCheck(ctx, err)
@@ -1353,8 +1338,6 @@ func inspectServiceLb(ctx *cli.Context) {
 
 	tenant := ctx.String("tenant")
 	service := ctx.Args()[0]
-
-	fmt.Printf("Inspecting service: %s tenant: %s\n", service, tenant)
 
 	net, err := getClient(ctx).ServiceLBInspect(tenant, service)
 	errCheck(ctx, err)


### PR DESCRIPTION
For ticket #859 