### PR TITLE
systemtests/hostaccess: remove redundant sleep

### DIFF
--- a/test/systemtests/hostaccess_test.go
+++ b/test/systemtests/hostaccess_test.go
@@ -11,7 +11,6 @@ func (s *systemtestSuite) TestBasicHostAccess(c *C) {
 		c.Skip("Skipping basic host access test for routing mode")
 	}
 
-	time.Sleep(30 * time.Second)
 	global, err := s.cli.GlobalGet("global")
 	c.Assert(err, IsNil)
 	// save the FwdMode


### PR DESCRIPTION
This PR removes one redundant sleep at the beginning of the TestBasicHostAccess test. Based on how the tests come up, this shouldn't be needed.

Let's see what happens on the CI.
