### PR TITLE
refactor v2plugin Dockerfile & the main netplugin image Dockerfile

### DIFF
--- a/install/v2plugin/Dockerfile
+++ b/install/v2plugin/Dockerfile
@@ -1,14 +1,26 @@
+##
+#Copyright 2017 Cisco Systems Inc. All rights reserved.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+##
+
 # Docker v2plugin container with OVS / netplugin / netmaster
 
-FROM alpine:3.5
+FROM alpine:3.6
 LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
 
-RUN mkdir -p /run/docker/plugins /etc/openvswitch /var/run/contiv/log \
+RUN mkdir -p /run/docker/plugins /etc/openvswitch /var/log/contiv \
  && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
- && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl \
- && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/sgerrand.rsa.pub \
- && wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk \
- && apk --no-cache add glibc-2.23-r1.apk
+ && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl bash
 
 COPY netplugin netmaster netctl startcontiv.sh /
 

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -19,8 +19,8 @@ import (
 	"log/syslog"
 	"net/url"
 	"os"
-	"os/user"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/contiv/netplugin/core"
@@ -181,8 +181,8 @@ func main() {
 	}
 
 	// Make sure we are running as root
-	usr, err := user.Current()
-	if (err != nil) || (usr.Username != "root") {
+	uid := syscall.Getuid()
+	if uid != 0 {
 		log.Fatalf("This process can only be run as root")
 	}
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,10 +26,10 @@ else
 fi
 
 echo $BUILD_VERSION >$VERSION_FILE
-
-GOGC=1500 go install \
+GOGC=1500 CGO_ENABLED=0 go install \
+	-a -installsuffix cgo \
 	-ldflags "-X $PKG_NAME.version=$BUILD_VERSION \
 	-X $PKG_NAME.buildTime=$BUILD_TIME \
 	-X $PKG_NAME.gitCommit=$GIT_COMMIT \
-	-s -w" \
+	-s -w -d" -pkgdir /tmp/foo-cgo \
 	-v $TO_BUILD

--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -13,19 +13,18 @@
 #limitations under the License.
 ##
 
-# One Container for OVS / netplugin / netmaster 
+# One Container for OVS / netplugin / netmaster
 
-FROM ubuntu:16.04
+FROM alpine:3.6
+LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
 
-# Make sure to Modify the Proxy Server values if required 
+# Make sure to Modify the Proxy Server values if required
 # ENV export http_proxy=http://proxy.localhost.com:8080
 # ENV export https_proxy=https://proxy.localhost.com:8080
 
-RUN apt-get update \
- && apt-get install -y openvswitch-switch=2.5.2-0ubuntu0.16.04.1 \
-        net-tools \
-        iptables \
- && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/openvswitch \
+ && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
+ && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl bash
 
 COPY ./bin /contiv/bin/
 COPY ./scripts /contiv/scripts/


### PR DESCRIPTION
This PR makes the following changes:
1. Migrates the main netplugin container from the Ubuntu base to alpine Linux. This should provide a more vendor independent base to make it more compatible with Ubuntu, CentOS and other distributions.

Fixes:
This addresses issues with running the container on CentOS 7.4 and later. The ubuntu image can't load kernel modules via insmod/modprobe when the kernel modules are compressed. This change was made in CentOS 7.4. This is issue #978

Advantages:
The size of the resulting image is ~100 MB. The previous image had a size of 300 MB. This decreases the requires storage and speeds up the download.

2. Refactors the v2plugin Dockerfile to make the image more like the main netplugin image. This removes the hacks which required glibc.

Fixes:
The third party untrusted binary package isn't needed any more.

Advantages:
The image is smaller, less likely to break in the future.

3. Refactors the code and the build.sh script to be able to produce static binaries. This enables us to not rely on the host's glibc any more. This allows us to remove the dependency on glibc.

Helps fix https://github.com/contiv/install/issues/248