### PR TITLE
Makefile: build binaries before running k8s tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,8 @@ k8s-legacy-test:
 	CONTIV_K8S_LEGACY=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|ACID|TestPolicy|TestTrigger"
 	cd vagrant/k8s && vagrant destroy -f
 k8s-test: k8s-cluster
+	cd vagrant/k8s/ && \
+	vagrant ssh k8master -c 'sudo -i bash -lc "cd /opt/gopath/src/github.com/contiv/netplugin && make run-build"'
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8s' -binpath contiv/bin -install_mode 'kubeadm'
 	CONTIV_K8S_USE_KUBEADM=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|TestPolicy"
 	cd vagrant/k8s && vagrant destroy -f


### PR DESCRIPTION
This PR fixes an issue which breaks the k8s-test target. This issue was discussed with @DivyaVavili and she could've sent the PR as well. Since she's busy with other things right now, I've tested this change and sent the PR.

This is needed to enable the kubernetes tests on the CI.