### PR TITLE
refactor network driver code and added vpp driver stubs

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -113,7 +113,7 @@ type NetworkDriver interface {
 	Init(instInfo *InstanceInfo) error
 	Deinit()
 	CreateNetwork(id string) error
-	DeleteNetwork(id, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error
+	DeleteNetwork(id, subnet, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error
 	CreateEndpoint(id string) error
 	UpdateEndpointGroup(id string) error
 	DeleteEndpoint(id string) error

--- a/drivers/driverconstants.go
+++ b/drivers/driverconstants.go
@@ -1,0 +1,11 @@
+package drivers
+
+import "github.com/contiv/netplugin/netmaster/mastercfg"
+
+const (
+	// StateOperPath is the path to the operations stored in state.
+	networkOperPathPrefix  = mastercfg.StateOperPath + "nets/"
+	networkOperPath        = networkOperPathPrefix + "%s"
+	endpointOperPathPrefix = mastercfg.StateOperPath + "eps/"
+	endpointOperPath       = endpointOperPathPrefix + "%s"
+)

--- a/drivers/endpointstate.go
+++ b/drivers/endpointstate.go
@@ -23,8 +23,8 @@ import (
 	"github.com/contiv/netplugin/netmaster/mastercfg"
 )
 
-// OvsOperEndpointState is the necessary data used to perform operations on endpoints.
-type OvsOperEndpointState struct {
+// OperEndpointState is the necessary data used to perform operations on endpoints.
+type OperEndpointState struct {
 	core.CommonState
 	NetID       string `json:"netID"`
 	EndpointID  string `json:"endpointID"`
@@ -39,7 +39,7 @@ type OvsOperEndpointState struct {
 }
 
 // Matches matches the fields updated from configuration state
-func (s *OvsOperEndpointState) Matches(c *mastercfg.CfgEndpointState) bool {
+func (s *OperEndpointState) Matches(c *mastercfg.CfgEndpointState) bool {
 	return s.NetID == c.NetID &&
 		s.EndpointID == c.EndpointID &&
 		s.IPAddress == c.IPAddress &&
@@ -50,24 +50,24 @@ func (s *OvsOperEndpointState) Matches(c *mastercfg.CfgEndpointState) bool {
 }
 
 // Write the state.
-func (s *OvsOperEndpointState) Write() error {
+func (s *OperEndpointState) Write() error {
 	key := fmt.Sprintf(endpointOperPath, s.ID)
 	return s.StateDriver.WriteState(key, s, json.Marshal)
 }
 
 // Read the state for a given identifier.
-func (s *OvsOperEndpointState) Read(id string) error {
+func (s *OperEndpointState) Read(id string) error {
 	key := fmt.Sprintf(endpointOperPath, id)
 	return s.StateDriver.ReadState(key, s, json.Unmarshal)
 }
 
 // ReadAll reads all state into separate objects.
-func (s *OvsOperEndpointState) ReadAll() ([]core.State, error) {
+func (s *OperEndpointState) ReadAll() ([]core.State, error) {
 	return s.StateDriver.ReadAllState(endpointOperPathPrefix, s, json.Unmarshal)
 }
 
 // Clear removes the state.
-func (s *OvsOperEndpointState) Clear() error {
+func (s *OperEndpointState) Clear() error {
 	key := fmt.Sprintf(endpointOperPath, s.ID)
 	return s.StateDriver.ClearState(key)
 }

--- a/drivers/endpointstate_test.go
+++ b/drivers/endpointstate_test.go
@@ -86,8 +86,8 @@ func (d *testEpStateDriver) WriteState(key string, value core.State,
 	return d.validateKey(key)
 }
 
-func TestOvsOperEndpointStateRead(t *testing.T) {
-	epOper := &OvsOperEndpointState{}
+func TestOperEndpointStateRead(t *testing.T) {
+	epOper := &OperEndpointState{}
 	epOper.StateDriver = epStateDriver
 
 	err := epOper.Read(testEpID)
@@ -96,8 +96,8 @@ func TestOvsOperEndpointStateRead(t *testing.T) {
 	}
 }
 
-func TestOvsOperEndpointStateWrite(t *testing.T) {
-	epOper := &OvsOperEndpointState{}
+func TestOperEndpointStateWrite(t *testing.T) {
+	epOper := &OperEndpointState{}
 	epOper.StateDriver = epStateDriver
 	epOper.ID = testEpID
 
@@ -107,8 +107,8 @@ func TestOvsOperEndpointStateWrite(t *testing.T) {
 	}
 }
 
-func TestOvsOperEndpointStateClear(t *testing.T) {
-	epOper := &OvsOperEndpointState{}
+func TestOperEndpointStateClear(t *testing.T) {
+	epOper := &OperEndpointState{}
 	epOper.StateDriver = epStateDriver
 	epOper.ID = testEpID
 

--- a/drivers/fakenetepdriver.go
+++ b/drivers/fakenetepdriver.go
@@ -26,7 +26,7 @@ func (d *FakeNetEpDriver) CreateNetwork(id string) error {
 }
 
 // DeleteNetwork is not implemented.
-func (d *FakeNetEpDriver) DeleteNetwork(id, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
+func (d *FakeNetEpDriver) DeleteNetwork(id, subnet, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
 	return core.Errorf("Not implemented")
 }
 

--- a/drivers/ovsd/nodeProxy.go
+++ b/drivers/ovsd/nodeProxy.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package ovsd
 
 import (
 	"fmt"

--- a/drivers/ovsd/nodeProxy_test.go
+++ b/drivers/ovsd/nodeProxy_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package ovsd
 
 import (
 	"fmt"
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/state"
 )
 
 var ipTablesPath string

--- a/drivers/ovsd/ovsSwitch.go
+++ b/drivers/ovsd/ovsSwitch.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package ovsd
 
 import (
 	"errors"
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/drivers"
 	"github.com/contiv/netplugin/netmaster/mastercfg"
 	"github.com/contiv/netplugin/utils/netutils"
 	"github.com/contiv/ofnet"
@@ -482,7 +483,7 @@ func (sw *OvsSwitch) UpdatePort(intfName string, cfgEp *mastercfg.CfgEndpointSta
 }
 
 // DeletePort removes a port from OVS
-func (sw *OvsSwitch) DeletePort(epOper *OvsOperEndpointState, skipVethPair bool) error {
+func (sw *OvsSwitch) DeletePort(epOper *drivers.OperEndpointState, skipVethPair bool) error {
 
 	if epOper.VtepIP != "" {
 		return nil

--- a/drivers/ovsd/ovsconstants.go
+++ b/drivers/ovsd/ovsconstants.go
@@ -1,6 +1,8 @@
-package drivers
+package ovsd
 
-import "github.com/contiv/netplugin/netmaster/mastercfg"
+import (
+	"github.com/contiv/netplugin/netmaster/mastercfg"
+)
 
 const (
 	operCreateBridge oper = iota
@@ -23,10 +25,6 @@ const (
 	hostPvtSubnet   = "172.20.0.0/16"
 
 	// StateOperPath is the path to the operations stored in state.
-	ovsOperPathPrefix      = mastercfg.StateOperPath + "ovs-driver/"
-	ovsOperPath            = ovsOperPathPrefix + "%s"
-	networkOperPathPrefix  = mastercfg.StateOperPath + "nets/"
-	endpointOperPathPrefix = mastercfg.StateOperPath + "eps/"
-	networkOperPath        = networkOperPathPrefix + "%s"
-	endpointOperPath       = endpointOperPathPrefix + "%s"
+	ovsOperPathPrefix = mastercfg.StateOperPath + "ovs-driver/"
+	ovsOperPath       = ovsOperPathPrefix + "%s"
 )

--- a/drivers/ovsd/ovsdbDriver.go
+++ b/drivers/ovsd/ovsdbDriver.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package ovsd
 
 import (
 	"errors"

--- a/drivers/ovsd/ovsdriver.go
+++ b/drivers/ovsd/ovsdriver.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package ovsd
 
 import (
 	"encoding/json"
@@ -26,6 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/drivers"
 	"github.com/contiv/netplugin/netmaster/mastercfg"
 	"github.com/contiv/netplugin/netplugin/nameserver"
 	"github.com/contiv/netplugin/utils/netutils"
@@ -220,7 +221,7 @@ func (d *OvsDriver) Init(info *core.InstanceInfo) error {
 func (d *OvsDriver) DeleteHostAccPort(id string) error {
 	sw, found := d.switchDb["host"]
 	if found {
-		operEp := &OvsOperEndpointState{}
+		operEp := &drivers.OperEndpointState{}
 		operEp.StateDriver = d.oper.StateDriver
 		err := operEp.Read(id)
 		if err != nil {
@@ -293,7 +294,7 @@ func (d *OvsDriver) CreateNetwork(id string) error {
 }
 
 // DeleteNetwork deletes a network by named identifier
-func (d *OvsDriver) DeleteNetwork(id, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
+func (d *OvsDriver) DeleteNetwork(id, subnet, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
 	log.Infof("delete net %s, nwType %s, encap %s, tags: %d/%d", id, nwType, encap, pktTag, extPktTag)
 
 	// Find the switch based on network type
@@ -309,7 +310,7 @@ func (d *OvsDriver) DeleteNetwork(id, nwType, encap string, pktTag, extPktTag in
 		hostName, _ := os.Hostname()
 		epID := id + "-" + hostName
 
-		epOper := OvsOperEndpointState{}
+		epOper := drivers.OperEndpointState{}
 		epOper.StateDriver = d.oper.StateDriver
 		err := epOper.Read(epID)
 		if err == nil {
@@ -386,7 +387,7 @@ func (d *OvsDriver) CreateEndpoint(id string) error {
 	// Skip Veth pair creation for infra nw endpoints
 	skipVethPair := (cfgNw.NwType == "infra")
 
-	operEp := &OvsOperEndpointState{}
+	operEp := &drivers.OperEndpointState{}
 	operEp.StateDriver = d.oper.StateDriver
 	err = operEp.Read(id)
 	if core.ErrIfKeyExists(err) != nil {
@@ -445,7 +446,7 @@ func (d *OvsDriver) CreateEndpoint(id string) error {
 		return err
 	}
 	// Save the oper state
-	operEp = &OvsOperEndpointState{
+	operEp = &drivers.OperEndpointState{
 		NetID:       cfgEp.NetID,
 		EndpointID:  cfgEp.EndpointID,
 		ServiceName: cfgEp.ServiceName,
@@ -517,7 +518,7 @@ func (d *OvsDriver) UpdateEndpointGroup(id string) error {
 
 // DeleteEndpoint deletes an endpoint by named identifier.
 func (d *OvsDriver) DeleteEndpoint(id string) error {
-	epOper := OvsOperEndpointState{}
+	epOper := drivers.OperEndpointState{}
 	epOper.StateDriver = d.oper.StateDriver
 	err := epOper.Read(id)
 	if err != nil {

--- a/drivers/ovsd/ovsdriver_test.go
+++ b/drivers/ovsd/ovsdriver_test.go
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package drivers
+package ovsd
 
 import (
 	"fmt"
@@ -342,7 +342,9 @@ func TestOvsDriverCreateEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("network creation failed. Error: %s", err)
 	}
-	defer func() { driver.DeleteNetwork(testOvsNwID, "", "", testPktTag, testExtPktTag, testGateway, testTenant) }()
+	defer func() {
+		driver.DeleteNetwork(testOvsNwID, "", "", "", testPktTag, testExtPktTag, testGateway, testTenant)
+	}()
 
 	// create endpoint
 	err = driver.CreateEndpoint(id)
@@ -377,7 +379,7 @@ func TestOvsDriverCreateEndpointStateful(t *testing.T) {
 		t.Fatalf("network creation failed. Error: %s", err)
 	}
 	defer func() {
-		driver.DeleteNetwork(testOvsNwIDStateful, "", "", testPktTagStateful, testExtPktTag, testGateway, testTenant)
+		driver.DeleteNetwork(testOvsNwIDStateful, "", "", "", testPktTagStateful, testExtPktTag, testGateway, testTenant)
 	}()
 
 	// Create endpoint
@@ -417,7 +419,9 @@ func TestOvsDriverCreateEndpointStatefulStateMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("network creation failed. Error: %s", err)
 	}
-	defer func() { driver.DeleteNetwork(testOvsNwID, "", "", testPktTag, testExtPktTag, testGateway, testTenant) }()
+	defer func() {
+		driver.DeleteNetwork(testOvsNwID, "", "", "", testPktTag, testExtPktTag, testGateway, testTenant)
+	}()
 
 	// create second network
 	err = driver.CreateNetwork(testOvsNwIDStateful)
@@ -425,7 +429,7 @@ func TestOvsDriverCreateEndpointStatefulStateMismatch(t *testing.T) {
 		t.Fatalf("network creation failed. Error: %s", err)
 	}
 	defer func() {
-		driver.DeleteNetwork(testOvsNwIDStateful, "", "", testPktTagStateful, testExtPktTag, testGateway, testTenant)
+		driver.DeleteNetwork(testOvsNwIDStateful, "", "", "", testPktTagStateful, testExtPktTag, testGateway, testTenant)
 	}()
 
 	// create endpoint
@@ -478,7 +482,9 @@ func TestOvsDriverDeleteEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("network creation failed. Error: %s", err)
 	}
-	defer func() { driver.DeleteNetwork(testOvsNwID, "", "", testPktTag, testExtPktTag, testGateway, testTenant) }()
+	defer func() {
+		driver.DeleteNetwork(testOvsNwID, "", "", "", testPktTag, testExtPktTag, testGateway, testTenant)
+	}()
 
 	// create endpoint
 	err = driver.CreateEndpoint(id)
@@ -561,7 +567,9 @@ func TestOvsDriverVethNameConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("network creation failed. Error: %s", err)
 	}
-	defer func() { driver.DeleteNetwork(testOvsNwID, "", "", testPktTag, testExtPktTag, testGateway, testTenant) }()
+	defer func() {
+		driver.DeleteNetwork(testOvsNwID, "", "", "", testPktTag, testExtPktTag, testGateway, testTenant)
+	}()
 
 	// create endpoint
 	err = driver.CreateEndpoint(createEpID)

--- a/drivers/vppd/vppconstants.go
+++ b/drivers/vppd/vppconstants.go
@@ -1,0 +1,11 @@
+package vppd
+
+import (
+	"github.com/contiv/netplugin/netmaster/mastercfg"
+)
+
+const (
+	// StateOperPath is the path to the operations stored in state.
+	vppOperPathPrefix = mastercfg.StateOperPath + "vpp-driver/"
+	vppOperPath       = vppOperPathPrefix + "%s"
+)

--- a/drivers/vppd/vppdriver.go
+++ b/drivers/vppd/vppdriver.go
@@ -1,0 +1,224 @@
+/***
+Copyright 2017 Cisco Systems Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vppd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/netplugin/core"
+	//vpp "github.com/ligato/vpp-agent"
+)
+
+// VppDriverOperState carries operational state of the VppDriver.
+type VppDriverOperState struct {
+	core.CommonState
+
+	// Add any vppdriver specific state for endpoint/network etc
+}
+
+// Write the state
+func (s *VppDriverOperState) Write() error {
+	key := fmt.Sprintf(vppOperPath, s.ID)
+	return s.StateDriver.WriteState(key, s, json.Marshal)
+}
+
+// Read the state given an ID.
+func (s *VppDriverOperState) Read(id string) error {
+	key := fmt.Sprintf(vppOperPath, id)
+	return s.StateDriver.ReadState(key, s, json.Unmarshal)
+}
+
+// ReadAll reads all the state
+func (s *VppDriverOperState) ReadAll() ([]core.State, error) {
+	return s.StateDriver.ReadAllState(vppOperPathPrefix, s, json.Unmarshal)
+}
+
+// Clear removes the state.
+func (s *VppDriverOperState) Clear() error {
+	key := fmt.Sprintf(vppOperPath, s.ID)
+	return s.StateDriver.ClearState(key)
+}
+
+// VppDriver holds the operational state of vpp driver
+type VppDriver struct {
+	oper    VppDriverOperState // Oper state of the driver
+	localIP string             // Local IP address
+	lock    sync.Mutex         // lock for modifying shared state
+}
+
+// Init is not implemented.
+func (d *VppDriver) Init(info *core.InstanceInfo) error {
+	log.Infof("Initializing vppdriver")
+
+	return nil
+}
+
+// Deinit is not implemented.
+func (d *VppDriver) Deinit() {
+	log.Infof("Cleaning up vppdriver")
+}
+
+// CreateNetwork is not implemented.
+// We get the Tenant/vrf and network/subnet info from contiv in this API
+func (d *VppDriver) CreateNetwork(id string) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DeleteNetwork is not implemented.
+func (d *VppDriver) DeleteNetwork(id, subnet, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// CreateEndpoint is not implemented.
+func (d *VppDriver) CreateEndpoint(id string) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+//UpdateEndpointGroup is not implemented.
+func (d *VppDriver) UpdateEndpointGroup(id string) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DeleteEndpoint is not implemented.
+func (d *VppDriver) DeleteEndpoint(id string) (err error) {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// CreateRemoteEndpoint is not implemented.
+func (d *VppDriver) CreateRemoteEndpoint(id string) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DeleteRemoteEndpoint is not implemented.
+func (d *VppDriver) DeleteRemoteEndpoint(id string) (err error) {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// CreateHostAccPort is not implemented.
+func (d *VppDriver) CreateHostAccPort(id, a string, nw int) (string, error) {
+	log.Infof("Not implemented")
+	return "", nil
+}
+
+// DeleteHostAccPort is not implemented.
+func (d *VppDriver) DeleteHostAccPort(id string) (err error) {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// AddPeerHost is not implemented.
+func (d *VppDriver) AddPeerHost(node core.ServiceInfo) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DeletePeerHost is not implemented.
+func (d *VppDriver) DeletePeerHost(node core.ServiceInfo) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// AddMaster is not implemented
+func (d *VppDriver) AddMaster(node core.ServiceInfo) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DeleteMaster is not implemented
+func (d *VppDriver) DeleteMaster(node core.ServiceInfo) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// AddBgp is not implemented.
+func (d *VppDriver) AddBgp(id string) (err error) {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DeleteBgp is not implemented.
+func (d *VppDriver) DeleteBgp(id string) (err error) {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// AddSvcSpec is not implemented.
+func (d *VppDriver) AddSvcSpec(svcName string, spec *core.ServiceSpec) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DelSvcSpec is not implemented.
+func (d *VppDriver) DelSvcSpec(svcName string, spec *core.ServiceSpec) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// SvcProviderUpdate is not implemented.
+func (d *VppDriver) SvcProviderUpdate(svcName string, providers []string) {
+}
+
+// GetEndpointStats is not implemented
+func (d *VppDriver) GetEndpointStats() ([]byte, error) {
+	log.Infof("Not implemented")
+	return []byte{}, nil
+}
+
+// InspectState is not implemented
+func (d *VppDriver) InspectState() ([]byte, error) {
+	log.Infof("Not implemented")
+	return []byte{}, nil
+}
+
+// InspectBgp is not implemented
+func (d *VppDriver) InspectBgp() ([]byte, error) {
+	log.Infof("Not implemented")
+	return []byte{}, nil
+}
+
+// GlobalConfigUpdate is not implemented
+func (d *VppDriver) GlobalConfigUpdate(inst core.InstanceInfo) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// InspectNameserver is not implemented
+func (d *VppDriver) InspectNameserver() ([]byte, error) {
+	log.Infof("Not implemented")
+	return []byte{}, nil
+}
+
+// AddPolicyRule is not implemented
+func (d *VppDriver) AddPolicyRule(id string) error {
+	log.Infof("Not implemented")
+	return nil
+}
+
+// DelPolicyRule is not implemented
+func (d *VppDriver) DelPolicyRule(id string) error {
+	log.Infof("Not implemented")
+	return nil
+}

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -530,14 +530,14 @@ func discoverDelete(w http.ResponseWriter, r *http.Request) {
 	w.Write(content)
 }
 
-func netdGetEndpoint(epID string) (*drivers.OvsOperEndpointState, error) {
+func netdGetEndpoint(epID string) (*drivers.OperEndpointState, error) {
 	// Get hold of the state driver
 	stateDriver, err := utils.GetStateDriver()
 	if err != nil {
 		return nil, err
 	}
 
-	operEp := &drivers.OvsOperEndpointState{}
+	operEp := &drivers.OperEndpointState{}
 	operEp.StateDriver = stateDriver
 	err = operEp.Read(epID)
 	if err != nil {

--- a/mgmtfn/k8splugin/driver.go
+++ b/mgmtfn/k8splugin/driver.go
@@ -54,14 +54,14 @@ type epAttr struct {
 }
 
 // netdGetEndpoint is a utility that reads the EP oper state
-func netdGetEndpoint(epID string) (*drivers.OvsOperEndpointState, error) {
+func netdGetEndpoint(epID string) (*drivers.OperEndpointState, error) {
 	// Get hold of the state driver
 	stateDriver, err := utils.GetStateDriver()
 	if err != nil {
 		return nil, err
 	}
 
-	operEp := &drivers.OvsOperEndpointState{}
+	operEp := &drivers.OperEndpointState{}
 	operEp.StateDriver = stateDriver
 	err = operEp.Read(epID)
 	if err != nil {

--- a/mgmtfn/k8splugin/kubeClient_test.go
+++ b/mgmtfn/k8splugin/kubeClient_test.go
@@ -93,7 +93,7 @@ func (d *KubeTestNetDrv) CreateNetwork(id string) error {
 }
 
 // DeleteNetwork is not implemented.
-func (d *KubeTestNetDrv) DeleteNetwork(id, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
+func (d *KubeTestNetDrv) DeleteNetwork(id, subnet, nwType, encap string, pktTag, extPktTag int, gateway string, tenant string) error {
 	return nil
 }
 

--- a/mgmtfn/mesosplugin/cnidriver.go
+++ b/mgmtfn/mesosplugin/cnidriver.go
@@ -88,7 +88,7 @@ func parseMesosAgentIPAddr(pidList []byte) (string, error) {
 	return agentIPaddr, fmt.Errorf("failed to find the ip address of mesos agent")
 }
 
-func (cniReq *cniServer) createHostBrIntf(ovsEpDriver *drivers.OvsOperEndpointState) error {
+func (cniReq *cniServer) createHostBrIntf(ovsEpDriver *drivers.OperEndpointState) error {
 
 	hostBrIfName := netutils.GetHostIntfName(ovsEpDriver.PortName)
 
@@ -149,7 +149,7 @@ func (cniReq *cniServer) deleteHostBrIntf() error {
 }
 
 // configure cni namespace
-func (cniReq *cniServer) configureNetNs(ovsEpDriver *drivers.OvsOperEndpointState,
+func (cniReq *cniServer) configureNetNs(ovsEpDriver *drivers.OperEndpointState,
 	mResp *master.CreateEndpointResponse,
 	nwState *mastercfg.CfgNetworkState) error {
 
@@ -230,7 +230,7 @@ func (cniReq *cniServer) unlinkNetNs() error {
 
 func (cniReq *cniServer) createCniEndPoint() error {
 	var err error
-	ovsEpDriver := &drivers.OvsOperEndpointState{}
+	ovsEpDriver := &drivers.OperEndpointState{}
 	ovsEpDriver.StateDriver = stateDriver
 
 	nwState := &mastercfg.CfgNetworkState{}

--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -519,7 +519,7 @@ func (ac *APIController) EndpointGetOper(endpoint *contivModel.EndpointInspect) 
 				endpoint.Oper.ContainerID = ep.ContainerID
 				endpoint.Oper.ContainerName = ep.EPCommonName
 
-				epOper := &drivers.OvsOperEndpointState{}
+				epOper := &drivers.OperEndpointState{}
 				epOper.StateDriver = stateDriver
 				err := epOper.Read(ep.NetID + "-" + ep.EndpointID)
 				if err == nil {

--- a/netplugin/agent/agent.go
+++ b/netplugin/agent/agent.go
@@ -71,7 +71,7 @@ func NewAgent(pluginConfig *plugin.Config) *Agent {
 	case "test":
 		// nothing to do. internal mode for testing
 	default:
-		log.Fatalf("Unknown plugin mode -- should be docker | kubernetes")
+		log.Fatalf("Unknown plugin mode -- should be docker | swarm-mode | kubernetes")
 	}
 	// init mesos plugin
 	mesosplugin.InitPlugin(netPlugin)

--- a/netplugin/agent/state_event.go
+++ b/netplugin/agent/state_event.go
@@ -214,7 +214,7 @@ func processNetEvent(netPlugin *plugin.NetPlugin, nwCfg *mastercfg.CfgNetworkSta
 	}
 	operStr := ""
 	if isDelete {
-		err = netPlugin.DeleteNetwork(nwCfg.ID, nwCfg.NwType, nwCfg.PktTagType, nwCfg.PktTag, nwCfg.ExtPktTag,
+		err = netPlugin.DeleteNetwork(nwCfg.ID, route, nwCfg.NwType, nwCfg.PktTagType, nwCfg.PktTag, nwCfg.ExtPktTag,
 			nwCfg.Gateway, nwCfg.Tenant)
 		operStr = "delete"
 		if err == nil && gwIP != "" {

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -76,6 +76,7 @@ type cliOpts struct {
 	vlanIntf     StringSlice // Uplink interface for VLAN switching
 	version      bool
 	dbURL        string // state store URL
+	nwDriver     string // network driver implementation (ovs/vpp)
 	vxlanUDPPort int    // Vxlan UDP port, default: 4789
 }
 
@@ -160,6 +161,10 @@ func main() {
 		"cluster-store",
 		"etcd://127.0.0.1:2379",
 		"state store url")
+	flagSet.StringVar(&opts.nwDriver,
+		"net-driver",
+		"ovs",
+		"network driver component ovs|vpp (vpp is not supported yet)")
 	flagSet.IntVar(&opts.vxlanUDPPort,
 		"vxlan-port",
 		4789,
@@ -211,6 +216,9 @@ func main() {
 	if opts.vtepIP == "" {
 		opts.vtepIP = opts.ctrlIP
 	}
+	if opts.nwDriver == "" {
+		opts.nwDriver = "ovs"
+	}
 
 	// parse store URL
 	parts := strings.Split(opts.dbURL, "://")
@@ -222,7 +230,7 @@ func main() {
 	// initialize the config
 	pluginConfig := plugin.Config{
 		Drivers: plugin.Drivers{
-			Network: "ovs",
+			Network: opts.nwDriver,
 			State:   stateStore,
 		},
 		Instance: core.InstanceInfo{

--- a/netplugin/plugin/netplugin.go
+++ b/netplugin/plugin/netplugin.go
@@ -117,10 +117,10 @@ func (p *NetPlugin) CreateNetwork(id string) error {
 }
 
 // DeleteNetwork deletes a network provided by the ID.
-func (p *NetPlugin) DeleteNetwork(id, nwType, encap string, pktTag, extPktTag int, Gw string, tenant string) error {
+func (p *NetPlugin) DeleteNetwork(id, subnet, nwType, encap string, pktTag, extPktTag int, Gw string, tenant string) error {
 	p.Lock()
 	defer p.Unlock()
-	return p.NetworkDriver.DeleteNetwork(id, nwType, encap, pktTag, extPktTag, Gw, tenant)
+	return p.NetworkDriver.DeleteNetwork(id, subnet, nwType, encap, pktTag, extPktTag, Gw, tenant)
 }
 
 // FetchNetwork retrieves a network's state given an ID.

--- a/state/cfgtool/cfgtool.go
+++ b/state/cfgtool/cfgtool.go
@@ -193,7 +193,7 @@ func processState(stateDriver core.StateDriver, stateName, stateID, fieldName, s
 	typeRegistry[reflect.TypeOf(resources.AutoVXLANCfgResource{}).Name()] = &resources.AutoVXLANCfgResource{}
 	typeRegistry[reflect.TypeOf(resources.AutoVXLANOperResource{}).Name()] = &resources.AutoVXLANOperResource{}
 	typeRegistry[reflect.TypeOf(drivers.OvsDriverOperState{}).Name()] = &drivers.OvsDriverOperState{}
-	typeRegistry[reflect.TypeOf(drivers.OvsOperEndpointState{}).Name()] = &drivers.OvsOperEndpointState{}
+	typeRegistry[reflect.TypeOf(drivers.OperEndpointState{}).Name()] = &drivers.OperEndpointState{}
 	typeRegistry[reflect.TypeOf(docknet.DnetOperState{}).Name()] = &docknet.DnetOperState{}
 
 	// find the type by name

--- a/utils/driverfactory.go
+++ b/utils/driverfactory.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/drivers"
+	"github.com/contiv/netplugin/drivers/ovsd"
+	"github.com/contiv/netplugin/drivers/vppd"
 	"github.com/contiv/netplugin/state"
 )
 
@@ -18,8 +20,12 @@ type driverConfigTypes struct {
 
 var networkDriverRegistry = map[string]driverConfigTypes{
 	OvsNameStr: {
-		DriverType: reflect.TypeOf(drivers.OvsDriver{}),
-		ConfigType: reflect.TypeOf(drivers.OvsDriver{}),
+		DriverType: reflect.TypeOf(ovsd.OvsDriver{}),
+		ConfigType: reflect.TypeOf(ovsd.OvsDriver{}),
+	},
+	VppNameStr: {
+		DriverType: reflect.TypeOf(vppd.VppDriver{}),
+		ConfigType: reflect.TypeOf(vppd.VppDriver{}),
 	},
 	// fakedriver is used for tests, so not exposing a public name for it.
 	"fakedriver": {
@@ -51,6 +57,8 @@ const (
 	ConsulNameStr = "consul"
 	// OvsNameStr is a string constant for ovs driver
 	OvsNameStr = "ovs"
+	// VppNameStr is a string constant for vpp driver
+	VppNameStr = "vpp"
 )
 
 var (


### PR DESCRIPTION
## Description of the changes
new directory structure for network drivers:
    contiv/netplugin/drivers : common code for all drivers 
    contiv/netplugin/drivers/ovsd/ : OVS driver for contiv
    contiv/netplugin/drivers/vppd/ : VPP driver for contiv 
    
new cli option to choose the network driver:
    netplugin -cluster-store etcd://localhost:2379 -net-driver vpp

VppDriver stub methods in contiv/netplugin/drivers/vppd/

## TODO
- [ ] Vpp team (@brecode) to add vpp-agent calls in the VppDriver stubs 
