### PR TITLE
objdb/modeldb/modeldb.go: fix import path

### DIFF
--- a/objdb/modeldb/modeldb.go
+++ b/objdb/modeldb/modeldb.go
@@ -18,7 +18,7 @@ package modeldb
 // Wrapper for persistently storing object model
 
 import (
-	"github.com/contiv/objdb"
+	"github.com/contiv/netplugin/objdb"
 
 	log "github.com/Sirupsen/logrus"
 )


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Forgot to add this in the last commit.  This package isn't being used yet so nothing needs to be tested