### PR TITLE
Build checks in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # we want to get the git commit SHA but not all the binary repo data
 .git/objects/pack
 bin/
+.vagrant
 vagrant/
 docs/
 scripts/gobgp
@@ -8,3 +9,4 @@ scripts/gobgp
 *.bz2
 # export from a docker container, no need to copy into any docker containers
 install/v2plugin/rootfs
+vagrant/k8s/export/netctl

--- a/Dockerfile-check
+++ b/Dockerfile-check
@@ -1,0 +1,10 @@
+FROM golang:1.7.6
+
+ENV GOPATH=/go
+
+WORKDIR /go/src/github.com/contiv/netplugin/
+
+RUN go get github.com/golang/lint/golint \
+           github.com/client9/misspell/cmd/misspell
+
+CMD ["make", "checks"]

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 GO_MIN_VERSION := 1.7
 GO_MAX_VERSION := 1.8
 GO_VERSION := $(shell go version | cut -d' ' -f3 | sed 's/go//')
-GOLINT_CMD := golint -set_exit_status
-GOFMT_CMD := gofmt -s -l
-GOVET_CMD := go tool vet
 CI_HOST_TARGETS ?= "host-unit-test host-integ-test host-build-docker-image"
 SYSTEM_TESTS_TO_RUN ?= "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
 K8S_SYSTEM_TESTS_TO_RUN ?= "00SSH|Basic|Network|Policy"
@@ -63,19 +60,20 @@ godep-restore:
 
 gofmt-src:
 	$(info +++ gofmt $(PKG_DIRS))
-	@for dir in $(PKG_DIRS); do $(GOFMT_CMD) $${dir} | grep "go"; [[ $$? -ne 0 ]] || exit 1; done
+	@[[ -z "$$(gofmt -s -d $(PKG_DIRS) | tee /dev/stderr)" ]] || exit 1
 
+# go lint does not automatically recurse
 golint-src:
 	$(info +++ golint $(PKG_DIRS))
-	@for dir in $(PKG_DIRS); do $(GOLINT_CMD) $${dir}/... || exit 1;done
+	@for dir in $(PKG_DIRS); do golint -set_exit_status $${dir}/...; done
 
 govet-src:
 	$(info +++ govet $(PKG_DIRS))
-	@for dir in $(PKG_DIRS); do $(GOVET_CMD) $${dir} || exit 1;done
+	@go tool vet $(PKG_DIRS)
 
 misspell-src:
 	$(info +++ check spelling $(PKG_DIRS))
-	misspell -locale US -error $(PKG_DIRS)
+	@misspell -locale US -error $(PKG_DIRS)
 
 go-version:
 	$(info +++ check go version)
@@ -86,7 +84,12 @@ ifneq ($(GO_VERSION), $(firstword $(sort $(GO_VERSION) $(GO_MAX_VERSION))))
 	$(error go version check failed, expected <= $(GO_MAX_VERSION), found $(GO_VERSION))
 endif
 
-checks: go-version gofmt-src golint-src govet-src misspell-src
+checks: go-version govet-src golint-src gofmt-src misspell-src
+
+# When multi-stage builds are available in VM, source can be copied into
+# container FROM the netplugin-build container to simplify this target
+checks-with-docker:
+	scripts/code_checks_in_docker.sh $(PKG_DIRS)
 
 compile:
 	cd $(GOPATH)/src/github.com/contiv/netplugin && \
@@ -263,7 +266,7 @@ host-integ-test: host-cleanup start-aci-gw
 
 start-aci-gw:
 	@echo dev: starting aci gw...
-	docker pull $(ACI_GW_IMAGE) 
+	docker pull $(ACI_GW_IMAGE)
 	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw $(ACI_GW_IMAGE)
 
 host-build-docker-image:
@@ -307,11 +310,11 @@ demo-v2plugin:
 	vagrant ssh netplugin-node1 -c 'bash -lc "source /etc/profile.d/envvar.sh && cd /opt/gopath/src/github.com/contiv/netplugin && make host-pluginfs-create host-plugin-restart host-swarm-restart"'
 
 # release a v2 plugin
-host-plugin-release: 
+host-plugin-release:
 	@echo dev: creating a docker v2plugin ...
-	sh scripts/v2plugin_rootfs.sh 
+	sh scripts/v2plugin_rootfs.sh
 	docker plugin create ${CONTIV_V2PLUGIN_NAME} install/v2plugin
-	@echo dev: pushing ${CONTIV_V2PLUGIN_NAME} to docker hub 
+	@echo dev: pushing ${CONTIV_V2PLUGIN_NAME} to docker hub
 	@echo dev: need docker login with user in contiv org
 	docker plugin push ${CONTIV_V2PLUGIN_NAME}
 

--- a/scripts/code_checks_in_docker.sh
+++ b/scripts/code_checks_in_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PKG_DIRS=$*
+
+docker build -f Dockerfile-check -t contiv/netplugin-checks .
+
+# create container, stdout is the created container id
+container_id=$(docker create --name netplugin-checks \
+    contiv/netplugin-checks)
+
+# when there is an exit, remove the container
+function remove_container {
+    docker rm ${container_id}
+}
+trap remove_container EXIT
+
+NETPLUGIN_DIR=/go/src/github.com/contiv/netplugin
+# copy Makefile and go packages to be checked
+docker cp Makefile ${container_id}:${NETPLUGIN_DIR}/
+for pkg in ${PKG_DIRS}; do
+    docker cp $pkg ${container_id}:${NETPLUGIN_DIR}/
+done
+
+# run the checks
+docker start --attach ${container_id}


### PR DESCRIPTION
Before the only option was to spin up a VM to run code checks, which is
expensive in terms of time.

Add Dockerfile-check to provide a container build for a runtime
environment that supports go tool vet, gofmt, and golint

Add script 'code_checks_in_docker.sh' intended to be run inside the
Dockerfile-check container that runs `make checks` which in turn runs a
variety of go code checks against packages passed in.

Checks are reordered so more severe issues (e.g. functional) are
resolved before less severe ones (e.g. formatting).

Some checks are upated to be simpler and faster because the command
accept multiple directories and recurse automatically.

Drive-by:
* removed some trailing whitespace
* found another binary to exclude in dockerignore
* variables for go check commands not needed, they are only refernced
  once and require a visual lookup to find what the command actually
  is

Signed-off-by: Chris Plock <chrisplo@cisco.com>