### PR TITLE
scripts/netContain/scripts/{contivNet.sh,ovsInit.sh}: init OVS before doing anything else and load OVS kernel module before starting OVS services

### DIFF
--- a/scripts/netContain/scripts/contivNet.sh
+++ b/scripts/netContain/scripts/contivNet.sh
@@ -76,6 +76,12 @@ while getopts ":xmp:v:i:c:drl:o:" opt; do
 	esac
 done
 
+if [ $cleanup == false ] && [ $netplugin == true ]; then
+	echo "Initializing OVS"
+	/contiv/scripts/ovsInit.sh
+	echo "Initialized OVS"
+fi
+
 if [ $cleanup == true ] || [ $reinit == true ]; then
 	ovs-vsctl del-br contivVlanBridge || true
 	ovs-vsctl del-br contivVxlanBridge || true
@@ -93,12 +99,6 @@ fi
 if [ $netplugin == false ] && [ $netmaster == false ]; then
 	echo "No netmaster or netplugin options were specified"
 	exit 1
-fi
-
-if [ $netplugin == true ]; then
-	echo "Initializing OVS"
-	/contiv/scripts/ovsInit.sh
-	echo "Initialized OVS"
 fi
 
 mkdir -p /opt/contiv/
@@ -135,7 +135,6 @@ if [ $netmaster == true ]; then
 	done
 elif [ $netplugin == true ]; then
 	echo "Starting netplugin"
-	modprobe openvswitch
 
 	while true; do
 		if [ -f /tmp/restart_netplugin ]; then

--- a/scripts/netContain/scripts/ovsInit.sh
+++ b/scripts/netContain/scripts/ovsInit.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+modprobe openvswitch
+
 mkdir -p /var/run/openvswitch
 
 sleep 2


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>