### PR TITLE
Makefile,k8s/Vagrantfile: change the owner again & abort system tests early

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,19 +153,19 @@ k8s-legacy-test:
 	cd vagrant/k8s/ && vagrant ssh k8master -c 'bash -lc "cd /opt/gopath/src/github.com/contiv/netplugin && make run-build"' && \
 	./start_sanity_service.sh
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8s'
-	CONTIV_K8S_LEGACY=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|ACID|TestPolicy|TestTrigger"
+	CONTIV_K8S_LEGACY=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.abort -check.f "00SSH|TestBasic|TestNetwork|ACID|TestPolicy|TestTrigger"
 	cd vagrant/k8s && vagrant destroy -f
 
 k8s-test: k8s-cluster
 	cd vagrant/k8s/ && vagrant ssh k8master -c 'bash -lc "cd /opt/gopath/src/github.com/contiv/netplugin && make run-build"'
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8s' -binpath contiv/bin -install_mode 'kubeadm'
-	CONTIV_K8S_USE_KUBEADM=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|TestPolicy"
+	CONTIV_K8S_USE_KUBEADM=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.abort -check.f "00SSH|TestBasic|TestNetwork|TestPolicy"
 	cd vagrant/k8s && vagrant destroy -f
 
 k8s-l3-test: k8s-l3-cluster
 	cd vagrant/k8s/ && vagrant ssh k8master -c 'bash -lc "cd /opt/gopath/src/github.com/contiv/netplugin && make run-build"'
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8s' -binpath contiv/bin -install_mode 'kubeadm' -contiv_l3=1
-	CONTIV_K8S_USE_KUBEADM=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.f "00SSH|TestBasic|TestNetwork|TestPolicy"
+	CONTIV_K8S_USE_KUBEADM=1 CONTIV_NODES=3 go test -v -timeout 540m ./test/systemtests -check.v -check.abort -check.f "00SSH|TestBasic|TestNetwork|TestPolicy"
 	cd vagrant/k8s && CONTIV_L3=1 vagrant destroy -f
 # ===================================================================
 

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -84,14 +84,10 @@ echo "export no_proxy='k8master,192.168.2.10,192.168.2.11,192.168.2.12,192.168.2
 echo "export no_proxy='k8master,192.168.2.10,192.168.2.11,192.168.2.12,192.168.2.13,netmaster,localhost,127.0.0.1'" >> ~/.profile
 source /etc/profile.d/envvar.sh
 # Change ownership for gopath folder
-sudo chown -R vagrant #{gopath_folder}
-sudo yum install -y net-tools
-sudo yum install -y go
-sudo yum install -y git
+sudo yum install -y net-tools git
 sudo -E bash
 go get github.com/tools/godep
-cd $GOPATH/src/github.com/tools
-go install ./godep
+sudo chown -R vagrant:vagrant #{gopath_folder}
 SCRIPT
 
 # begin execution here


### PR DESCRIPTION
This PR fixes the compilation of the binaries on the Kubernetes CI.

Let's see what happens with the CI run.