### PR TITLE
Removed GOPATH check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-ifeq ($(GOPATH),)
-$(error GOPATH is not set. Set GOPATH by doing "export GOPATH=<your GOPATH>".)
-endif
-
 .PHONY: all all-CI build clean default unit-test release tar checks go-version gofmt-src \
 	golint-src govet-src run-build compile-with-docker
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ that lives behind an OVS bridge and has its own unique interfaces.
 #### Step 1: Clone the project and bringup the VMs
 
 Note: if you have $GOPATH set, then please ensure either you unset GOPATH,
-or clone the tree in `$GOPATH/src/github.com/contiv/` location. If you are
-using a Makefile target that needs `GOPATH`, please set it by doing 
-`export GOPATH=<your GOPATH>`.
+or clone the tree in `$GOPATH/src/github.com/contiv/` location
 
 ```
 $ git clone https://github.com/contiv/netplugin

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ that lives behind an OVS bridge and has its own unique interfaces.
 #### Step 1: Clone the project and bringup the VMs
 
 Note: if you have $GOPATH set, then please ensure either you unset GOPATH,
-or clone the tree in `$GOPATH/src/github.com/contiv/` location
+or clone the tree in `$GOPATH/src/github.com/contiv/` location. If you are
+using a Makefile target that needs `GOPATH`, please set it by doing 
+`export GOPATH=<your GOPATH>`.
 
 ```
 $ git clone https://github.com/contiv/netplugin


### PR DESCRIPTION
Not all Makefile targets need `GOPATH` to be set. Makefile targets like `demo` and `demo-v2plugin` do not need `GOPATH` to be set in order to sync the directory `src/github.com/contiv/netplugin` on the laptop with `/opt/gopath` inside the vagrant VM (https://github.com/contiv/netplugin/blob/master/Vagrantfile#L370). Targets like `tar` and `compile-with-docker` also do not need `GOPATH`.

Hence, this PR removes the check for `GOPATH` in the Makefile and adds documentation in `README.md` for the user to set `GOPATH` when using Makefile targets like `k8s-test`, `system-test`, `clean` and `compile` that **do need** `GOPATH` to be set (https://github.com/contiv/netplugin/blob/master/Makefile#L99).

Tested on Mac laptop.

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>