### PR TITLE
fix flag parse issue

### DIFF
--- a/install/v2plugin/startcontiv.sh
+++ b/install/v2plugin/startcontiv.sh
@@ -59,8 +59,8 @@ set +e
 
 echo "Starting Netplugin " >> $BOOTUP_LOGFILE
 while true ; do
-    echo "/netplugin $dbg_flag -plugin-mode $plugin_mode $vxlan_port_cfg -vlan-if $iflist -cluster-store $cluster_store $ctrl_ip_cfg $vtep_ip_cfg" >> $BOOTUP_LOGFILE
-    /netplugin $dbg_flag -plugin-mode $plugin_mode $vxlan_port_cfg -vlan-if $iflist -cluster-store $cluster_store $ctrl_ip_cfg $vtep_ip_cfg &> $log_dir/netplugin.log
+    echo "/netplugin $dbg_flag -plugin-mode=$plugin_mode $vxlan_port_cfg -vlan-if=$iflist -cluster-store=$cluster_store $ctrl_ip_cfg $vtep_ip_cfg" >> $BOOTUP_LOGFILE
+    /netplugin $dbg_flag -plugin-mode=$plugin_mode $vxlan_port_cfg -vlan-if=$iflist -cluster-store=$cluster_store $ctrl_ip_cfg $vtep_ip_cfg &> $log_dir/netplugin.log
     echo "CRITICAL : Net Plugin has exited, Respawn in 5" >> $BOOTUP_LOGFILE
     mv $log_dir/netplugin.log $log_dir/netplugin.log.lastrun
     sleep 5


### PR DESCRIPTION
separate flag name and flag value with equal sign instand of space.

Signed-off-by: Jizhong Jiang <jiangjizhong@gmail.com>

## Description of the changes

#### Type of fix: Bug Fix

#### Fixes 
Please describe:
- Separate flag name and flag value with equal sign instand of space in install/v2plugin/startcontiv.sh

The flag name and value was separated by space, if the value is empty, go flag set the value with the next flag name.

for example: 
```
/netplugin $dbg_flag -plugin-mode=$plugin_mode $vxlan_port_cfg -vlan-if=$iflist -cluster-store=$cluster_store $ctrl_ip_cfg $vtep_ip_cfg
```
if iflist is empty, the value of -vlan-if is "-cluster-store"
