### PR TITLE
Godeps/Godeps.json: update client-go version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -78,533 +78,533 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/discovery",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/apps/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/autoscaling/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/batch/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/batch/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/certificates/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/core/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/policy/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/kubernetes/typed/storage/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api/errors",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api/meta",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api/resource",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/api/validation/path",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apimachinery",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apimachinery/announced",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apimachinery/registered",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/apps",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/apps/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/apps/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/authentication",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/authentication/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/authentication/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/authorization",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/authorization/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/authorization/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/autoscaling",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/autoscaling/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/autoscaling/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/batch",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/batch/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/batch/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/batch/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/certificates",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/certificates/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/certificates/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/extensions",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/extensions/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/extensions/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/meta/v1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/meta/v1/unstructured",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/policy",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/policy/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/policy/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/rbac",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/rbac/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/rbac/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/storage",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/storage/install",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/apis/storage/v1beta1",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/auth/user",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/conversion",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/conversion/queryparams",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/fields",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/genericapiserver/openapi/common",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/labels",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/schema",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/serializer",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/serializer/json",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/serializer/protobuf",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/serializer/recognizer",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/serializer/streaming",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/runtime/serializer/versioning",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/selection",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/third_party/forked/golang/reflect",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/third_party/forked/golang/template",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/types",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/cert",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/clock",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/errors",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/flowcontrol",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/framer",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/integer",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/intstr",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/json",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/jsonpath",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/labels",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/net",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/parsers",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/rand",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/runtime",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/sets",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/uuid",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/validation",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/validation/field",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/wait",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/util/yaml",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/version",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/watch",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/pkg/watch/versioned",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/plugin/pkg/client/auth",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/plugin/pkg/client/auth/gcp",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/plugin/pkg/client/auth/oidc",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/rest",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/tools/clientcmd/api",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/tools/metrics",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/client-go/transport",
-			"Comment": "v2.0.0-alpha.0-27-g5e51774",
-			"Rev": "5e51774bcc09bc9fa9f96c9a9afab9229f8354a5"
+			"Comment": "v2.0.0-alpha.0-29-g97109fe",
+			"Rev": "97109fe21bf8cf9f43f26f1a1b5e3454ac084c35"
 		},
 		{
 			"ImportPath": "github.com/contiv/contivmodel",


### PR DESCRIPTION
There are no vendored changes with this commit.  This is necessary to resolve an issue with Godeps where it barfs on dependency detection because "client-go" had an empty Godeps.json

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>
