### PR TITLE
Makefile: use aci-gw:04-12-2017.2.2_1n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,8 @@ host-integ-test: host-cleanup start-aci-gw
 
 start-aci-gw:
 	@echo dev: starting aci gw...
-	docker pull contiv/aci-gw:11-28-2016.1.3_2i
-	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw contiv/aci-gw:11-28-2016.1.3_2i
+	docker pull contiv/aci-gw:04-12-2017.2.2_1n
+	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw contiv/aci-gw:04-12-2017.2.2_1n
 
 host-build-docker-image:
 	./scripts/netContain/build_image.sh


### PR DESCRIPTION
This PR updates the aci-gw image to a newer version which is smaller than the previous version.

TODO:
- [ ] figure out if we should test with multiple versions
- [ ] investigate potential issues
