### PR TITLE
v2plugin: add checks for delete network/epg

### DIFF
--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -400,7 +400,7 @@ func allocateNetwork(w http.ResponseWriter, r *http.Request) {
 	// node where a container in the network is instantiated.
 	// We process only allocateNetwork in this case.
 	//
-	if pluginMode == "swarm-mode" {
+	if pluginMode == master.SwarmMode {
 		tag := ""
 		log.Infof("Options: %+v", anreq.Options)
 		if _, tagOk := anreq.Options["contiv-tag"]; tagOk {
@@ -442,7 +442,7 @@ func freeNetwork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if pluginMode == "swarm-mode" {
+	if pluginMode == master.SwarmMode {
 		err = deleteNetworkHelper(req.NetworkID)
 		if err != nil {
 			httpError(w, "Could not delete network", err)
@@ -572,7 +572,7 @@ func GetDockerNetworkName(nwID string) (string, string, string, error) {
 	if err == nil {
 		return dnetOper.TenantName, dnetOper.NetworkName, dnetOper.ServiceName, nil
 	}
-	if pluginMode == "swarm-mode" {
+	if pluginMode == master.SwarmMode {
 		log.Errorf("Unable to find docknet info in objstore")
 		return "", "", "", err
 	}

--- a/netmaster/docknet/docknet.go
+++ b/netmaster/docknet/docknet.go
@@ -287,6 +287,30 @@ func DeleteDockNetState(tenantName, networkName, serviceName string) error {
 	return dnetOper.Clear()
 }
 
+// GetDocknetState gets the docknet entry from state store
+func GetDocknetState(tenantName, networkName, serviceName string) (*DnetOperState, error) {
+	log.Infof("GetDocknetState for %s.%s.%s", tenantName, networkName, serviceName)
+
+	// Get the state driver
+	stateDriver, err := utils.GetStateDriver()
+	if err != nil {
+		log.Warnf("Couldn't get state driver for docknet %v", err)
+		return nil, err
+	}
+
+	// save docknet oper state
+	dnetOper := DnetOperState{}
+	dnetOper.ID = fmt.Sprintf("%s.%s.%s", tenantName, networkName, serviceName)
+	dnetOper.StateDriver = stateDriver
+
+	// Read the dnet oper state
+	err = dnetOper.Read(dnetOper.ID)
+	if err == nil {
+		return &dnetOper, nil
+	}
+	return nil, err
+}
+
 // FindDocknetByUUID find the docknet by UUID
 func FindDocknetByUUID(dnetID string) (*DnetOperState, error) {
 	log.Infof("find docker network '%s' ", dnetID)

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -26,6 +26,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/netplugin/netmaster/daemon"
 	"github.com/contiv/netplugin/netmaster/docknet"
+	"github.com/contiv/netplugin/netmaster/master"
 	"github.com/contiv/netplugin/version"
 )
 
@@ -153,7 +154,7 @@ func execOpts(opts *cliOpts) {
 	}
 	log.Infof("Control IP:Port %s:%s", controlIP, controlURL[1])
 
-	if opts.clusterMode == "docker" || opts.clusterMode == "swarm-mode" {
+	if opts.clusterMode == master.Docker || opts.clusterMode == master.SwarmMode {
 		docknet.UpdatePluginName(opts.pluginName)
 	}
 }

--- a/netmaster/master/api.go
+++ b/netmaster/master/api.go
@@ -191,7 +191,7 @@ func AllocAddressHandler(w http.ResponseWriter, r *http.Request, vars map[string
 	}
 
 	if networkID == "" {
-		if GetClusterMode() == "swarm-mode" {
+		if GetClusterMode() == SwarmMode {
 			// If the network was created using docker command,
 			// we get allocReq before the network is created. Here,
 			// we return the first IP in the subnet as gateway IP.

--- a/netmaster/master/endpointGroup.go
+++ b/netmaster/master/endpointGroup.go
@@ -100,7 +100,7 @@ func CreateEndpointGroup(tenantName, networkName, groupName, ipPool, cfgdTag str
 	}
 
 	// params for docker network
-	if GetClusterMode() == "docker" {
+	if GetClusterMode() == Docker {
 		// Create each EPG as a docker network
 		err = docknet.CreateDockNet(tenantName, networkName, groupName, nwCfg)
 		if err != nil {
@@ -249,7 +249,7 @@ func DeleteEndpointGroup(tenantName, groupName string) error {
 		return err
 	}
 
-	if GetClusterMode() == "docker" {
+	if GetClusterMode() == Docker {
 		return docknet.DeleteDockNet(epgCfg.TenantName, epgCfg.NetworkName, epgCfg.GroupName)
 	}
 	return nil

--- a/netmaster/master/netmaster.go
+++ b/netmaster/master/netmaster.go
@@ -33,6 +33,14 @@ const (
 	defaultInfraNetName = "infra"
 )
 
+// Plugin modes
+const (
+	Docker     = "docker"
+	Kubernetes = "kubernetes"
+	SwarmMode  = "swarm-mode"
+	Test       = "test"
+)
+
 // Run Time config of netmaster
 type nmRunTimeConf struct {
 	clusterMode string
@@ -43,13 +51,14 @@ var masterRTCfg nmRunTimeConf
 // SetClusterMode sets the cluster mode for the contiv plugin
 func SetClusterMode(cm string) error {
 	switch cm {
-	case "docker":
-	case "kubernetes":
-	case "swarm-mode":
-	case "test": // internal mode used for integration testing
+	case Docker:
+	case Kubernetes:
+	case SwarmMode:
+	case Test: // internal mode used for integration testing
 		break
 	default:
-		return core.Errorf("%s not a valid cluster mode {docker | kubernetes | swarm-mode}", cm)
+		return core.Errorf("%s not a valid cluster mode {%s | %s | %s}",
+			cm, Docker, Kubernetes, SwarmMode)
 	}
 
 	masterRTCfg.clusterMode = cm

--- a/netmaster/master/network.go
+++ b/netmaster/master/network.go
@@ -190,7 +190,7 @@ func CreateNetwork(network intent.ConfigNetwork, stateDriver core.StateDriver, t
 		return nil
 	}
 
-	if GetClusterMode() == "docker" {
+	if GetClusterMode() == Docker {
 		// Create the network in docker
 		err = docknet.CreateDockNet(tenantName, network.Name, "", nwCfg)
 		if err != nil {
@@ -264,7 +264,7 @@ func DeleteNetworkID(stateDriver core.StateDriver, netID string) error {
 			return core.Errorf("Error: Network has active endpoints")
 		}
 
-		if GetClusterMode() == "docker" && aci == false {
+		if GetClusterMode() == Docker && aci == false {
 			// Delete the docker network
 			err = docknet.DeleteDockNet(nwCfg.Tenant, nwCfg.NetworkName, "")
 			if err != nil {

--- a/netmaster/objApi/objapi_test.go
+++ b/netmaster/objApi/objapi_test.go
@@ -2333,21 +2333,30 @@ func TestEPCreate(t *testing.T) {
 // TestClusterMode verifies cluster mode is correctly reflected.
 func TestClusterMode(t *testing.T) {
 
-	master.SetClusterMode("kubernetes")
+	master.SetClusterMode(master.Kubernetes)
 	insp, err := contivClient.GlobalInspect("global")
 	if err != nil {
 		t.Fatalf("Error inspecting global %v", err)
 	}
-	if insp.Oper.ClusterMode != "kubernetes" {
+	if insp.Oper.ClusterMode != master.Kubernetes {
 		t.Fatalf("Error expected kubernetes, got %s", insp.Oper.ClusterMode)
 	}
 
-	master.SetClusterMode("docker")
+	master.SetClusterMode(master.Docker)
 	insp, err = contivClient.GlobalInspect("global")
 	if err != nil {
 		t.Fatalf("Error inspecting global %v", err)
 	}
-	if insp.Oper.ClusterMode != "docker" {
+	if insp.Oper.ClusterMode != master.Docker {
+		t.Fatalf("Error expected docker, got %s", insp.Oper.ClusterMode)
+	}
+
+	master.SetClusterMode(master.SwarmMode)
+	insp, err = contivClient.GlobalInspect("global")
+	if err != nil {
+		t.Fatalf("Error inspecting global %v", err)
+	}
+	if insp.Oper.ClusterMode != master.SwarmMode {
 		t.Fatalf("Error expected docker, got %s", insp.Oper.ClusterMode)
 	}
 }

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -66,7 +66,7 @@ func (s *StringSlice) Value() []string {
 
 type cliOpts struct {
 	hostLabel    string
-	pluginMode   string // plugin could be docker | kubernetes
+	pluginMode   string // plugin could be docker | kubernetes | swarm-mode
 	cfgFile      string
 	debug        bool
 	syslog       string
@@ -137,7 +137,7 @@ func main() {
 	flagSet.StringVar(&opts.pluginMode,
 		"plugin-mode",
 		"docker",
-		"plugin mode docker|kubernetes")
+		"plugin mode docker|kubernetes|swarm-mode")
 	flagSet.StringVar(&opts.cfgFile,
 		"config",
 		"",


### PR DESCRIPTION
In swarm-mode, add check for mapped docker network
when deleting netctl network or epg.

Fixes https://github.com/contiv/netplugin/issues/962

