### PR TITLE
Check if GOPATH variable is empty in netplugin/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(GOPATH),)
+$(error GOPATH is not set. Set GOPATH by doing "export GOPATH=<your GOPATH>".)
+endif
+
 .PHONY: all all-CI build clean default unit-test release tar checks go-version gofmt-src \
 	golint-src govet-src run-build compile-with-docker
 


### PR DESCRIPTION
When we **DO NOT** set `GOPATH`, `netplugin/Makefile` uses an empty `GOPATH` variable without setting it. Hence, when we run `make k8s-test`, the line https://github.com/contiv/netplugin/blob/master/Makefile#L164 fails with the following error:
```
cd /src/github.com/contiv/netplugin/scripts/python && PYTHONIOENCODING=utf-8 ./createcfg.py -scheduler 'k8s' -binpath contiv/bin -install_mode 'kubeadm'

/bin/bash: line 0: cd: /src/github.com/contiv/netplugin/scripts/python: No such file or directory
```

This PR checks if `GOPATH` variable is empty in `netplugin/Makefile` and exits with an error if `GOPATH` is unset.

Tested on Mac laptop.

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>