### PR TITLE
print error if policy doesn't exist 

### DIFF
--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -294,6 +294,10 @@ func listRules(ctx *cli.Context) {
 	errCheck(ctx, err)
 	policy := ctx.Args()[0]
 
+	// check if policy exists
+	_, err = getClient(ctx).PolicyGet(tenant, policy)
+	errCheck(ctx, err)
+
 	rules, err := getClient(ctx).RuleList()
 	errCheck(ctx, err)
 


### PR DESCRIPTION
print error if policy doesn't exist instead of
listing empty rules.