### PR TITLE
Vagrantfile: disable NetworkManager on CentOS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,8 @@ fi
 chown -R vagrant #{gopath_folder}
 
 if [[ "#{node_os}" != "ubuntu" ]]; then
+    systemctl disable NetworkManager.service
+    systemctl stop NetworkManager.service
     # Remove the unneeded ceph repository if it exists
     echo "Remove the unneeded ceph repository if it exists"
     rm -f /etc/yum.repos.d/ceph.repo


### PR DESCRIPTION
This tiny PR disables NetworkManager. We don't want to have NetworkManager use CPU on the VMs we use to test/develop netplugin. This change helps avoid that issue.