### PR TITLE
'make tar' to use docker compiled assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 ##
 
 ##
-# Container image for netplugin
+# Container image for compiled netplugin binaries
 #
 # Run netplugin:
 # docker run --net=host <image> -host-label=<label>
@@ -22,7 +22,7 @@
 
 FROM golang:1.7.6
 
-# Insert your proxy server settings if this build is running behind 
+# Insert your proxy server settings if this build is running behind
 # a proxy.
 #ENV http_proxy ""
 #ENV https_proxy ""


### PR DESCRIPTION
`make tar` is primarily used for release, it is much faster to use compile-with-docker locally than spawn a VM to run the build.

Signed-off-by: Chris Plock <chrisplo@cisco.com>