### PR TITLE
fix bash syntax error on make host-plugin-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ host-plugin-release:
 	sh scripts/v2plugin_rootfs.sh 
 	docker plugin create ${CONTIV_V2PLUGIN_NAME} install/v2plugin
 	@echo dev: pushing ${CONTIV_V2PLUGIN_NAME} to docker hub 
-	@echo dev: (need docker login with user in contiv org)
+	@echo dev: need docker login with user in contiv org
 	docker plugin push ${CONTIV_V2PLUGIN_NAME}
 
 # GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release


### PR DESCRIPTION
Signed-off-by: Jizhong Jiang <jiangjizhong@gmail.com>

## Description of the changes
#### Type of fix: Bug Fix
#### Fixes 

```
# make host-plugin-release
...
/bin/bash: -c: line 0: syntax error near unexpected token `('
/bin/bash: -c: line 0: `echo dev: (need docker login with user in contiv org)'
Makefile:315: recipe for target 'host-plugin-release' failed
...
```

Please describe:
- changes made in the Pull request

    Escape parenthesis in make file at line 319

- type of testing done (both manual and automated)


