### PR TITLE
**/Vagrantfile: use linked clones in Vagrant 1.8 or >

### DIFF
--- a/vagrant/mesos-cni/Vagrantfile
+++ b/vagrant/mesos-cni/Vagrantfile
@@ -104,7 +104,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.box = "contiv/mesos-ubuntu1504"
     end
     config.vm.provider 'virtualbox' do |v|
-        v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+        v.linked_clone = true if Vagrant::VERSION >= "1.8"
     end
 
     num_nodes = 2

--- a/vagrant/mesos-docker/Vagrantfile
+++ b/vagrant/mesos-docker/Vagrantfile
@@ -93,6 +93,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "contiv/centos71-netplugin"
     config.vm.box_version = "0.3.1"
 
+    config.vm.provider 'virtualbox' do |v|
+      v.linked_clone = true if Vagrant::VERSION >= "1.8"
+    end
+
     num_nodes = 2
     if ENV['CONTIV_NODES'] && ENV['CONTIV_NODES'] != "" then
         num_nodes = ENV['CONTIV_NODES'].to_i

--- a/vagrant/nomad-docker/Vagrantfile
+++ b/vagrant/nomad-docker/Vagrantfile
@@ -101,7 +101,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	    config.vm.box = "contiv/centos71-netplugin"
     end
     config.vm.provider 'virtualbox' do |v|
-        v.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+        v.linked_clone = true if Vagrant::VERSION >= "1.8"
     end
 
     num_nodes = 2


### PR DESCRIPTION
Just to be clear, the current code only enables this feature for 1.8.x ... people running 1.9.x wouldn't have it enabled.  This PR turns it on for 1.8+

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>