### PR TITLE
scripts/build.sh: strip unneeded debug symbols

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,5 +30,6 @@ echo $BUILD_VERSION >$VERSION_FILE
 GOGC=1500 go install \
 	-ldflags "-X $PKG_NAME.version=$BUILD_VERSION \
 	-X $PKG_NAME.buildTime=$BUILD_TIME \
-	-X $PKG_NAME.gitCommit=$GIT_COMMIT" \
+	-X $PKG_NAME.gitCommit=$GIT_COMMIT \
+	-s -w" \
 	-v $TO_BUILD


### PR DESCRIPTION
This PR reduces the size of the binaries by removing the unneeded debugging information. This isn't needed for debugging crashes and other failures.
