### PR TITLE
Docker network creation workflow changes for swarm-mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,8 +274,17 @@ host-plugin-restart:
 
 # complete workflow to create rootfs, create/enable plugin and start swarm-mode
 demo-v2plugin:
-	CONTIV_V2PLUGIN_NAME="$${CONTIV_V2PLUGIN_NAME:-contiv/v2plugin:0.1}" CONTIV_DOCKER_VERSION="$${CONTIV_DOCKER_VERSION:-1.13.1}" CONTIV_DOCKER_SWARM="$${CONTIV_DOCKER_SWARM:-classic_mode}" make ssh-build
+	CONTIV_V2PLUGIN_NAME="$${CONTIV_V2PLUGIN_NAME:-contiv/v2plugin:0.1}" CONTIV_DOCKER_VERSION="$${CONTIV_DOCKER_VERSION:-1.13.1}" CONTIV_DOCKER_SWARM="$${CONTIV_DOCKER_SWARM:-swarm_mode}" make ssh-build
 	vagrant ssh netplugin-node1 -c 'bash -lc "source /etc/profile.d/envvar.sh && cd /opt/gopath/src/github.com/contiv/netplugin && make host-pluginfs-create host-plugin-restart host-swarm-restart"'
+
+# release a v2 plugin
+host-plugin-release: 
+	@echo dev: creating a docker v2plugin ...
+	sh scripts/v2plugin_rootfs.sh 
+	docker plugin create ${CONTIV_V2PLUGIN_NAME} install/v2plugin
+	@echo dev: pushing ${CONTIV_V2PLUGIN_NAME} to docker hub 
+	@echo dev: (need docker login with user in contiv org)
+	docker plugin push ${CONTIV_V2PLUGIN_NAME}
 
 only-tar:
 
