### PR TITLE
Fix IPv6 docker issue

### DIFF
--- a/drivers/ovsd/ovsdbDriver.go
+++ b/drivers/ovsd/ovsdbDriver.go
@@ -839,12 +839,13 @@ func (d *OvsdbDriver) GetOfpPortNo(intfName string) (uint32, error) {
 
 		if err == nil && len(row) > 0 && len(row[0].Rows) > 0 {
 			value := row[0].Rows[0]["ofport"]
-			if value != -1 && reflect.TypeOf(value).Kind() == reflect.Float64 {
+			if reflect.TypeOf(value).Kind() == reflect.Float64 {
 				//retry few more time. Due to asynchronous call between
 				//port creation and populating ovsdb entry for the interface
 				//may not be populated instantly.
-				ofpPort := uint32(reflect.ValueOf(value).Float())
-				return ofpPort, nil
+				if ofpPort := reflect.ValueOf(value).Float(); ofpPort != -1 {
+					return uint32(ofpPort), nil
+				}
 			}
 		}
 		time.Sleep(300 * time.Millisecond)

--- a/netmaster/docknet/docknet.go
+++ b/netmaster/docknet/docknet.go
@@ -182,6 +182,7 @@ func CreateDockNet(tenantName, networkName, serviceName string, nwCfg *mastercfg
 			IPAM:           &ipamCfg,
 			Options:        netPluginOptions,
 			Attachable:     true,
+			EnableIPv6:     (subnetCIDRv6 != ""),
 		}
 
 		log.Infof("Creating docker network: %+v", nwCreate)


### PR DESCRIPTION
Branching https://github.com/contiv/netplugin/pull/950 PR into 2

Docker containers were not getting IPv6 assigned due to a missing field in the response. So, this enables IPv6 on docker when the underlying network supports IPv6.

Signed-off-by: Yuva Shankar <yuva29@users.noreply.github.com>