### PR TITLE
Add .dockerignore for faster docker build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# we want to get the git commit SHA but not all the binary repo data
+.git/objects/pack
+bin/
+vagrant/
+docs/
+scripts/gobgp
+*.tar
+*.bz2


### PR DESCRIPTION
On OSX, the entire directory structure, including artifacts, are copied
into the docker machine every docker build.

This eliminates copying some large artifacts, git binary data, etc. to
save a few seconds each build attempt.