### PR TITLE
version is based on git state or BUILD_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,10 +340,12 @@ release-built-version: tar
 	NIGHTLY_RELEASE=${NIGHTLY_RELEASE} scripts/release.sh
 	@make clean-tar
 
-# run make as a subshell but with BUILD_VERSION set to write the correct
-# version everywhere
+# The first "release" below is not a target, it is a "target-specific variable"
+#   and sets (and in this case exports) a variable to the target's environment
+# The second release runs make as a subshell but with BUILD_VERSION set
+# to write the correct version for assets everywhere
 #
-# GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release
+# GITHUB_USER and GITHUB_TOKEN are needed be set (used by github-release)
 release: export BUILD_VERSION=$(shell cat version/CURRENT_VERSION)
 release:
 	@make release-built-version

--- a/Makefile
+++ b/Makefile
@@ -334,11 +334,16 @@ tar: compile-with-docker
 clean-tar:
 	@rm -f $(TAR_LOC)/*.$(TAR_EXT)
 
-# GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release
+# do not run directly, use "release" target
 release-built-version: tar
 	TAR_FILENAME=$(TAR_FILENAME) TAR_FILE=$(TAR_FILE) OLD_VERSION=${OLD_VERSION} \
 	NIGHTLY_RELEASE=${NIGHTLY_RELEASE} scripts/release.sh
 	@make clean-tar
+
+# run make as a subshell but with BUILD_VERSION set to write the correct
+# version everywhere
+#
+# GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release
 release: export BUILD_VERSION=$(shell cat version/CURRENT_VERSION)
 release:
-	@make release-built-version BUILD_VERSION=$(shell cat version/CURRENT_VERSION)
+	@make release-built-version

--- a/Makefile
+++ b/Makefile
@@ -322,11 +322,8 @@ host-plugin-release:
 
 # build tarball
 tar: compile-with-docker
-	@# $(TAR_FILE) depends on local file netplugin-version (exists in image),
-	@# but it is evaluated after we have extracted that file to local disk
 	docker rm netplugin-build || :
 	c_id=$$(docker create --name netplugin-build netplugin-build:$(NETPLUGIN_CONTAINER_TAG)) && \
-	docker cp $${c_id}:/go/src/github.com/contiv/netplugin/netplugin-version ./ && \
 	for f in netplugin netmaster netctl contivk8s netcontiv; do \
 		docker cp $${c_id}:/go/bin/$$f bin/$$f; done && \
 	docker rm $${c_id}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,16 +38,8 @@ You'll find a few examples below:
 
 Please keep in mind that the release notes can be updated on GitHub manually.
 
-BUILD_VERSION can be used to override the version specified in
-version/CURRENT_VERSION. This variable should be used to avoid changing
-the version for every single beta/rc release.
-
-BUILD_VERSION shouln't be used to override the version for actual
+BUILD_VERSION will not override the version for actual
 releases (1.0, 1.0.1, 1.1.0 and so on).
-
-Automated nightly releases use the version from version/CURRENT_VERSION.
-These nightly releases also append a timestamp to the version found in
-that file.
 
 The release process can be found below.
 
@@ -61,20 +53,16 @@ release isn't made from the HEAD of master.
 	git push origin 1.0.1
 	```
 
-3. Write down the BUILD_VERSION or update version/CURRENT_VERSION. This
-will be needed for the next steps. Please refer to the explanation
-related to BUILD_VERSION and version/CURRENT_VERSION above.
+3. Update version/CURRENT_VERSION. This will be needed for the next steps.
 
 4. Make sure GITHUB_USER and GITHUB_TOKEN variables are exported in your environment.
 
 5. Make the release to GitHub.
 	```
-	# BUILD_VERSION is used to override version/CURRENT_VERSION
-	OLD_VERSION=1.1.0-beta.1 BUILD_VERSION=1.1.0-beta.2 make release
+	OLD_VERSION=1.1.0-beta.1 make release
 	```
 
 	```
-	# version/CURRENT_VERSION is used for a new stable release
 	# version/CURRENT_VERSION is 1.1.1
 	OLD_VERSION=1.1.0 make release
 	```

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,28 +2,15 @@
 
 set -euxo pipefail
 
-BUILD_TIME=$(date -u +%m-%d-%Y.%H-%M-%S.UTC)
-VERSION=$(cat version/CURRENT_VERSION | tr -d '\n')
-PKG_NAME=github.com/contiv/netplugin/version
-
-# BUILD_VERSION overrides the version from CURRENT_VERSION
-if [ -n "$BUILD_VERSION" ]; then
-	VERSION=$BUILD_VERSION
-fi
-
-if [ -z "$NIGHTLY_RELEASE" ]; then
-	BUILD_VERSION="$VERSION"
-else
-	BUILD_VERSION="$VERSION-$BUILD_TIME"
-fi
-
 GIT_COMMIT=$(./scripts/getGitCommit.sh)
 
-echo $BUILD_VERSION >$VERSION_FILE
+# TODO(chrisplo): remove when contiv/install no longer needs
+echo $BUILD_VERSION > netplugin-version
 
+PKG_NAME=github.com/contiv/netplugin/version
 GOGC=1500 go install -v \
 	-ldflags "-X $PKG_NAME.version=$BUILD_VERSION \
-	-X $PKG_NAME.buildTime=$BUILD_TIME \
+	-X $PKG_NAME.buildTime=$(date -u +%m-%d-%Y.%H-%M-%S.UTC) \
 	-X $PKG_NAME.gitCommit=$GIT_COMMIT \
 	-s -w" \
 	$TO_BUILD

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,9 +4,6 @@ set -euxo pipefail
 
 GIT_COMMIT=$(./scripts/getGitCommit.sh)
 
-# TODO(chrisplo): remove when contiv/install no longer needs
-echo $BUILD_VERSION >netplugin-version
-
 PKG_NAME=github.com/contiv/netplugin/version
 GOGC=1500 go install -v \
 	-ldflags "-X $PKG_NAME.version=$BUILD_VERSION \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 GIT_COMMIT=$(./scripts/getGitCommit.sh)
 
 # TODO(chrisplo): remove when contiv/install no longer needs
-echo $BUILD_VERSION > netplugin-version
+echo $BUILD_VERSION >netplugin-version
 
 PKG_NAME=github.com/contiv/netplugin/version
 GOGC=1500 go install -v \

--- a/scripts/getGitVersion.sh
+++ b/scripts/getGitVersion.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BUILD_VERSION=${BUILD_VERSION:-}
+NIGHTLY_RELEASE=${NIGHTLY_RELEASE:-}
+
+# calculate version
+if command -v git &>/dev/null && git rev-parse &>/dev/null; then
+    GIT_COMMIT=$(git describe --tags --always 2>/dev/null || echo unknown)
+    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+        GIT_COMMIT="$GIT_COMMIT-unsupported"
+    fi
+    VERSION=$GIT_COMMIT
+else
+    echo >&2 'error: unable to determine the git revision'
+    exit 1
+fi
+
+# BUILD_VERSION overrides the git calculated version
+if [ -n "$BUILD_VERSION" ]; then
+	VERSION=$BUILD_VERSION
+fi
+
+if [ -z "$NIGHTLY_RELEASE" ]; then
+	VERSION="$VERSION"
+else
+    BUILD_TIME=$(date -u +%m-%d-%Y.%H-%M-%S.UTC)
+	VERSION="$VERSION-$BUILD_TIME"
+fi
+
+echo $VERSION

--- a/scripts/getGitVersion.sh
+++ b/scripts/getGitVersion.sh
@@ -7,14 +7,14 @@ NIGHTLY_RELEASE=${NIGHTLY_RELEASE:-}
 
 # calculate version
 if command -v git &>/dev/null && git rev-parse &>/dev/null; then
-    GIT_COMMIT=$(git describe --tags --always 2>/dev/null || echo unknown)
-    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-        GIT_COMMIT="$GIT_COMMIT-unsupported"
-    fi
-    VERSION=$GIT_COMMIT
+	GIT_COMMIT=$(git describe --tags --always 2>/dev/null || echo unknown)
+	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+		GIT_COMMIT="$GIT_COMMIT-unsupported"
+	fi
+	VERSION=$GIT_COMMIT
 else
-    echo >&2 'error: unable to determine the git revision'
-    exit 1
+	echo >&2 'error: unable to determine the git revision'
+	exit 1
 fi
 
 # BUILD_VERSION overrides the git calculated version
@@ -25,7 +25,7 @@ fi
 if [ -z "$NIGHTLY_RELEASE" ]; then
 	VERSION="$VERSION"
 else
-    BUILD_TIME=$(date -u +%m-%d-%Y.%H-%M-%S.UTC)
+	BUILD_TIME=$(date -u +%m-%d-%Y.%H-%M-%S.UTC)
 	VERSION="$VERSION-$BUILD_TIME"
 fi
 


### PR DESCRIPTION
Git version to be calculated by 'git describe --tags --always' and add
'-unsupported' when the local workspace has an uncommitted change.

the rules are:
* BUILD_VERSION will override any calculated version if set as env/make
  cli variable
* if current commit is tagged, use just the tag
* else `<tag>-<num commits since>-g<commit id>`

release target will use CURRENT_VERSION to make it simple to set in the
release branch

Signed-off-by: Chris Plock <chrisplo@cisco.com>