### PR TITLE
Harden and simplify release script logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ test/systemtests/cfg.json
 .vagrant-state
 
 netplugin-version
+
+# release artifacts
+scripts/netContain/*.tgz
+scripts/netContain/*.tar.bz2


### PR DESCRIPTION
- added "set -euo pipefail"
- fixes a bug where rereleasing a version resulted in a foo.tar.bz2.1 download being created and not actually used
- fixes a bug where extracting the netplugin release to "bin" failed silently if it existed and had files in it
- removed explicit call to `docker login`, now the cached login credentials will be used ("contiv" is an organization now)

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>