### PR TITLE
Adding CPU and memory settings for k8s Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Optionally, variables can be passed to Makefile if needed. For example, to
 use 1GB memory for the vagrant VMs, run:
 
 ```
-CONTIV_MEMORY=1024 make demo
+CONTIV_MEMORY=4096 make demo
 ```
 
 #### Step 2: Create a network

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ vagrant ssh netplugin-node1
 ```
 
 Optionally, variables can be passed to Makefile if needed. For example, to
-use 1GB memory for the vagrant VMs, run:
+use 4 GB memory for the vagrant VMs, run:
 
 ```
 CONTIV_MEMORY=4096 make demo

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ $ vagrant ssh netplugin-node1
 ```
 
 Optionally, variables can be passed to Makefile if needed. For example, to
-use 4 GB memory for the vagrant VMs, run:
+use 4 GB memory and 2 CPUs for the vagrant VMs, run:
 
 ```
-CONTIV_MEMORY=4096 make demo
+CONTIV_MEMORY=4096 CONTIV_CPUS=2 make demo
 ```
+
+CONTIV_MEMORY and CONTIV_CPUS are set to 2048 and 4 as the default values
+respectively.
 
 #### Step 2: Create a network
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ $ cd netplugin; make demo
 $ vagrant ssh netplugin-node1
 ```
 
+Optionally, variables can be passed to Makefile if needed. For example, to
+use 1GB memory for the vagrant VMs, run:
+
+```
+CONTIV_MEMORY=1024 make demo
+```
+
 #### Step 2: Create a network
 
 ```

--- a/vagrant/k8s/Vagrantfile
+++ b/vagrant/k8s/Vagrantfile
@@ -12,6 +12,8 @@ master_ip = "192.168.2.10"
 
 http_proxy = ENV['HTTP_PROXY'] || ENV['http_proxy'] || ''
 https_proxy = ENV['HTTPS_PROXY'] || ENV['https_proxy'] || ''
+num_vm_cpus = (ENV['CONTIV_CPUS'] || 4).to_i
+vm_memory = (ENV['CONTIV_MEMORY'] || 2048).to_i
 
 # python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))
 token = "d900e1.8a392798f13b33a4"
@@ -211,7 +213,8 @@ Vagrant.configure(2) do |config|
         c.vm.network :private_network, ip: member_info["contiv_network_ip"], virtualbox__intnet: network_name, auto_config: false
         c.vm.provider "virtualbox" do |v|
           customize(v)
-          v.memory = 2048
+          v.memory = vm_memory
+          v.cpus = num_vm_cpus
           v.customize ['modifyvm', :id, '--nicpromisc2', 'allow-all']
           v.customize ['modifyvm', :id, '--nicpromisc3', 'allow-all']
         end # v


### PR DESCRIPTION
This PR adds:
- CPU and memory variables for the k8s Vagrantfile so that they can be passed at runtime.
- Documentation for the user about how to pass variables to Makefile when deploying Contiv.

Tested on Mac laptop.

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>

