### PR TITLE
Remove skipping tests for older docker versions

### DIFF
--- a/test/systemtests/basic_test.go
+++ b/test/systemtests/basic_test.go
@@ -3,7 +3,6 @@ package systemtests
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"strings"
 	"time"
 
@@ -152,10 +151,6 @@ func (s *systemtestSuite) TestBasicSvcDiscoveryVLAN(c *C) {
 func (s *systemtestSuite) testBasicSvcDiscovery(c *C, encap string) {
 	if !strings.Contains(s.basicInfo.ClusterStore, "etcd") {
 		c.Skip("Skipping test")
-	}
-	// HACK: "--dns" option is broken in docker 1.10.3. skip this test
-	if os.Getenv("CONTIV_DOCKER_VERSION") == "1.10.3" {
-		c.Skip("Skipping dns test docker 1.10.3")
 	}
 
 	if s.fwdMode == "routing" && encap == "vlan" {

--- a/test/systemtests/trigger_test.go
+++ b/test/systemtests/trigger_test.go
@@ -3,7 +3,6 @@ package systemtests
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"strings"
 	"time"
 
@@ -248,8 +247,8 @@ func (s *systemtestSuite) TestTriggerNetpluginDisconnect(c *C) {
 
 func (s *systemtestSuite) TestTriggerNodeReload(c *C) {
 	// can not run this test on docker 1.10 & k8s
-	if os.Getenv("CONTIV_DOCKER_VERSION") == "1.10.3" || s.basicInfo.Scheduler == "k8" {
-		c.Skip("Skipping node reload test on [older docker version | consul | k8s]")
+	if s.basicInfo.Scheduler == "k8" {
+		c.Skip("Skipping node reload test for k8s")
 	}
 
 	network := &client.Network{


### PR DESCRIPTION
## Description of the changes
Removing checks for older docker version as we no longer support it
#### Type of fix: 
Remove archaic checks

Cleaning up test framework to remove checks for older versions of docker

## NOTE
It is good to have these checks if we are going to support older versions of docker
