### PR TITLE
Makefile: use env var for list of system tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ GOLINT_CMD := golint -set_exit_status
 GOFMT_CMD := gofmt -s -l
 GOVET_CMD := go tool vet
 CI_HOST_TARGETS ?= "host-unit-test host-integ-test host-build-docker-image"
+SYSTEM_TESTS_TO_RUN ?= "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
 
 all: build unit-test system-test ubuntu-tests
 
@@ -224,7 +225,7 @@ ubuntu-tests:
 
 system-test:start
 	cd $(GOPATH)/src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py
-	go test -v -timeout 480m ./test/systemtests -check.v -check.abort -check.f "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
+	go test -v -timeout 480m ./test/systemtests -check.v -check.abort -check.f $(SYSTEM_TESTS_TO_RUN)
 
 l3-test:
 	CONTIV_L3=2 CONTIV_NODES=3 make stop start ssh-build


### PR DESCRIPTION
This PR moves the default list of tests to be run for the system tests to an environment variable. This makes it possible to choose what tests to run using an environment variable.

The tests run exactly as they were being run before:
```
#before
go test -v -timeout 480m ./test/systemtests -check.v -check.abort -check.f "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
#after
go test -v -timeout 480m ./test/systemtests -check.v -check.abort -check.f "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
```