### PR TITLE
process docker events only when lb services exist

### DIFF
--- a/netplugin/agent/agent.go
+++ b/netplugin/agent/agent.go
@@ -194,7 +194,7 @@ func (ag *Agent) monitorDockerEvents(de chan error) {
 	contFilter.Add("type", events.ContainerEventType)
 
 	events, errs := docker.Events(context.Background(), types.EventsOptions{Filters: contFilter})
-	go handleDockerEvents(events, errs)
+	go ag.handleDockerEvents(events, errs)
 }
 
 // HandleEvents handles events


### PR DESCRIPTION
lb services are only interested in docker events
so process it only when lb services exist

Signed-off-by: rchirakk <rchirakk@users.noreply.github.com>