### PR TITLE
Adding debugs in netplugin/scripts/build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euxo pipefail
+
 BUILD_TIME=$(date -u +%m-%d-%Y.%H-%M-%S.UTC)
 VERSION=$(cat version/CURRENT_VERSION | tr -d '\n')
 PKG_NAME=github.com/contiv/netplugin/version
@@ -19,7 +21,7 @@ GIT_COMMIT=$(./scripts/getGitCommit.sh)
 
 echo $BUILD_VERSION >$VERSION_FILE
 
-GOGC=1500 go install \
+GOGC=1500 go install -v \
 	-ldflags "-X $PKG_NAME.version=$BUILD_VERSION \
 	-X $PKG_NAME.buildTime=$BUILD_TIME \
 	-X $PKG_NAME.gitCommit=$GIT_COMMIT \


### PR DESCRIPTION
When we run `make k8s-test`, the `compile` target takes a long time to run `scripts/build.sh` (https://github.com/contiv/netplugin/blob/master/Makefile#L94) as it builds the entire netplugin code in `netplugin, netmaster, netctl, mgmtfn/k8splugin and mgmtfn/mesosplugin`. It looks as if scripts/build.sh **hangs** for a long time when we run `make k8s-test`.

This PR adds debugs in `netplugin/scripts/build.sh` so that the user sees the name of each go file and the package name compiled in the output when netplugin is being built and does not think that `scripts/build.sh ` hangs for a long time when building netplugin.

Tested on Mac laptop.

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>