### PR TITLE
Provide a way to reclaim stale endpoints

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -635,23 +635,23 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet",
-			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
+			"Rev": "c73438ea8ef0dcf4b94a8904f3f3808132703eb6"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ofctrl",
-			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
+			"Rev": "c73438ea8ef0dcf4b94a8904f3f3808132703eb6"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/ovsdbDriver",
-			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
+			"Rev": "c73438ea8ef0dcf4b94a8904f3f3808132703eb6"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/pqueue",
-			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
+			"Rev": "c73438ea8ef0dcf4b94a8904f3f3808132703eb6"
 		},
 		{
 			"ImportPath": "github.com/contiv/ofnet/rpcHub",
-			"Rev": "369938dc3d203fc4d35760bc96556441c467a7cc"
+			"Rev": "c73438ea8ef0dcf4b94a8904f3f3808132703eb6"
 		},
 		{
 			"ImportPath": "github.com/contiv/remotessh",

--- a/drivers/ovsd/ovsdriver.go
+++ b/drivers/ovsd/ovsdriver.go
@@ -553,6 +553,10 @@ func (d *OvsDriver) DeleteEndpoint(id string) error {
 	d.oper.localEpInfoMutex.Lock()
 	delete(d.oper.LocalEpInfo, id)
 	d.oper.localEpInfoMutex.Unlock()
+	err = d.oper.Write()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -781,7 +781,7 @@ func inspectEndpointGroup(ctx *cli.Context) {
 
 func deleteEndpointGroup(ctx *cli.Context) {
 	if len(ctx.Args()) != 1 {
-		errExit(ctx, exitHelp, "Endpoint name required", true)
+		errExit(ctx, exitHelp, "EndpointGroup name required", true)
 	}
 
 	tenant := ctx.String("tenant")

--- a/netmaster/daemon/daemon.go
+++ b/netmaster/daemon/daemon.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/netmaster/intent"
 	"github.com/contiv/netplugin/netmaster/master"
 	"github.com/contiv/netplugin/netmaster/mastercfg"
 	"github.com/contiv/netplugin/netmaster/objApi"
@@ -205,6 +206,52 @@ func (d *MasterDaemon) startDeferredCleanup(host ofnet.OfnetNode, hostName strin
 	}
 }
 
+// getPluginAddress gets the adrress of the netplugin agent given the host name
+func (d *MasterDaemon) getPluginAddress(hostName string) (string, error) {
+	srvList, err := d.objdbClient.GetService("netplugin.vtep")
+	if err != nil {
+		log.Errorf("Error getting netplugin nodes. Err: %v", err)
+		return "", err
+	}
+
+	for _, srv := range srvList {
+		if srv.Hostname == hostName {
+			return srv.HostAddr, nil
+		}
+	}
+
+	return "", fmt.Errorf("Could not find plugin instance with name: %s", hostName)
+}
+
+// ClearEndpoints clears all the endpoints
+func (d *MasterDaemon) ClearEndpoints(stateDriver core.StateDriver, epCfgs *[]core.State, id, matchField string) error {
+	for _, epCfg := range *epCfgs {
+		ep := epCfg.(*mastercfg.CfgEndpointState)
+		if (matchField == "net" && ep.NetID == id) ||
+			(matchField == "group" && ep.ServiceName == id) ||
+			(matchField == "ep" && strings.Contains(ep.EndpointID, id)) {
+			// Delete the endpoint state from netmaster
+			_, err := master.DeleteEndpointID(stateDriver, ep.ID)
+			if err != nil {
+				return fmt.Errorf("Cannot cleanup EP: %s. Err: %+v", ep.EndpointID, err)
+			}
+
+			pluginAddress, err := d.getPluginAddress(ep.HomingHost)
+			if err != nil {
+				return err
+			}
+
+			epDelURL := "http://" + pluginAddress + ":9090/debug/reclaimEndpoint/" + ep.ID
+			err = utils.HTTPDel(epDelURL)
+			if err != nil {
+				return fmt.Errorf("Error sending HTTP delete request to %s. Err: %+v", pluginAddress, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 // registerRoutes registers HTTP route handlers
 func (d *MasterDaemon) registerRoutes(router *mux.Router) {
 	// Add REST routes
@@ -258,6 +305,98 @@ func (d *MasterDaemon) registerRoutes(router *mux.Router) {
 		w.Write(ofnetMasterState)
 	})
 
+	s = router.Methods("Delete").Subrouter()
+	s.HandleFunc("/debug/epcleanup/tenant/{tenant}/{category}/{id}", func(w http.ResponseWriter, r *http.Request) {
+		errStr := ""
+		var epCfgs []core.State
+
+		vars := mux.Vars(r)
+		tenantName := vars["tenant"]
+		category := vars["category"]
+		id := vars["id"]
+
+		// Get the state driver
+		stateDriver, err := utils.GetStateDriver()
+		if err != nil {
+			log.Errorf("error getting state drive. Error: %+v", err)
+			return
+		}
+
+		switch category {
+		case "net":
+			errStr = fmt.Sprintf("Received request to cleanup Network with ID: %s", id)
+			nwKey := mastercfg.GetNwCfgKey(id, tenantName)
+			nwCfg := &mastercfg.CfgNetworkState{}
+			nwCfg.StateDriver = stateDriver
+			err = nwCfg.Read(nwKey)
+			if err != nil {
+				log.Errorf("error reading network: %s. Error: %s", nwKey, err)
+				return
+			}
+
+			if nwCfg.EpCount == 0 {
+				return
+			}
+			readEp := &mastercfg.CfgEndpointState{}
+			readEp.StateDriver = stateDriver
+			epCfgs, err = readEp.ReadAll()
+			if err != nil {
+				log.Errorf("Could not read eps for network: %s. Err: %v", id, err)
+				return
+			}
+
+			id = id + "." + tenantName
+		case "group":
+			errStr = fmt.Sprintf("Received request to cleanup EPG with ID: %s", id)
+
+			epgKey := mastercfg.GetEndpointGroupKey(id, tenantName)
+			epgCfg := &mastercfg.EndpointGroupState{}
+			epgCfg.StateDriver = stateDriver
+			err = epgCfg.Read(epgKey)
+			if err != nil {
+				log.Errorf("error reading EPG: %s. Error: %s", epgKey, err)
+				return
+			}
+
+			if epgCfg.EpCount == 0 {
+				return
+			}
+			readEp := &mastercfg.CfgEndpointState{}
+			readEp.StateDriver = stateDriver
+			epCfgs, err = readEp.ReadAll()
+			if err != nil {
+				log.Errorf("Could not read eps for group: %s. Err: %v", id, err)
+				return
+			}
+		case "ep":
+			errStr = fmt.Sprintf("Received request to cleanup Endpoint with ID: %s", id)
+			readEp := &mastercfg.CfgEndpointState{}
+			readEp.StateDriver = stateDriver
+			epCfgs, err = readEp.ReadAll()
+			if err != nil {
+				log.Errorf("Could not read eps for group: %s. Err: %v", id, err)
+				return
+			}
+		default:
+			errStr = fmt.Sprintf("Unknown category error")
+			return
+		}
+		err = d.ClearEndpoints(stateDriver, &epCfgs, id, category)
+		if err != nil {
+			log.Errorf("Error during ClearEndpoints. Err: %+v", err)
+			return
+		}
+		http.Error(w, errStr, http.StatusOK)
+		return
+	})
+}
+
+func getEpName(networkName string, ep *intent.ConfigEP) string {
+	if ep.Container != "" {
+		return networkName + "-" + ep.Container
+	}
+
+	return ep.Host + "-native-intf"
 }
 
 // runLeader runs leader loop

--- a/netplugin/cluster/cluster.go
+++ b/netplugin/cluster/cluster.go
@@ -273,7 +273,7 @@ func peerDiscoveryLoop(netplugin *plugin.NetPlugin, objClient objdb.API, ctrlIP,
 					Port:     netplugin.PluginConfig.Instance.VxlanUDPPort,
 				})
 				if err != nil {
-					log.Errorf("Error adding node {%+v}. Err: %v", nodeInfo, err)
+					log.Errorf("Error deleting node {%+v}. Err: %v", nodeInfo, err)
 				}
 			}
 		case srvEvent := <-masterEventCh:

--- a/netplugin/cluster/cluster.go
+++ b/netplugin/cluster/cluster.go
@@ -206,6 +206,7 @@ func registerService(objClient objdb.API, ctrlIP, vtepIP, hostname string, vxlan
 		TTL:         10,
 		HostAddr:    vtepIP,
 		Port:        vxlanUDPPort,
+		Hostname:    hostname,
 	}
 
 	// Register the node with service registry

--- a/utils/httputils.go
+++ b/utils/httputils.go
@@ -79,7 +79,7 @@ func writeJSON(w http.ResponseWriter, code int, v interface{}) error {
 
 // UnknownAction is a catchall handler for additional driver functions
 func UnknownAction(w http.ResponseWriter, r *http.Request) {
-	log.Infof("Unknown networkdriver action at %q", r.URL.Path)
+	log.Infof("Unknown action at %q", r.URL.Path)
 	content, _ := ioutil.ReadAll(r.Body)
 	log.Infof("Body content: %s", string(content))
 	http.NotFound(w, r)

--- a/vendor/github.com/contiv/ofnet/ofnetBgp.go
+++ b/vendor/github.com/contiv/ofnet/ofnetBgp.go
@@ -155,7 +155,7 @@ func (self *OfnetBgp) StartProtoServer(routerInfo *OfnetProtoRouterInfo) error {
 
 	intf, _ := net.InterfaceByName(self.intfName)
 	vrf := "default"
-	epid := self.agent.getEndpointIdByIpVrf(net.ParseIP(self.routerIP), vrf)
+	epid := self.agent.GetEndpointIdByIpVrf(net.ParseIP(self.routerIP), vrf)
 	default_vlan := uint16(1)
 	_, ok := self.agent.createVrf(vrf)
 	if !ok {
@@ -309,7 +309,7 @@ func (self *OfnetBgp) AddProtoNeighbor(neighborInfo *OfnetProtoNeighborInfo) err
 		return err
 	}
 
-	epid := self.agent.getEndpointIdByIpVrf(net.ParseIP(neighborInfo.NeighborIP), "default")
+	epid := self.agent.GetEndpointIdByIpVrf(net.ParseIP(neighborInfo.NeighborIP), "default")
 	epreg := &OfnetEndpoint{
 		EndpointID: epid,
 		IpAddr:     net.ParseIP(neighborInfo.NeighborIP),
@@ -492,7 +492,7 @@ func (self *OfnetBgp) modRib(path *table.Path) error {
 	endpointIPNet, _ := netlink.ParseIPNet(nlri.String())
 	log.Infof("Bgp Rib Received endpoint update for path %s", path.String())
 
-	nhEpid := self.agent.getEndpointIdByIpVrf(net.ParseIP(nextHop), "default")
+	nhEpid := self.agent.GetEndpointIdByIpVrf(net.ParseIP(nextHop), "default")
 
 	if ep := self.agent.getEndpointByID(nhEpid); ep == nil {
 		//the nexthop is not the directly connected eBgp peer
@@ -504,7 +504,7 @@ func (self *OfnetBgp) modRib(path *table.Path) error {
 	}
 
 	//check if bgp published a route local to the host
-	epid := self.agent.getEndpointIdByIpVrf(endpointIPNet.IP.Mask(endpointIPNet.Mask), "default")
+	epid := self.agent.GetEndpointIdByIpVrf(endpointIPNet.IP.Mask(endpointIPNet.Mask), "default")
 	var epreg *OfnetEndpoint
 	//Check if the route is local
 


### PR DESCRIPTION
## Description of the changes
#### Type of fix: Enhancement

This PR includes the following changes:
- Add **/debug/reclaimEndpoint** REST endpoint in netplugin that clears up endpoint state store state, ovs state and ofnet flows on all hosts in the cluster
- Add **/debug/epcleanup/tenant/\<tenantName\>/\<category\>/\<id\>** REST endpoint in netmaster to cleanup the endpoints in the category
**NOTE:** \<category\> can take three values - _net/group/ep_
<id> depends on the category. net category takes network name as id and clears up all endpoints within the network and recursively in all EPGs in the network, group category takes group name as id and clears up all endpoints in the group and ep category takes endpointID as id and clears the single endpoint
-  Misc changes: 
-- Fix an issue where deleting an endpoint does not update the ovs-driver oper state in state store
-- Minor typos
-- Fix missing hostname in netplugin.vtep state

#### Testing done:
- Test netplugin REST endpoint and verify that the port is deleted in OVS, the endpoint states in state store (cfg and oper states) and clear up all the flows in the ofnet on all hosts in a cluster. 
- Test netmaster REST endpoints for network/group/endpoint and verify all states (mentioned above) are cleared up

#### TODO
- [ ] Add system test-cases
- [ ] provide documentation to expose this along with disclaimer