### PR TITLE
remove USE_RELEASE & remove release timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ checks: go-version gofmt-src golint-src govet-src misspell-src
 
 run-build: deps checks clean
 	cd $(GOPATH)/src/github.com/contiv/netplugin && \
-	USE_RELEASE=${USE_RELEASE} BUILD_VERSION=${BUILD_VERSION} \
+	NIGHTLY_RELEASE=${NIGHTLY_RELEASE} BUILD_VERSION=${BUILD_VERSION} \
 	TO_BUILD="${TO_BUILD}" VERSION_FILE=${VERSION_FILE} \
 	scripts/build.sh
 
@@ -335,5 +335,5 @@ clean-tar:
 release: tar
 	TAR_FILENAME=$(TAR_FILENAME) TAR_FILE=$(TAR_FILE) \
 	OLD_VERSION=${OLD_VERSION} BUILD_VERSION=${BUILD_VERSION} \
-	USE_RELEASE=${USE_RELEASE} scripts/release.sh
+	NIGHTLY_RELEASE=${NIGHTLY_RELEASE} scripts/release.sh
 	@make clean-tar

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,10 +13,13 @@ The GITHUB_USER and GITHUB_TOKEN environment variables need to be set up.
 Automated releases are done using the scripts/REL.sh script. This script
 will prepare and release binaries to GitHub.
 
-The timestamp is appended to the release version.
+The timestamp is appended to the release version if NIGHTLY_RELEASE=1 is
+passed as an environment variable on build.
 
 An example of a such release tag is "1.0.0-beta-01-31-2017.21-11-13.UTC".
 
+Releases are marked as pre-releases by default. The pre-release needs to
+be marked by hand as a release.
 
 ### Manual releases
 
@@ -26,11 +29,11 @@ need to be provided manually.
 You'll find a few examples below:
 
 	# version/CURRENT_VERSION is 1.0.1
-	$ USE_RELEASE=1 OLD_VERSION=1.0 make release
+	$ OLD_VERSION=1.0 make release
 	# will release version 1.0.1 on GitHub
 
 	# version/CURRENT_VERSION is 1.0
-	$ USE_RELEASE=1 OLD_VERSION=none make release
+	$ OLD_VERSION=none make release
 	# will release version 1.0 when no previous stable release exists
 
 Please keep in mind that the release notes can be updated on GitHub manually.
@@ -67,13 +70,13 @@ related to BUILD_VERSION and version/CURRENT_VERSION above.
 5. Make the release to GitHub.
 	```
 	# BUILD_VERSION is used to override version/CURRENT_VERSION
-	USE_RELEASE=1 OLD_VERSION=1.1.0-beta.1 BUILD_VERSION=1.1.0-beta.2 make release
+	OLD_VERSION=1.1.0-beta.1 BUILD_VERSION=1.1.0-beta.2 make release
 	```
 
 	```
 	# version/CURRENT_VERSION is used for a new stable release
 	# version/CURRENT_VERSION is 1.1.1
-	USE_RELEASE=1 OLD_VERSION=1.1.0 make release
+	OLD_VERSION=1.1.0 make release
 	```
 
 ## Build and upload container image (manual only)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ build_version = ENV['BUILD_VERSION'] || ''
 cluster_ip_nodes = ''
 v2plugin_name = ENV['CONTIV_V2PLUGIN_NAME'] || 'contiv/v2netplugin:0.1'
 cluster_store = ENV['CONTIV_CLUSTER_STORE'] || 'etcd://localhost:2379'
-use_release = ENV['USE_RELEASE'] || ''
+nightly_release = ENV['NIGHTLY_RELEASE'] || ''
 node_os = ENV['CONTIV_NODE_OS'] || 'centos'
 base_ip = ENV['CONTIV_IP_PREFIX'] || '192.168.2.'
 num_nodes = ENV['CONTIV_NODES'].to_i == 0 ? 3 : ENV['CONTIV_NODES'].to_i