@@ -293,3 +302,4 @@ release: tar
 	OLD_VERSION=${OLD_VERSION} BUILD_VERSION=${BUILD_VERSION} \
 	USE_RELEASE=${USE_RELEASE} scripts/release.sh
 	@make clean-tar
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,7 +115,7 @@ fi
 # setup docker cluster store
 # No cluster store needed for swarm_mode
 if [[ #{docker_swarm} == "swarm_mode" ]]; then
-    perl -i -lpe 's!^ExecStart(.+)$!ExecStart$1 -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock!' /lib/systemd/system/docker.service
+    perl -i -lpe 's!^ExecStart(.+)$!ExecStart$1 !' /lib/systemd/system/docker.service
 else
     if [[ "$CONTIV_CLUSTER_STORE" == *"consul:"* ]]
     then
@@ -367,7 +367,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             end
 
             node.vm.provision "shell" do |s|
-                s.inline = "echo '#{node_ips[0]} netmaster' >> /etc/hosts; echo '#{node_ips[1]} netmaster' >> /etc/hosts;   echo '#{node_addr} #{node_name}' >> /etc/hosts"
+               if ENV["DOCKER_SWARM"] == "SWARM_MODE"
+                   # In swarm mode first VM is the master. Should make it configurable later
+                   s.inline = "echo '#{node_ips[0]} netmaster' >> /etc/hosts; echo '#{node_addr} #{node_name}' >> /etc/hosts"
+               else
+                   s.inline = "echo '#{node_ips[0]} netmaster' >> /etc/hosts; echo '#{node_ips[1]} netmaster' >> /etc/hosts;   echo '#{node_addr} #{node_name}' >> /etc/hosts"
+               end
             end
 
             provision_common_once_script = provision_common_once % {

--- a/core/core.go
+++ b/core/core.go
@@ -75,17 +75,18 @@ type Plugin interface {
 // InstanceInfo encapsulates data that is specific to a running instance of
 // netplugin like label of host on which it is started.
 type InstanceInfo struct {
-	StateDriver StateDriver `json:"-"`
-	HostLabel   string      `json:"host-label"`
-	CtrlIP      string      `json:"ctrl-ip"`
-	VtepIP      string      `json:"vtep-ip"`
-	UplinkIntf  []string    `json:"uplink-if"`
-	RouterIP    string      `json:"router-ip"`
-	FwdMode     string      `json:"fwd-mode"`
-	ArpMode     string      `json:"arp-mode"`
-	DbURL       string      `json:"db-url"`
-	PluginMode  string      `json:"plugin-mode"`
-	HostPvtNW   int         `json:"host-pvt-nw"`
+	StateDriver  StateDriver `json:"-"`
+	HostLabel    string      `json:"host-label"`
+	CtrlIP       string      `json:"ctrl-ip"`
+	VtepIP       string      `json:"vtep-ip"`
+	UplinkIntf   []string    `json:"uplink-if"`
+	RouterIP     string      `json:"router-ip"`
+	FwdMode      string      `json:"fwd-mode"`
+	ArpMode      string      `json:"arp-mode"`
+	DbURL        string      `json:"db-url"`
+	PluginMode   string      `json:"plugin-mode"`
+	HostPvtNW    int         `json:"host-pvt-nw"`
+	VxlanUDPPort int         `json:"vxlan-port"`
 }
 
 // PortSpec defines protocol/port info required to host the service

--- a/drivers/ovsSwitch.go
+++ b/drivers/ovsSwitch.go
@@ -89,7 +89,7 @@ func (sw *OvsSwitch) GetUplinkInterfaces(uplinkID string) []string {
 
 // NewOvsSwitch Creates a new OVS switch instance
 func NewOvsSwitch(bridgeName, netType, localIP, fwdMode string,
-	vlanIntf []string, hostPvtNW int) (*OvsSwitch, error) {
+	vlanIntf []string, hostPvtNW int, vxlanUDPPort int) (*OvsSwitch, error) {
 	var err error
 	var datapath string
 	var ofnetPort, ctrlrPort uint16
@@ -101,7 +101,7 @@ func NewOvsSwitch(bridgeName, netType, localIP, fwdMode string,
 	sw.hostPvtNW = hostPvtNW
 
 	// Create OVS db driver
-	sw.ovsdbDriver, err = NewOvsdbDriver(bridgeName, "secure")
+	sw.ovsdbDriver, err = NewOvsdbDriver(bridgeName, "secure", vxlanUDPPort)
 	if err != nil {
 		log.Fatalf("Error creating ovsdb driver. Err: %v", err)
 	}

--- a/drivers/ovsdriver.go
+++ b/drivers/ovsdriver.go
@@ -170,13 +170,13 @@ func (d *OvsDriver) Init(info *core.InstanceInfo) error {
 
 	// Create Vxlan switch
 	d.switchDb["vxlan"], err = NewOvsSwitch(vxlanBridgeName, "vxlan", info.VtepIP,
-		info.FwdMode, nil, info.HostPvtNW)
+		info.FwdMode, nil, info.HostPvtNW, info.VxlanUDPPort)
 	if err != nil {
 		log.Fatalf("Error creating vlan switch. Err: %v", err)
 	}
 	// Create Vlan switch
 	d.switchDb["vlan"], err = NewOvsSwitch(vlanBridgeName, "vlan", info.VtepIP,
-		info.FwdMode, info.UplinkIntf, info.HostPvtNW)
+		info.FwdMode, info.UplinkIntf, info.HostPvtNW, info.VxlanUDPPort)
 	if err != nil {
 		log.Fatalf("Error creating vlan switch. Err: %v", err)
 	}

--- a/install/v2plugin/Dockerfile
+++ b/install/v2plugin/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
 
 RUN mkdir -p /run/docker/plugins /etc/openvswitch /var/run/contiv/log \
  && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
- && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl \
+ && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl \
  && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/sgerrand.rsa.pub \
  && wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk \
  && apk --no-cache add glibc-2.23-r1.apk

--- a/install/v2plugin/README.md
+++ b/install/v2plugin/README.md
@@ -3,16 +3,18 @@
 Docker 1.13/17.03 supports legacy plugins (binaries/containers) and docker managed plugins (v2plugin) using docker plugin commands. Contiv binaries (netplugin and netmaster) and Contiv container (contiv/netplugin) support legacy plugin mode. In addition, Contiv can be run as v2plugin (contiv/v2plugin).
 
 ## Classic Swarm and Swarm-mode
-In Classic Swarm or Legacy Docker Swarm, swarm binary/container running on each host forms a cluster using an external key-value store. Network plugins can run in the legacy mode. Docker versions upto 1.12 supported only this mode for remote drivers. In this mode docker engine is started with a cluster-store option. Docker 1.13.1 also supports this mode and the plugin can be run legacy plugin or v2plugin. Contiv binaries/containers will be supported in this legacy mode. 
+In Classic Swarm or Legacy Docker Swarm, swarm binary/container running on each host forms a cluster using an external key-value store. Network plugins can run in the legacy mode. Docker versions up to 1.12 supported only this mode for remote drivers. In this mode docker engine is started with a cluster-store option. Docker 1.13.1 also supports this mode and the plugin can be run as legacy plugin or v2plugin. Contiv binaries/containers will be supported in this legacy mode.
 
-Docker introduced swarm-mode in 1.12 where the docker engines form a cluster without using an external key-value store. Swarm-mode in Docker 1.12 only supported docker overlay network driver. In this mode the swarm is initialized using docker swarm commands. From Docker 1.13.1, remote network drivers implemented as v2plugins are also supported in swarm-mode. Contiv v2plugin support for docker swarm-mode is still in progress.
+Docker introduced swarm-mode in 1.12 where the docker engines form a cluster without using an external key-value store. Swarm-mode in Docker 1.12 only supported docker overlay network driver. In this mode the swarm is initialized using docker swarm commands. From Docker 1.13.1, remote network drivers implemented as v2plugins are also supported in swarm-mode. Contiv v2plugin supports docker swarm-mode.
 
-## v2plugin 
+## v2plugin
 Docker managed [plugins](https://docs.docker.com/engine/extend/) are run as runc containers and are managed using docker plugin commands. Docker engine running in [swarm-mode](https://docs.docker.com/engine/swarm/) requires the remote drivers to implement v2plugin architecture.
+
 
 ## Contiv plugin install
 Contiv plugin config options should be specified if it is different from default:
-docker plugin install contiv/v2plugin:0.1 ARG1=VALUE1 ARG2=VALUE2 ...
+
+docker plugin install contiv/v2plugin:1.0.0 ARG1=VALUE1 ARG2=VALUE2 ...
 ```
 ARG           : DESCRIPTION                                   : DEFAULT VALUE
 --------------:-----------------------------------------------:----------------------
@@ -30,12 +32,12 @@ dbg_flag      : To enable debug mode, set to '-debug'         : ""
 ### docker store
 Docker certified contiv plugin is avaliable on [Docker Store](https://store.docker.com/plugins/803eecee-0780-401a-a454-e9523ccf86b3?tab=description).
 ```
-docker plugin install store/contiv/v2plugin:1.0.0-beta.3 iflist=eth1,eth2
+docker plugin install store/contiv/v2plugin:1.0.0 iflist=eth1,eth2
 ```
 ### docker hub
 Contiv plugin released from contiv repo is also pushed to docker hub. iflist has the list of data interfaces used for vlan networks in contiv.
 ```
-docker plugin install contiv/v2plugin:1.0.0-beta.3 iflist=eth1,eth2
+docker plugin install contiv/v2plugin:1.0.0 iflist=eth1,eth2
 ```
 ### vagrant dev/demo setup
 To create a plugin from [contiv repo](https://github.com/contiv/netplugin), enable v2plugin and run docker in swarm-mode, use the Makefile target demo-v2plugin
@@ -43,27 +45,106 @@ To create a plugin from [contiv repo](https://github.com/contiv/netplugin), enab
 make demo-v2plugin
 ```
 
-## Contiv plugin-modes
-Contiv plugin runs both netplugin and netmaster by default. Contiv v2plugin can be run with only netplugin by setting the plugin_role to slave.
+## Contiv plugin-roles
+Contiv plugin runs both netplugin and netmaster by default. Contiv v2plugin can be run with only netplugin by setting the plugin_role to worker.
 ```
-docker plugin install contiv/v2plugin:1.0.0-beta.3 iflist=eth1,eth2 plugin_role=slave
+docker plugin install contiv/v2plugin:1.0.0 iflist=eth1,eth2 plugin_role=worker
 ```
 
-## Contiv plugin workflow
+## Contiv plugin swarm-mode workflow (recommended and default for v2plugin)
   1. Etcd cluster should be brought up on the hosts on localhost:2379. If a different port (or Consul) is used, cluster-store option needs to be specified in the plugin install command.
 
-  2. Install contiv v2plugin
+  2. Bring up Docker Swarm-mode
   ```
-  docker plugin install contiv/v2plugin:1.0.0-beta.3 iflist=<data ifs used for vlan networks>
+  # on manager node init swarm-mode
+  docker swarm init --advertise-addr 192.168.2.10:2377
+
+  # get the join-token from master node
+  docker swarm join-token worker -q
+
+  # on worker nodes, use the token to join swarm
+  docker swarm join --token SWMTKN-1-4qgg20vkzhc3jhc765k5x0coyriggkdvw1t7fmbiimqguagqr7-8um9goip0d03yqmmrb4c4fh1j 192.168.2.10:2377  
+  ```  
+  3. Install contiv v2plugin
+  ```
+  # on swarm manager node install plugin with 'master' role
+  docker plugin install contiv/v2plugin:1.0.0 plugin_role=master iflist=<data ifs used for vlan networks>
   ( allow/grant the install permissions when prompted )
 
+  # on worker nodes, install plugin with 'worker' role
+  docker plugin install contiv/v2plugin:1.0.0 plugin_role=worker iflist=<data ifs used for vlan networks>
+
+  # to see if the plugin is installed and enabled
   docker plugin ls
+  # also check is netplugin/netmaster started
+  cat /var/run/contiv/log/plugin_bootup.log
+  ```
+  ```
+  If there are multiple local interfaces you need to specify the local IP address to use.
+  docker plugin install contiv/v2plugin:1.0.0 ctrl_ip=192.168.2.10 control_url=192.168.2.10:9999 iflist=eth2,eth3
+  ```
+  4. Debug logs
+  ```
+  # bootup logs are in /var/log/contiv/plugin_bootup.log
+  # netplugin, netmaster and ovs logs are also in /var/log/contiv/
+  ```
+  5. Docker workflow  
+
+  5.1 Create docker network and start docker services  
+
+  This workflow doesn't support multi-tenancy and policy
+  ```
+  # create docker network
+  docker network create svc-net1 --subnet 100.1.1.0/24 --gateway 100.1.1.254 -d contiv/v2plugin:1.0.0 --ipam-driver contiv/v2plugin:1.0.0
+
+  # create docker service
+  docker service create --name my-db --replicas 3 --network svc-net1 redis
+
+  # create docker service with port published in routing-mesh
+  docker service create --name my-web --publish 8080:80 --network svc-net1 --replicas 2  nginx
+  ```
+
+  5.2 Create Contiv policies and continue with the docker workflow
+
+  Multi-tenancy and policies are configured on contiv and docker networks are mapped to it.
+  ```
+  # create contiv policy
+  netctl network create contiv-net-1 -s 200.1.1.1/24 -g 200.1.1.200
+  netctl policy create p1
+  netctl group create -p p1 -tag policylabel contiv-net-1 group1
+
+  # create docker network with contiv-tag
+  docker network create svc-net2 -o contiv-tag=policylabel -d contiv/v2plugin:1.0.0 --ipam-opt contiv-tag=policylabel --ipam-driver contiv/v2plugin:1.0.0
+
+  # create docker service
+  docker service create --name my-policy-db --replicas 3 --network svc-net2 redis
+
+  # create docker service with port published in routing-mesh
+  docker service create --name my-policy-web --publish 8880:80 --network svc-net2 --replicas 2  nginx
+  ```
+
+## Contiv plugin workflow (legacy docker mode)
+  v2plugin can also run in legacy mode by setting the plugin_mode to docker explicitly when installing the plugin  
+  1.  Etcd cluster should be brought up on the hosts on localhost:2379.  
+  2. Install contiv v2plugin
+  ```
+  docker plugin install contiv/v2plugin:1.0.0 plugin-mode=docker iflist=<data ifs used for vlan networks>
+  ( allow/grant the install permissions when prompted )
+
+  # on node where netmaster needs to run, install plugin with 'master' role
+  docker plugin install contiv/v2plugin:1.0.0 plugin_role=master iflist=<data ifs used for vlan networks>
+  ( allow/grant the install permissions when prompted )
+
+  # on all other nodes, install plugin with 'worker' role
+  docker plugin install contiv/v2plugin:1.0.0 plugin_role=worker iflist=<data ifs used for vlan networks>
+
   # to see if the plugin is installed properly and enabled
+  docker plugin ls
   ```
   3. Debug logs
   ```
-  # bootup logs are in /var/run/contiv/log/plugin_bootup.log
-  # netplugin and netmaster logs are also in /var/run/contiv/log
+  # bootup logs are in /var/log/contiv/plugin_bootup.log
+  # netplugin, netmaster and ovs logs are also in /var/log/contiv/
   ```
   4. Continue with the regular workflow to create networks and run containers
   ```
@@ -74,4 +155,3 @@ docker plugin install contiv/v2plugin:1.0.0-beta.3 iflist=eth1,eth2 plugin_role=
   docker run -itd --net=contiv-net --name=c1 alpine /bin/sh
   docker run –it –rm –net=contiv-net –name=c2 alpine ping –c2 c1
   ```
-  

--- a/install/v2plugin/config.template
+++ b/install/v2plugin/config.template
@@ -16,6 +16,14 @@
           "Value": ""
        },
        {
+          "Description": "Change the directory where the logs are saved",
+          "Name": "log_dir",
+          "Settable": [
+             "value"
+          ],
+          "Value": "/var/log/contiv"
+       },
+       {
           "Description": "VLAN uplink interface used by OVS",
           "Name": "iflist",
           "Settable": [
@@ -32,6 +40,14 @@
           "Value": "etcd://localhost:2379"
        },
        {
+          "Description": "Plugin mode set to docker or swarm-mode",
+          "Name": "plugin_mode",
+          "Settable": [
+             "value"
+          ],
+          "Value": "swarm-mode"
+       },
+       {
           "Description": "Local IP address to be used by netplugin for control communication",
           "Name": "ctrl_ip",
           "Settable": [
@@ -46,6 +62,14 @@
              "value"
           ],
           "Value": "none"
+       },
+       {
+          "Description": "Vxlan UDP port number used for encapsulating vxlan packets",
+          "Name": "vxlan_port",
+          "Settable": [
+             "value"
+          ],
+          "Value": "8742"
        },
        {
           "Description": "In 'master' role, plugin runs netmaster and netplugin",
@@ -91,8 +115,8 @@
        {
           "type": "bind",
           "options": ["rbind"],
-          "source": "/var/log/openvswitch",
-          "destination": "/var/log/openvswitch"
+          "source": "/var/log",
+          "destination": "/var/log"
        },
        {
           "type": "bind",

--- a/install/v2plugin/startcontiv.sh
+++ b/install/v2plugin/startcontiv.sh
@@ -3,11 +3,14 @@
 ### Pre-requisite on the host
 # run a cluster store like etcd or consul
 
-mkdir -p /var/run/contiv/log
+if [ $log_dir == "" ]; then
+    log_dir="/var/log/contiv"
+fi
+BOOTUP_LOGFILE="$log_dir/plugin_bootup.log"
+
+mkdir -p $log_dir
 mkdir -p /var/run/openvswitch
 mkdir -p /etc/openvswitch
-
-BOOTUP_LOGFILE="/var/run/contiv/log/plugin_bootup.log"
 
 echo "V2 Plugin logs" > $BOOTUP_LOGFILE
 
@@ -26,9 +29,14 @@ fi
 if [ $control_url != ":9999" ]; then
     control_url_cfg="-control-url=$control_url"
 fi
+if [ $vxlan_port != "4789" ]; then
+    vxlan_port_cfg="-vxlan-port=$vxlan_port"
+fi
+
+set -e
 
 echo "Loading OVS" >> $BOOTUP_LOGFILE
-(modprobe openvswitch) || (echo "Load ovs FAILED!!! " >> $BOOTUP_LOGFILE && while true; do sleep 1; done)
+(modprobe openvswitch) || (echo "Load ovs FAILED!!! " >> $BOOTUP_LOGFILE)
 
 echo "  Cleaning up ovsdb files" >> $BOOTUP_LOGFILE
 rm -rf /var/run/openvswitch/*
@@ -39,19 +47,22 @@ echo "  Creating OVS DB" >> $BOOTUP_LOGFILE
 (ovsdb-tool create  /etc/openvswitch/conf.db /usr/share/openvswitch/vswitch.ovsschema) || (while true; do sleep 1; done)
 
 echo "  Starting OVSBD server " >> $BOOTUP_LOGFILE
-ovsdb-server --remote=punix:/var/run/openvswitch/db.sock --remote=db:Open_vSwitch,Open_vSwitch,manager_options --private-key=db:Open_vSwitch,SSL,private_key --certificate=db:Open_vSwitch,SSL,certificate --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert --log-file=/var/log/openvswitch/ovs-db.log -vsyslog:dbg -vfile:dbg --pidfile --detach /etc/openvswitch/conf.db >> $BOOTUP_LOGFILE
+ovsdb-server --remote=punix:/var/run/openvswitch/db.sock --remote=db:Open_vSwitch,Open_vSwitch,manager_options --private-key=db:Open_vSwitch,SSL,private_key --certificate=db:Open_vSwitch,SSL,certificate --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert --log-file=$log_dir/ovs-db.log -vsyslog:dbg -vfile:dbg --pidfile --detach /etc/openvswitch/conf.db >> $BOOTUP_LOGFILE
 echo "  Starting ovs-vswitchd " >> $BOOTUP_LOGFILE
-ovs-vswitchd -v --pidfile --detach --log-file=/var/log/openvswitch/ovs-vswitchd.log -vconsole:err -vsyslog:info -vfile:info &
+ovs-vswitchd -v --pidfile --detach --log-file=$log_dir/ovs-vswitchd.log -vconsole:err -vsyslog:info -vfile:info &
 ovs-vsctl set-manager tcp:127.0.0.1:6640 
 ovs-vsctl set-manager ptcp:6640
 
-echo "Started OVS, logs in /var/log/openvswitch/" >> $BOOTUP_LOGFILE
+echo "Started OVS, logs in $log_dir" >> $BOOTUP_LOGFILE
+
+set +e
 
 echo "Starting Netplugin " >> $BOOTUP_LOGFILE
 while true ; do
-    echo "/netplugin $dbg_flag -plugin-mode docker -vlan-if $iflist -cluster-store $cluster_store $ctrl_ip_cfg $vtep_ip_cfg" >> $BOOTUP_LOGFILE
-    /netplugin $dbg_flag -plugin-mode docker -vlan-if $iflist -cluster-store $cluster_store $ctrl_ip_cfg $vtep_ip_cfg &> /var/run/contiv/log/netplugin.log
-    echo "CRITICAL : Netplugin has exited, Respawn in 5s" >> $BOOTUP_LOGFILE
+    echo "/netplugin $dbg_flag -plugin-mode $plugin_mode $vxlan_port_cfg -vlan-if $iflist -cluster-store $cluster_store $ctrl_ip_cfg $vtep_ip_cfg" >> $BOOTUP_LOGFILE
+    /netplugin $dbg_flag -plugin-mode $plugin_mode $vxlan_port_cfg -vlan-if $iflist -cluster-store $cluster_store $ctrl_ip_cfg $vtep_ip_cfg &> $log_dir/netplugin.log
+    echo "CRITICAL : Net Plugin has exited, Respawn in 5" >> $BOOTUP_LOGFILE
+    mv $log_dir/netplugin.log $log_dir/netplugin.log.lastrun
     sleep 5
     echo "Restarting Netplugin " >> $BOOTUP_LOGFILE
 done &
@@ -59,11 +70,12 @@ done &
 if [ $plugin_role == "master" ]; then
     echo "Starting Netmaster " >> $BOOTUP_LOGFILE
     while  true ; do
-        echo "/netmaster $dbg_flag -plugin-name=$plugin_name -cluster-store=$cluster_store $listen_url_cfg $control_url_cfg " >> $BOOTUP_LOGFILE
-        /netmaster $dbg_flag -plugin-name=$plugin_name -cluster-store=$cluster_store $listen_url_cfg $control_url_cfg &> /var/run/contiv/log/netmaster.log
-        echo "CRITICAL : Netmaster has exited, Respawn in 5s" >> $BOOTUP_LOGFILE
-        echo "Restarting Netmaster " >> $BOOTUP_LOGFILE
+        echo "/netmaster $dbg_flag -plugin-name=$plugin_name -cluster-mode=$plugin_mode -cluster-store=$cluster_store $listen_url_cfg $control_url_cfg" >> $BOOTUP_LOGFILE
+        /netmaster $dbg_flag -plugin-name=$plugin_name -cluster-mode=$plugin_mode -cluster-store=$cluster_store $listen_url_cfg $control_url_cfg &> $log_dir/netmaster.log
+        echo "CRITICAL : Net Master has exited, Respawn in 5s" >> $BOOTUP_LOGFILE
+	mv $log_dir/netmaster.log $log_dir/netmaster.log.lastrun
         sleep 5
+        echo "Restarting Netmaster " >> $BOOTUP_LOGFILE
     done &
 else
     echo "Not starting netmaster as plugin role is" $plugin_role >> $BOOTUP_LOGFILE

--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -77,6 +77,10 @@ var Commands = []cli.Command{
 						Name:  "ip-pool, r",
 						Usage: "IP Address range, example 10.36.0.1-10.36.0.10",
 					},
+					cli.StringFlag{
+						Name:  "epg-tag, tag",
+						Usage: "Configured Group Tag",
+					},
 				},
 				Action: createEndpointGroup,
 			},
@@ -232,6 +236,10 @@ var Commands = []cli.Command{
 					cli.StringFlag{
 						Name:  "gatewayv6, g6",
 						Usage: "IPv6 Gateway",
+					},
+					cli.StringFlag{
+						Name:  "nw-tag, tag",
+						Usage: "Configured Network Tag",
 					},
 				},
 				Action: createNetwork,

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -163,7 +163,7 @@ func inspectPolicy(ctx *cli.Context) {
 	tenant := ctx.String("tenant")
 	policy := ctx.Args()[0]
 
-	fmt.Printf("Inspeting policy: %s tenant: %s\n", policy, tenant)
+	fmt.Printf("Inspecting policy: %s tenant: %s\n", policy, tenant)
 
 	pol, err := getClient(ctx).PolicyInspect(tenant, policy)
 	errCheck(ctx, err)
@@ -537,6 +537,7 @@ func createNetwork(ctx *cli.Context) {
 	encap := ctx.String("encap")
 	pktTag := ctx.Int("pkt-tag")
 	nwType := ctx.String("nw-type")
+	nwTag := ctx.String("nw-tag")
 
 	errCheck(ctx, getClient(ctx).NetworkPost(&contivClient.Network{
 		TenantName:  tenant,
@@ -548,6 +549,7 @@ func createNetwork(ctx *cli.Context) {
 		Ipv6Gateway: gatewayv6,
 		PktTag:      pktTag,
 		NwType:      nwType,
+		CfgdTag:     nwTag,
 	}))
 
 	fmt.Printf("Creating network %s:%s\n", tenant, network)
@@ -575,7 +577,7 @@ func inspectNetwork(ctx *cli.Context) {
 	tenant := ctx.String("tenant")
 	network := ctx.Args()[0]
 
-	fmt.Printf("Inspeting network: %s tenant: %s\n", network, tenant)
+	fmt.Printf("Inspecting network: %s tenant: %s\n", network, tenant)
 
 	net, err := getClient(ctx).NetworkInspect(tenant, network)
 	errCheck(ctx, err)
@@ -623,12 +625,12 @@ func listNetworks(ctx *cli.Context) {
 	} else {
 		writer := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
 		defer writer.Flush()
-		writer.Write([]byte("Tenant\tNetwork\tNw Type\tEncap type\tPacket tag\tSubnet\tGateway\tIPv6Subnet\tIPv6Gateway\n"))
-		writer.Write([]byte("------\t-------\t-------\t----------\t----------\t-------\t------\t----------\t-----------\n"))
+		writer.Write([]byte("Tenant\tNetwork\tNw Type\tEncap type\tPacket tag\tSubnet\tGateway\tIPv6Subnet\tIPv6Gateway\tCfgd Tag \n"))
+		writer.Write([]byte("------\t-------\t-------\t----------\t----------\t-------\t------\t----------\t-----------\t---------\n"))
 
 		for _, net := range filtered {
 			writer.Write(
-				[]byte(fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+				[]byte(fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 					net.TenantName,
 					net.NetworkName,
 					net.NwType,
@@ -638,6 +640,7 @@ func listNetworks(ctx *cli.Context) {
 					net.Gateway,
 					net.Ipv6Subnet,
 					net.Ipv6Gateway,
+					net.CfgdTag,
 				)))
 		}
 	}
@@ -747,6 +750,7 @@ func createEndpointGroup(ctx *cli.Context) {
 	group := ctx.Args()[1]
 	netprofile := ctx.String("networkprofile")
 	ipPool := ctx.String("ip-pool")
+	epgTag := ctx.String("tag")
 	policies := ctx.StringSlice("policy")
 
 	extContractsGrps := ctx.StringSlice("external-contract")
@@ -758,6 +762,7 @@ func createEndpointGroup(ctx *cli.Context) {
 		IpPool:           ipPool,
 		Policies:         policies,
 		ExtContractsGrps: extContractsGrps,
+		CfgdTag:          epgTag,
 	}))
 
 	fmt.Printf("Creating EndpointGroup %s:%s\n", tenant, group)
@@ -771,7 +776,7 @@ func inspectEndpointGroup(ctx *cli.Context) {
 	tenant := ctx.String("tenant")
 	endpointGroup := ctx.Args()[0]
 
-	fmt.Printf("Inspeting endpointGroup: %s tenant: %s\n", endpointGroup, tenant)
+	fmt.Printf("Inspecting endpointGroup: %s tenant: %s\n", endpointGroup, tenant)
 
 	epg, err := getClient(ctx).EndpointGroupInspect(tenant, endpointGroup)
 	errCheck(ctx, err)
@@ -824,8 +829,8 @@ func listEndpointGroups(ctx *cli.Context) {
 
 		writer := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
 		defer writer.Flush()
-		writer.Write([]byte("Tenant\tGroup\tNetwork\tIP Pool\tPolicies\tNetwork profile\n"))
-		writer.Write([]byte("------\t-----\t-------\t--------\t---------------\n"))
+		writer.Write([]byte("Tenant\tGroup\tNetwork\tIP Pool\tCfgdTag\tPolicies\tNetwork profile\n"))
+		writer.Write([]byte("------\t-----\t-------\t-------\t-------\t--------\t---------------\n"))
 		for _, group := range filtered {
 			policies := ""
 			if group.Policies != nil {
@@ -836,11 +841,12 @@ func listEndpointGroups(ctx *cli.Context) {
 				policies = strings.Join(policyList, ",")
 			}
 			writer.Write(
-				[]byte(fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\n",
+				[]byte(fmt.Sprintf("%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 					group.TenantName,
 					group.GroupName,
 					group.NetworkName,
 					group.IpPool,
+					group.CfgdTag,
 					policies,
 					group.NetProfile,
 				)))

--- a/netmaster/intent/config.go
+++ b/netmaster/intent/config.go
@@ -50,6 +50,7 @@ type ConfigNetwork struct {
 	IPv6SubnetCIDR string
 	IPv6Gateway    string
 	Vrf            string
+	CfgdTag        string
 
 	// eps associated with the network
 	Endpoints []ConfigEP

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -81,7 +81,7 @@ func parseOpts(opts *cliOpts) error {
 	flagSet.StringVar(&opts.clusterMode,
 		"cluster-mode",
 		"docker",
-		"{docker, kubernetes}")
+		"{docker, kubernetes, swarm-mode}")
 	flagSet.BoolVar(&opts.version,
 		"version",
 		false,
@@ -153,7 +153,7 @@ func execOpts(opts *cliOpts) {
 	}
 	log.Infof("Control IP:Port %s:%s", controlIP, controlURL[1])
 
-	if opts.clusterMode == "docker" {
+	if opts.clusterMode == "docker" || opts.clusterMode == "swarm-mode" {
 		docknet.UpdatePluginName(opts.pluginName)
 	}
 }

--- a/netmaster/master/endpointGroup.go
+++ b/netmaster/master/endpointGroup.go
@@ -37,7 +37,7 @@ const maxEpgID = 65535
 var globalEpgID = 1
 
 // CreateEndpointGroup handles creation of endpoint group
-func CreateEndpointGroup(tenantName, networkName, ipPool, groupName string) error {
+func CreateEndpointGroup(tenantName, networkName, groupName, ipPool, cfgdTag string) error {
 	var epgID int
 
 	// Get the state driver
@@ -93,6 +93,12 @@ func CreateEndpointGroup(tenantName, networkName, ipPool, groupName string) erro
 		}
 	}
 
+	// if there is no label given generate one for the epg
+	epgTag := cfgdTag
+	if epgTag == "" {
+		epgTag = groupName + "." + tenantName
+	}
+
 	// params for docker network
 	if GetClusterMode() == "docker" {
 		// Create each EPG as a docker network
@@ -128,6 +134,7 @@ func CreateEndpointGroup(tenantName, networkName, ipPool, groupName string) erro
 		PktTagType:      nwCfg.PktTagType,
 		PktTag:          nwCfg.PktTag,
 		ExtPktTag:       nwCfg.ExtPktTag,
+		GroupTag:        epgTag,
 	}
 
 	epgCfg.StateDriver = stateDriver

--- a/netmaster/master/netmaster.go
+++ b/netmaster/master/netmaster.go
@@ -45,10 +45,11 @@ func SetClusterMode(cm string) error {
 	switch cm {
 	case "docker":
 	case "kubernetes":
+	case "swarm-mode":
 	case "test": // internal mode used for integration testing
 		break
 	default:
-		return core.Errorf("%s not a valid cluster mode {docker | kubernetes}", cm)
+		return core.Errorf("%s not a valid cluster mode {docker | kubernetes | swarm-mode}", cm)
 	}
 
 	masterRTCfg.clusterMode = cm

--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -102,6 +102,12 @@ func CreateNetwork(network intent.ConfigNetwork, stateDriver core.StateDriver, t
 
 	ipv6Subnet, ipv6SubnetLen, _ := netutils.ParseCIDR(network.IPv6SubnetCIDR)
 
+	// if there is no label given generate one for the network
+	nwTag := network.CfgdTag
+	if nwTag == "" {
+		nwTag = network.Name + "." + tenantName
+	}
+
 	// construct and update network state
 	nwCfg = &mastercfg.CfgNetworkState{
 		Tenant:        tenantName,
@@ -112,6 +118,7 @@ func CreateNetwork(network intent.ConfigNetwork, stateDriver core.StateDriver, t
 		SubnetLen:     subnetLen,
 		IPv6Subnet:    ipv6Subnet,
 		IPv6SubnetLen: ipv6SubnetLen,
+		NetworkTag:    nwTag,
 	}
 
 	nwCfg.ID = networkID

--- a/netmaster/mastercfg/endpointGroupState.go
+++ b/netmaster/mastercfg/endpointGroupState.go
@@ -41,6 +41,7 @@ type EndpointGroupState struct {
 	Burst           int           `json:"Burst"`
 	IPPool          string        `json:"IPPool"`
 	EPGIPAllocMap   bitset.BitSet `json:"epgIpAllocMap"`
+	GroupTag        string        `json:"groupTag"`
 }
 
 // Write the state.

--- a/netmaster/mastercfg/networkstate.go
+++ b/netmaster/mastercfg/networkstate.go
@@ -61,6 +61,7 @@ type CfgNetworkState struct {
 	IPv6Gateway   string          `json:"ipv6Gateway"`
 	IPv6AllocMap  map[string]bool `json:"ipv6AllocMap"`
 	IPv6LastHost  string          `json:"ipv6LastHost"`
+	NetworkTag    string          `json:"networkTag"`
 }
 
 // Write the state.

--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -625,10 +625,9 @@ func (ac *APIController) EndpointGroupCreate(endpointGroup *contivModel.Endpoint
 		return core.Errorf("Network %s conflicts with the endpointGroup name",
 			nameClash.NetworkName)
 	}
-
 	// create the endpoint group state
 	err := master.CreateEndpointGroup(endpointGroup.TenantName, endpointGroup.NetworkName,
-		endpointGroup.IpPool, endpointGroup.GroupName)
+		endpointGroup.GroupName, endpointGroup.IpPool, endpointGroup.CfgdTag)
 	if err != nil {
 		log.Errorf("Error creating endpoint group %+v. Err: %v", endpointGroup, err)
 		return err
@@ -944,6 +943,8 @@ func (ac *APIController) EndpointGroupGetOper(endpointGroup *contivModel.Endpoin
 		nwCfg.SubnetIP, nwCfg.SubnetLen)
 	endpointGroup.Oper.AllocatedIPAddresses = netutils.ListAllocatedIPs(epgCfg.EPGIPAllocMap,
 		epgCfg.IPPool, nwCfg.SubnetIP, nwCfg.SubnetLen)
+	endpointGroup.Oper.GroupTag = epgCfg.GroupTag
+
 	readEp := &mastercfg.CfgEndpointState{}
 	readEp.StateDriver = stateDriver
 	epCfgs, err := readEp.ReadAll()
@@ -1064,6 +1065,7 @@ func (ac *APIController) NetworkCreate(network *contivModel.Network) error {
 		Gateway:        network.Gateway,
 		IPv6SubnetCIDR: network.Ipv6Subnet,
 		IPv6Gateway:    network.Ipv6Gateway,
+		CfgdTag:        network.CfgdTag,
 	}
 
 	// Create the network
@@ -1111,6 +1113,7 @@ func (ac *APIController) NetworkGetOper(network *contivModel.NetworkInspect) err
 	network.Oper.ExternalPktTag = nwCfg.ExtPktTag
 	network.Oper.NumEndpoints = nwCfg.EpCount
 	network.Oper.PktTag = nwCfg.PktTag
+	network.Oper.NetworkTag = nwCfg.NetworkTag
 
 	readEp := &mastercfg.CfgEndpointState{}
 	readEp.StateDriver = stateDriver

--- a/netplugin/agent/agent.go
+++ b/netplugin/agent/agent.go
@@ -60,8 +60,10 @@ func NewAgent(pluginConfig *plugin.Config) *Agent {
 
 	// Initialize appropriate plugin
 	switch opts.PluginMode {
+	case "swarm-mode":
+		fallthrough
 	case "docker":
-		dockplugin.InitDockPlugin(netPlugin)
+		dockplugin.InitDockPlugin(netPlugin, opts.PluginMode)
 
 	case "kubernetes":
 		k8splugin.InitCNIServer(netPlugin)
@@ -218,7 +220,8 @@ func (ag *Agent) HandleEvents() error {
 
 	go handlePolicyRuleEvents(ag.netPlugin, opts, recvErr)
 
-	if ag.pluginConfig.Instance.PluginMode == "docker" {
+	if ag.pluginConfig.Instance.PluginMode == "docker" ||
+		ag.pluginConfig.Instance.PluginMode == "swarm-mode" {
 		go ag.monitorDockerEvents(recvErr)
 	} else if ag.pluginConfig.Instance.PluginMode == "kubernetes" {
 		// start watching kubernetes events

--- a/netplugin/agent/state_event.go
+++ b/netplugin/agent/state_event.go
@@ -372,7 +372,7 @@ func processReinit(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, newCfg *
 		if serviceInfo.HostAddr != opts.VtepIP {
 			netPlugin.AddPeerHost(core.ServiceInfo{
 				HostAddr: serviceInfo.HostAddr,
-				Port:     4789, //vxlanUDPPort
+				Port:     opts.VxlanUDPPort,
 			})
 		}
 	}

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -65,17 +65,18 @@ func (s *StringSlice) Value() []string {
 // network provisioning interfaces
 
 type cliOpts struct {
-	hostLabel  string
-	pluginMode string // plugin could be docker | kubernetes
-	cfgFile    string
-	debug      bool
-	syslog     string
-	jsonLog    bool
-	ctrlIP     string      // IP address to be used by control protocols
-	vtepIP     string      // IP address to be used by the VTEP
-	vlanIntf   StringSlice // Uplink interface for VLAN switching
-	version    bool
-	dbURL      string // state store URL
+	hostLabel    string
+	pluginMode   string // plugin could be docker | kubernetes
+	cfgFile      string
+	debug        bool
+	syslog       string
+	jsonLog      bool
+	ctrlIP       string      // IP address to be used by control protocols
+	vtepIP       string      // IP address to be used by the VTEP
+	vlanIntf     StringSlice // Uplink interface for VLAN switching
+	version      bool
+	dbURL        string // state store URL
+	vxlanUDPPort int    // Vxlan UDP port, default: 4789
 }
 
 func configureSyslog(syslogParam string) {
@@ -159,6 +160,10 @@ func main() {
 		"cluster-store",
 		"etcd://127.0.0.1:2379",
 		"state store url")
+	flagSet.IntVar(&opts.vxlanUDPPort,
+		"vxlan-port",
+		4789,
+		"VxLAN UDP port number")
 
 	err = flagSet.Parse(os.Args[1:])
 	if err != nil {
@@ -221,12 +226,13 @@ func main() {
 			State:   stateStore,
 		},
 		Instance: core.InstanceInfo{
-			HostLabel:  opts.hostLabel,
-			CtrlIP:     opts.ctrlIP,
-			VtepIP:     opts.vtepIP,
-			UplinkIntf: opts.vlanIntf,
-			DbURL:      opts.dbURL,
-			PluginMode: opts.pluginMode,
+			HostLabel:    opts.hostLabel,
+			CtrlIP:       opts.ctrlIP,
+			VtepIP:       opts.vtepIP,
+			UplinkIntf:   opts.vlanIntf,
+			DbURL:        opts.dbURL,
+			PluginMode:   opts.pluginMode,
+			VxlanUDPPort: opts.vxlanUDPPort,
 		},
 	}
 

--- a/scripts/python/api/tbed.py
+++ b/scripts/python/api/tbed.py
@@ -57,11 +57,15 @@ class Testbed:
     # Start legacy plugin
     def startV2Plugin(self):
         # Start netplugin on all nodes
-        for node in self.nodes:
+        for nidx,node in enumerate(self.nodes):
             print "Creating v2plugin on " + node.hostname
             node.createV2Plugin()
             print "Enabling v2plugin on " + node.hostname
-            node.enableV2Plugin()
+            # first node is the swarm master
+            if nidx == 0:
+                node.enableV2Plugin()
+            else:
+                node.enableV2Plugin("worker")
 
     # Cleanup a testbed once test is done
     def cleanup(self):


### PR DESCRIPTION
Add support for a new mode (docker-compose) in which user explicitly creates a docker network. Without this mode contiv users were required to create a contiv network and contiv implicitly creates a docker network. With this change the following workflows are allowed in swarm-mode.

1. create a docker network and specify the network driver as contiv
docker network create docker-net-1 --subnet 100.0.0.0/24 --gateway 100.0.0.1 -d contiv/v2plugin:0.1 --ipam-driver contiv/v2plugin:0.1

2. create a contiv group with a tag. Then create a docker network with that tag to associate the docker network to the contiv group (epg)
netctl group create -p p1 -tag epglabel contiv-net-1 group1
docker network create docker-net-2 -d contiv/v2plugin:0.1 -o contiv-tag=epglabel --ipam-driver contiv/v2plugin:0.1 --ipam-opt contiv-tag=epglabel --attachable 

3. create a contiv network with a tag and create a docker network with the same tag to associate them
netctl network create contiv-net-2 -s 20.2.2.2/24 -g 20.2.2.20 -tag netlabel
docker network create docker-net-3 -d contiv/v2plugin:0.1 -o contiv-tag=netlabel --ipam-driver contiv/v2plugin:0.1 --ipam-opt contiv-tag=netlabel 
