### PR TITLE
Makefile: abort L3 tests early on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ system-test:start
 l3-test:
 	CONTIV_L3=2 CONTIV_NODES=3 make stop start ssh-build
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -contiv_l3 2
-	CONTIV_L3=2 CONTIV_NODES=3 go test -v -timeout 900m ./test/systemtests -check.v
+	CONTIV_L3=2 CONTIV_NODES=3 go test -v -timeout 900m ./test/systemtests -check.v -check.abort
 	CONTIV_L3=2 CONTIV_NODES=3 make stop
 l3-demo:
 	CONTIV_L3=1 CONTIV_NODES=3 vagrant up


### PR DESCRIPTION
This PR makes one change which wasn't made by https://github.com/contiv/netplugin/pull/668. The L3 tests should also be interrupted when we run into the first failure. This change is identical to the change made to the system tests in #668.