### PR TITLE
Fixed a golint error in test file

### DIFF
--- a/test/systemtests/aci_util_test.go
+++ b/test/systemtests/aci_util_test.go
@@ -64,11 +64,7 @@ func aciHTTPGet(url string, jin, jout interface{}) error {
 		return err
 	}
 
-	if err := json.Unmarshal(response, jout); err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(response, jout)
 }
 
 // GetEPFromAPIC checks learning


### PR DESCRIPTION
#### Fixes the following golint error after https://github.com/contiv/netplugin/pull/787
```
+++ golint core drivers mgmtfn netctl netmaster netplugin state test utils version
test/systemtests/aci_util_test.go:67:2: redundant if ...; err != nil check, just return error instead.
Found 1 lint suggestions; failing.
make: *** [golint-src] Error 1
Connection to 127.0.0.1 closed.
make: *** [ssh-build] Error 2
```
