### PR TITLE
netContain/Dockerfile: symlink /var/run to /run

### DIFF
--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -24,7 +24,10 @@ LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
 
 RUN mkdir -p /etc/openvswitch \
  && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
- && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl bash
+ && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl bash \
+ && mv /var/run/* /run/ \
+ && rmdir /var/run \
+ && ln -s /run /var/run
 
 COPY ./bin /contiv/bin/
 COPY ./scripts /contiv/scripts/


### PR DESCRIPTION
This PR converts /var/run to symlink to /run. /var/run is a symlink to /run on the ubuntu image. The recent migration of this netplugin Docker image to the alpine base image has broken this assumption. The side effect of having /run and /var/run as independent directories is that contivk8s can't find its UNIX socket.

This PR solves the issue.