### PR TITLE
Dockerfile: bump Go to 1.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # docker run --net=host <image> -host-label=<label>
 ##
 
-FROM golang:1.7.5
+FROM golang:1.7.6
 
 # Insert your proxy server settings if this build is running behind 
 # a proxy.


### PR DESCRIPTION
This bumps Go to 1.7.6 to use the same version of Go as the Vagrant boxes.
