### PR TITLE
Makefile,scripts/release.sh: change release script to match release process for other repos (auth_proxy, install)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,6 @@ NAME := netplugin
 VERSION_FILE := $(NAME)-version
 VERSION := `cat $(VERSION_FILE)`
 TAR_EXT := tar.bz2
-TAR_FILENAME := $(NAME)-$(VERSION).$(TAR_EXT)
-TAR_LOC := .
-TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 GO_MIN_VERSION := 1.7
 GO_MAX_VERSION := 1.8
 GO_VERSION := $(shell go version | cut -d' ' -f3 | sed 's/go//')
@@ -321,20 +318,7 @@ host-plugin-release:
 	@echo dev: (need docker login with user in contiv org)
 	docker plugin push ${CONTIV_V2PLUGIN_NAME}
 
-only-tar:
-
-tar: clean-tar
-	CONTIV_NODES=1 ${MAKE} build
-	@tar -jcf $(TAR_FILE) -C $(GOPATH)/src/github.com/contiv/netplugin/bin netplugin netmaster netctl contivk8s netcontiv -C $(GOPATH)/src/github.com/contiv/netplugin/scripts contrib/completion/bash/netctl -C $(GOPATH)/src/github.com/contiv/netplugin/scripts get-contiv-diags
-
-clean-tar:
-	@rm -f $(TAR_LOC)/*.$(TAR_EXT)
-	@rm -f ${VERSION_FILE}
-
 # GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release
-release: tar
-	TAR_FILENAME=$(TAR_FILENAME) TAR_FILE=$(TAR_FILE) VERSION=$(VERSION) \
+release:
 	OLD_VERSION=${OLD_VERSION} BUILD_VERSION=${BUILD_VERSION} \
 	USE_RELEASE=${USE_RELEASE} scripts/release.sh
-	@make clean-tar
-

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,36 +1,33 @@
 #!/bin/bash
+# Assumes following variables to be defined:
+#  OLD_VERSION - previous version against which to create changelog
+#  BUILD_VERSION - new version being released
+#  GITHUB_USER - contiv
+#  GITHUB_TOKEN - your github token
+#  USE_RELEASE - if 0 or not set, will make a pre-release
 
-set -euo pipefail
-
-if [ -z "${VERSION-}" ]; then
-	echo "VERSION needs to be defined to make a release"
+if [ -z "$(which github-release)" ]; then
+	echo "Please install github-release before running this script"
+	echo "You may download a release from https://github.com/aktau/github-release/releases or run 'go get github.com/aktau/github-release' if you have Go installed"
 	exit 1
 fi
 
-if [ -z "${TAR_FILENAME-}" ]; then
-	echo "TAR_FILENAME needs to be defined to make a release"
+if [ -z "$BUILD_VERSION" ]; then
+	echo "A release requires BUILD_VERSION to be defined"
 	exit 1
 fi
 
-if [ ! -f "$TAR_FILE" ]; then
-	echo "TAR_FILE ($TAR_FILE) doesn't exist"
+if [ -z "$OLD_VERSION" ]; then
+	echo "A release requires OLD_VERSION to be defined"
 	exit 1
 fi
 
-if [ -n "$USE_RELEASE" ]; then
-	if [ -z "$OLD_VERSION" ]; then
-		echo "A release requires OLD_VERSION to be defined"
-		exit 1
-	fi
-	if [ "$OLD_VERSION" != "none" ]; then
-		comparison="$OLD_VERSION..HEAD"
-	fi
-	pre_release=""
-else
-	latest_tag=$(git tag | egrep -v "^v" | grep UTC | sort -V | tail -1)
+if [ "$OLD_VERSION" != "none" ]; then
+	comparison="$OLD_VERSION..HEAD"
+fi
 
-	comparison="$latest_tag..HEAD"
-	echo "Making a pre-release..."
+if [ "$USE_RELEASE" != "1" ]; then
+	echo "Making a pre-release.."
 	pre_release="-p"
 fi
 
@@ -46,6 +43,4 @@ else
 fi
 
 set -x
-( (github-release -v release $pre_release -r netplugin -t $VERSION -d "**Changelog**<br/>$changelog") \
-	&& (github-release -v upload -r netplugin -t $VERSION -n $TAR_FILENAME -f $TAR_FILE \
-		|| github-release -v delete -r netplugin -t $VERSION)) || exit 1
+( (github-release -v release $pre_release -r netplugin -t $BUILD_VERSION -d "**Changelog**<br/>$changelog")) || exit 1


### PR DESCRIPTION
Specifically, removed code for generating and uploading tarballs to Github and replaced it with a tag-based release system.

Changes to the Contiv release process necessitated the alignment of the USE_RELEASE variable in scripts/release.sh with the other projects' release.sh files.

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

**Note**: these changes only affect the **Netplugin_Release** job on the CI.