### PR TITLE
Deferred cleanup of resources when a node crashes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -635,23 +635,23 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "b44a11b0bcffa08b3a7546e76fa2709457396867"
+			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ofctrl",
-			"Rev": "b44a11b0bcffa08b3a7546e76fa2709457396867"
+			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ovsdbDriver",
-			"Rev": "b44a11b0bcffa08b3a7546e76fa2709457396867"
+			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/pqueue",
-			"Rev": "b44a11b0bcffa08b3a7546e76fa2709457396867"
+			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/rpcHub",
-			"Rev": "b44a11b0bcffa08b3a7546e76fa2709457396867"
+			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
 		},
 		{
 			"ImportPath": "github.com/contiv/remotessh",

--- a/netmaster/master/api.go
+++ b/netmaster/master/api.go
@@ -379,7 +379,7 @@ func DeleteEndpointHandler(w http.ResponseWriter, r *http.Request, vars map[stri
 
 	log.Infof("Received DeleteEndpointRequest: %+v", epdelReq)
 
-	// Gte the state driver
+	// Get the state driver
 	stateDriver, err := utils.GetStateDriver()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description of the changes
#### Type of fix: Enhancement
#### Fixes #845 
Changes in the PR include:
- DeleteEndpoints API which takes in a hostname of the node crashed and cleans up the etcd endpoint cfg and oper state and calls ofnet API to clean up the flows of these endpoints on all other hosts in the cluster
- Vendoring in ofnet changes of ClearNode which clears up flow state of all endpoints in the host

#### TODO
- [ ] Cleanup ovs-driver oper state of the node (required exposing new APIs to netmaster. ovs-drive is currently accessed only by netplugin on the host)
- [ ] Test cases
- [ ] Have an option to configure the timer for starting cleanup of resources
