### PR TITLE
scripts/netContain/Dockerfile: update OVS version

### DIFF
--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:16.04
 # ENV export https_proxy=https://proxy.localhost.com:8080
 
 RUN apt-get update \
- && apt-get install -y openvswitch-switch=2.5.2-0ubuntu0.16.04.1 \
+ && apt-get install -y openvswitch-switch=2.5.2-0ubuntu0.16.04.2 \
         net-tools \
         iptables \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
the .1 release was removed from the mirrors:  https://launchpad.net/ubuntu/+source/openvswitch

.2 is the latest release for Ubuntu 16.04 (Xenial Xerus)

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>