### PR TITLE
Initialize Mesos plugin only in mesos mode

### DIFF
--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -63,10 +63,9 @@ func (s *StringSlice) Value() []string {
 
 // a daemon based on etcd client's Watch interface to trigger plugin's
 // network provisioning interfaces
-
 type cliOpts struct {
 	hostLabel    string
-	pluginMode   string // plugin could be docker | kubernetes
+	pluginMode   string // plugin could be docker | kubernetes | mesos
 	cfgFile      string
 	debug        bool
 	syslog       string
@@ -136,7 +135,7 @@ func main() {
 	flagSet.StringVar(&opts.pluginMode,
 		"plugin-mode",
 		"docker",
-		"plugin mode docker|kubernetes")
+		"plugin mode docker|kubernetes|swarm-mode|mesos")
 	flagSet.StringVar(&opts.cfgFile,
 		"config",
 		"",

--- a/netplugin/plugin/netplugin.go
+++ b/netplugin/plugin/netplugin.go
@@ -52,6 +52,20 @@ type NetPlugin struct {
 
 const defaultPvtSubnet = 0xac130000
 
+// Plugin mode constants
+const (
+	// Docker plugin
+	DockerPlugin = "docker"
+	// Kubernetes plugin
+	K8sPlugin = "kubernetes"
+	// Swarm mode plugin
+	SwarmPlugin = "swarm-mode"
+	// Mesos plugin
+	MesosPlugin = "mesos"
+	// Test plugin
+	TestPlugin = "test"
+)
+
 // Init initializes the NetPlugin instance via the configuration string passed.
 func (p *NetPlugin) Init(pluginConfig Config) error {
 	var err error


### PR DESCRIPTION
Currently, Mesos plugin is getting initialized by default. Create new plugin-mode and initialize Mesos plugin only when --plugin-mode="mesos"