@@ -41,7 +41,7 @@ export GOSRC=\\\$GOPATH/src
 export PATH=\\\$PATH:/usr/local/go/bin:\\\$GOBIN
 export http_proxy='#{http_proxy}'
 export https_proxy='#{https_proxy}'
-export USE_RELEASE=#{use_release}
+export NIGHTLY_RELEASE=#{nightly_release}
 export no_proxy=%{cluster_ip_nodes},127.0.0.1,localhost,netmaster
 export CLUSTER_NODE_IPS=%{cluster_ip_nodes}
 export CONTIV_CLUSTER_STORE=#{cluster_store}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,10 +9,10 @@ if [ -n "$BUILD_VERSION" ]; then
 	VERSION=$BUILD_VERSION
 fi
 
-if [ -z "$USE_RELEASE" ]; then
-	BUILD_VERSION="$VERSION-$BUILD_TIME"
-else
+if [ -z "$NIGHTLY_RELEASE" ]; then
 	BUILD_VERSION="$VERSION"
+else
+	BUILD_VERSION="$VERSION-$BUILD_TIME"
 fi
 
 if command -v git &>/dev/null && git rev-parse &>/dev/null; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,6 @@
 #  BUILD_VERSION - new version being released
 #  GITHUB_USER - contiv
 #  GITHUB_TOKEN - your github token
-#  USE_RELEASE - if 0 or not set, will make a pre-release
 
 if [ -z "$(which github-release)" ]; then
 	echo "Please install github-release before running this script"
@@ -37,11 +36,6 @@ if [ "$OLD_VERSION" != "none" ]; then
 	comparison="$OLD_VERSION..HEAD"
 fi
 
-if [ "$USE_RELEASE" != "1" ]; then
-	echo "Making a pre-release.."
-	pre_release="-p"
-fi
-
 if [ "$OLD_VERSION" != "none" ]; then
 	changelog=$(git log $comparison --oneline --no-merges --reverse)
 
@@ -54,6 +48,6 @@ else
 fi
 
 set -x
