### PR TITLE
Makefile: allow aci-gw image to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ GOFMT_CMD := gofmt -s -l
 GOVET_CMD := go tool vet
 CI_HOST_TARGETS ?= "host-unit-test host-integ-test host-build-docker-image"
 SYSTEM_TESTS_TO_RUN ?= "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
+ACI_GW_IMAGE ?= "contiv/aci-gw:04-12-2017.2.2_1n"
 
 all: build unit-test system-test ubuntu-tests
 
@@ -262,8 +263,8 @@ host-integ-test: host-cleanup start-aci-gw
 
 start-aci-gw:
 	@echo dev: starting aci gw...
-	docker pull contiv/aci-gw:04-12-2017.2.2_1n
-	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw contiv/aci-gw:04-12-2017.2.2_1n
+	docker pull $(ACI_GW_IMAGE) 
+	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw $(ACI_GW_IMAGE)
 
 host-build-docker-image:
 	./scripts/netContain/build_image.sh


### PR DESCRIPTION
This PR makes the changes discussed in #906. The new environment variable makes it possible to use another aci-gw Docker image for the integration tests. This should make it easy to test with different images.

Please keep in mind the fact that we can't use the latest tag by default because we need to use a certain version on the CI.