-( (github-release -v release $pre_release -r netplugin -t $BUILD_VERSION -d "**Changelog**<br/>$changelog") \
+( (github-release -v release --pre-release -r netplugin -t $BUILD_VERSION -d "**Changelog**<br/>$changelog") \
 	&& (github-release -v upload -r netplugin -t $BUILD_VERSION -n $TAR_FILENAME -f $TAR_FILE \
 		|| github-release -v delete -r netplugin -t $BUILD_VERSION)) || exit 1

--- a/vagrant/mesos-cni/Vagrantfile
+++ b/vagrant/mesos-cni/Vagrantfile
@@ -22,7 +22,7 @@ echo 'export GOSRC=$GOPATH/src' >> /etc/profile.d/envvar.sh
 echo 'export PATH=$PATH:/usr/local/go/bin:$GOBIN' >> /etc/profile.d/envvar.sh
 echo "export http_proxy='$4'" >> /etc/profile.d/envvar.sh
 echo "export https_proxy='$5'" >> /etc/profile.d/envvar.sh
-echo "export USE_RELEASE=$6" >> /etc/profile.d/envvar.sh
+echo "export NIGHTLY_RELEASE=$6" >> /etc/profile.d/envvar.sh
 echo "export no_proxy=$3,127.0.0.1,localhost,netmaster" >> /etc/profile.d/envvar.sh
 echo "export CLUSTER_NODE_IPS=$3" >> /etc/profile.d/envvar.sh
 echo "export CONTIV_CLUSTER_STORE=$7" >> /etc/profile.d/envvar.sh
@@ -166,7 +166,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             end
             node.vm.provision "shell" do |s|
                 s.inline = provision_common_once
-                s.args = [node_name, node_addr, cluster_ip_nodes, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["USE_RELEASE"] || "", ENV["CONTIV_CLUSTER_STORE"] || "etcd://localhost:2379", ENV["CONTIV_DOCKER_VERSION"] || "", ENV['CONTIV_NODE_OS'] || "", *ENV['CONTIV_ENV']]
+                s.args = [node_name, node_addr, cluster_ip_nodes, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["NIGHTLY_RELEASE"] || "", ENV["CONTIV_CLUSTER_STORE"] || "etcd://localhost:2379", ENV["CONTIV_DOCKER_VERSION"] || "", ENV['CONTIV_NODE_OS'] || "", *ENV['CONTIV_ENV']]
             end
             node.vm.provision "shell", run: "always" do |s|
                 s.inline = provision_common_always

--- a/vagrant/mesos-docker/Vagrantfile
+++ b/vagrant/mesos-docker/Vagrantfile
@@ -53,7 +53,7 @@ echo "export http_proxy='$4'" >> /etc/profile.d/envvar.sh
 echo "export https_proxy='$5'" >> /etc/profile.d/envvar.sh
 echo "export no_proxy=192.168.2.10,192.168.2.11,127.0.0.1,localhost,netmaster" >> /etc/profile.d/envvar.sh
 echo "export CLUSTER_NODE_IPS=192.168.2.10,192.168.2.11" >> /etc/profile.d/envvar.sh
-echo "export USE_RELEASE=$6" >> /etc/profile.d/envvar.sh
+echo "export NIGHTLY_RELEASE=$6" >> /etc/profile.d/envvar.sh
 
 
 source /etc/profile.d/envvar.sh
@@ -153,7 +153,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             end
             node.vm.provision "shell" do |s|
                 s.inline = provision_common
-                s.args = [node_name, ENV["CONTIV_NODE_OS"] || "", node_addr, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["USE_RELEASE"] || "", *ENV['CONTIV_ENV']]
+                s.args = [node_name, ENV["CONTIV_NODE_OS"] || "", node_addr, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["NIGHTLY_RELEASE"] || "", *ENV['CONTIV_ENV']]
             end
 provision_node = <<SCRIPT
 ## start etcd with generated config

--- a/vagrant/nomad-docker/Vagrantfile
+++ b/vagrant/nomad-docker/Vagrantfile
@@ -22,7 +22,7 @@ echo 'export GOSRC=$GOPATH/src' >> /etc/profile.d/envvar.sh
 echo 'export PATH=$PATH:/usr/local/go/bin:$GOBIN' >> /etc/profile.d/envvar.sh
 echo "export http_proxy='$4'" >> /etc/profile.d/envvar.sh
 echo "export https_proxy='$5'" >> /etc/profile.d/envvar.sh
-echo "export USE_RELEASE=$6" >> /etc/profile.d/envvar.sh
+echo "export NIGHTLY_RELEASE=$6" >> /etc/profile.d/envvar.sh
 echo "export no_proxy=$3,127.0.0.1,localhost,netmaster" >> /etc/profile.d/envvar.sh
 echo "export CLUSTER_NODE_IPS=$3" >> /etc/profile.d/envvar.sh
 echo "export CONTIV_CLUSTER_STORE=$7" >> /etc/profile.d/envvar.sh
@@ -167,7 +167,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             end
             node.vm.provision "shell" do |s|
                 s.inline = provision_common_once
-                s.args = [node_name, node_addr, cluster_ip_nodes, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["USE_RELEASE"] || "", ENV["CONTIV_CLUSTER_STORE"] || "etcd://localhost:2379", ENV["CONTIV_DOCKER_VERSION"] || "", ENV['CONTIV_NODE_OS'] || "", *ENV['CONTIV_ENV']]
+                s.args = [node_name, node_addr, cluster_ip_nodes, ENV["http_proxy"] || "", ENV["https_proxy"] || "", ENV["NIGHTLY_RELEASE"] || "", ENV["CONTIV_CLUSTER_STORE"] || "etcd://localhost:2379", ENV["CONTIV_DOCKER_VERSION"] || "", ENV['CONTIV_NODE_OS'] || "", *ENV['CONTIV_ENV']]
             end
             node.vm.provision "shell", run: "always" do |s|
                 s.inline = provision_common_always


### PR DESCRIPTION
This PR changes the USE_RELEASE logic to make it NIGHTLY_RELEASE. NIGHTLY_RELEASE can be used to make a release which has a timestamp appended to the version. Regular releases must not have this appended to the version.