### PR TITLE
Init global settings from object store

### DIFF
--- a/netmaster/objApi/apiController.go
+++ b/netmaster/objApi/apiController.go
@@ -116,7 +116,7 @@ func NewAPIController(router *mux.Router, objdbClient objdb.API, storeURL string
 			NetworkInfraType: "default",
 			Vlans:            "1-4094",
 			Vxlans:           "1-10000",
-			FwdMode:          "bridge",
+			FwdMode:          "", // set empty fwd mode by default
 			ArpMode:          "proxy",
 			PvtSubnet:        defHostPvtNet,
 		})

--- a/netplugin/plugin/netplugin_test.go
+++ b/netplugin/plugin/netplugin_test.go
@@ -18,25 +18,52 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"testing"
-
+	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/netmaster/mastercfg"
 	"github.com/contiv/netplugin/state"
+	"github.com/contiv/netplugin/utils"
+	"testing"
 )
 
 var fakeStateDriver *state.FakeStateDriver
 
+func initFakeStateDriver(t *testing.T) {
+	// init fake state driver
+	instInfo := core.InstanceInfo{}
+	d, err := utils.NewStateDriver("fakedriver", &instInfo)
+	if err != nil {
+		t.Fatalf("failed to init statedriver. Error: %s", err)
+	}
+
+	fakeStateDriver = d.(*state.FakeStateDriver)
+}
+
+func deinitFakeStateDriver() {
+	// release fake state driver
+	utils.ReleaseStateDriver()
+}
+
 func TestNetPluginInit(t *testing.T) {
+	// Testing init NetPlugin
+	initFakeStateDriver(t)
+	defer deinitFakeStateDriver()
+	gCfg := mastercfg.GlobConfig{
+		FwdMode:   "bridge",
+		PvtSubnet: "172.19.0.0/16"}
+	gCfg.StateDriver = fakeStateDriver
+	gCfg.Write()
+
 	configStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
-                       "state": "fakedriver"
-                    },
-                    "plugin-instance": {
-                       "host-label": "testHost",
-		       		   "fwd-mode":"bridge"
-                    }
-                  }`
+					"drivers" : {
+						"network": "ovs",
+						"endpoint": "ovs",
+						"state": "fakedriver"
+					},
+					"plugin-instance": {
+						"host-label": "testHost",
+						"fwd-mode":"bridge"
+					}
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}
@@ -56,6 +83,7 @@ func TestNetPluginInit(t *testing.T) {
 }
 
 func TestNetPluginInitInvalidConfigEmptyString(t *testing.T) {
+	// Test NetPlugin init failure when no config provided
 	pluginConfig := Config{}
 
 	plugin := NetPlugin{}
@@ -66,13 +94,14 @@ func TestNetPluginInitInvalidConfigEmptyString(t *testing.T) {
 }
 
 func TestNetPluginInitInvalidConfigMissingInstance(t *testing.T) {
+	// Test NetPlugin init failure when missing instance config
 	configStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
-                       "state": "fakedriver"
-                    }
-                  }`
+					"drivers" : {
+						"network": "ovs",
+						"endpoint": "ovs",
+						"state": "fakedriver"
+					}
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}
@@ -86,18 +115,19 @@ func TestNetPluginInitInvalidConfigMissingInstance(t *testing.T) {
 }
 
 func TestNetPluginInitInvalidConfigEmptyHostLabel(t *testing.T) {
+	// Test NetPlugin init failure when empty HostLabel provided
 	configStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
-                       "state": "fakedriver"
-                    },
-                    "plugin-instance": {
-                       "host-label": "",
-					   "fwd-mode":"bridge",
-					   "db-url": "etcd://127.0.0.1:4001"
-                    }
-                  }`
+					"drivers" : {
+						"network": "ovs",
+						"endpoint": "ovs",
+						"state": "fakedriver"
+					},
+					"plugin-instance": {
+						"host-label": "",
+						"fwd-mode":"bridge",
+						"db-url": "etcd://127.0.0.1:4001"
+					}
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}
@@ -114,17 +144,18 @@ func TestNetPluginInitInvalidConfigEmptyHostLabel(t *testing.T) {
 }
 
 func TestNetPluginInitInvalidConfigMissingStateDriverName(t *testing.T) {
+	// Test NetPlugin init failure when missing state driver name
 	configStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs"
-                    },
-                    "plugin-instance": {
-                       "host-label": "testHost",
-		       		   "fwd-mode":"bridge",
-					   "db-url": "etcd://127.0.0.1:4001"
-                    }
-                  }`
+					"drivers" : {
+						"network": "ovs",
+						"endpoint": "ovs"
+					},
+					"plugin-instance": {
+						"host-label": "testHost",
+						"fwd-mode":"bridge",
+						"db-url": "etcd://127.0.0.1:4001"
+					}
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}
@@ -141,17 +172,18 @@ func TestNetPluginInitInvalidConfigMissingStateDriverName(t *testing.T) {
 }
 
 func TestNetPluginInitInvalidConfigMissingStateDriverURL(t *testing.T) {
+	// Test NetPlugin init failure when missing state driver url
 	configStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
-                       "state": "etcd"
-                    },
-                    "plugin-instance": {
-                       "host-label": "testHost",
-           	           "fwd-mode":"bridge"
-                    }
-                  }`
+					"drivers" : {
+						"network": "ovs",
+						"endpoint": "ovs",
+						"state": "etcd"
+					},
+					"plugin-instance": {
+						"host-label": "testHost",
+						"fwd-mode":"bridge"
+					}
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}
@@ -169,18 +201,26 @@ func TestNetPluginInitInvalidConfigMissingStateDriverURL(t *testing.T) {
 }
 
 func TestNetPluginInitInvalidConfigMissingNetworkDriverName(t *testing.T) {
+	// Test NetPlugin init failure when missing network driver name
+	initFakeStateDriver(t)
+	defer deinitFakeStateDriver()
+	gCfg := mastercfg.GlobConfig{
+		FwdMode:   "bridge",
+		PvtSubnet: "172.19.0.0/16"}
+	gCfg.StateDriver = fakeStateDriver
+	gCfg.Write()
 	configStr := `{
-                    "drivers" : {
-                       "endpoint": "ovs",
-                       "state": "fakedriver",
-                       "container": "docker"
-                    },
-                    "plugin-instance": {
-                       "host-label": "testHost",
-		       		   "fwd-mode":"bridge",
-					   "db-url": "etcd://127.0.0.1:4001"
-                    }
-                  }`
+					"drivers" : {
+						"endpoint": "ovs",
+						"state": "fakedriver",
+						"container": "docker"
+					},
+					"plugin-instance": {
+						"host-label": "testHost",
+						"fwd-mode":"bridge",
+						"db-url": "etcd://127.0.0.1:4001"
+					}
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}
@@ -196,19 +236,28 @@ func TestNetPluginInitInvalidConfigMissingNetworkDriverName(t *testing.T) {
 	}
 }
 
-func TestNetPluginInitInvalidConfigMissingFwdMode(t *testing.T) {
+func TestNetPluginInitInvalidConfigInvalidPrivateSubnet(t *testing.T) {
+	// Test NetPlugin init failure when private subnet is not valid
+	initFakeStateDriver(t)
+	defer deinitFakeStateDriver()
+	gCfg := mastercfg.GlobConfig{
+		FwdMode:   "routing",
+		PvtSubnet: "172.19.0.0"}
+	gCfg.StateDriver = fakeStateDriver
+	gCfg.Write()
 	configStr := `{
-                    "drivers" : {
-                       "network": "ovs",
-                       "endpoint": "ovs",
-                       "state": "fakedriver",
-                       "container": "docker",
-                    },
+					"drivers" : {
+						"network": "ovs",
+						"endpoint": "ovs",
+						"state": "fakedriver",
+						"container": "docker",
+					},
 					"plugin-instance": {
-						 "host-label": "testHost",
-						 "db-url": "etcd://127.0.0.1:4001"
+						"host-label": "testHost",
+						"db-url": "etcd://127.0.0.1:4001",
+						"fwd-mode":"routing",
 					}
-                  }`
+				}`
 
 	// Parse the config
 	pluginConfig := Config{}

--- a/test/integration/npcluster_test.go
+++ b/test/integration/npcluster_test.go
@@ -85,21 +85,19 @@ func NewNPCluster(its *integTestSuite) (*NPCluster, error) {
 	// Wait for a second for master to initialize
 	time.Sleep(10 * time.Second)
 
-	// set forwarding mode if required
-	if its.fwdMode != "bridge" || its.fabricMode != "default" {
-		err := contivModel.CreateGlobal(&contivModel.Global{
-			Key:              "global",
-			Name:             "global",
-			NetworkInfraType: its.fabricMode,
-			Vlans:            "1-4094",
-			Vxlans:           "1-10000",
-			FwdMode:          its.fwdMode,
-			ArpMode:          its.arpMode,
-			PvtSubnet:        "172.19.0.0/16",
-		})
-		if err != nil {
-			log.Fatalf("Error creating global state. Err: %v", err)
-		}
+	err = contivModel.CreateGlobal(&contivModel.Global{
+		Key:              "global",
+		Name:             "global",
+		NetworkInfraType: its.fabricMode,
+		Vlans:            "1-4094",
+		Vxlans:           "1-10000",
+		FwdMode:          its.fwdMode,
+		ArpMode:          its.arpMode,
+		PvtSubnet:        "172.19.0.0/16",
+	})
+
+	if err != nil {
+		log.Fatalf("Error creating global state. Err: %v", err)
 	}
 
 	// Create a new agent

--- a/test/systemtests/util_test.go
+++ b/test/systemtests/util_test.go
@@ -1318,6 +1318,17 @@ func (s *systemtestSuite) SetUpSuiteVagrant(c *C) {
 	})
 }
 
+func (s *systemtestSuite) setGlobalSettings(c *C, mode string) {
+	c.Assert(s.cli.GlobalPost(&client.Global{FwdMode: mode,
+		Name:             "global",
+		NetworkInfraType: "default",
+		Vlans:            "1-4094",
+		Vxlans:           "1-10000",
+		ArpMode:          "proxy",
+		PvtSubnet:        "172.19.0.0/16",
+	}), IsNil)
+}
+
 func (s *systemtestSuite) SetUpTestBaremetal(c *C) {
 
 	for _, node := range s.nodes {
@@ -1365,17 +1376,10 @@ func (s *systemtestSuite) SetUpTestBaremetal(c *C) {
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
-	if s.fwdMode == "routing" {
-		c.Assert(s.cli.GlobalPost(&client.Global{FwdMode: "routing",
-			Name:             "global",
-			NetworkInfraType: "default",
-			Vlans:            "1-4094",
-			Vxlans:           "1-10000",
-			ArpMode:          "proxy",
-			PvtSubnet:        "172.19.0.0/16",
-		}), IsNil)
-		time.Sleep(40 * time.Second)
-	}
+
+	s.setGlobalSettings(c, s.fwdMode)
+	time.Sleep(40 * time.Second)
+
 }
 
 func (s *systemtestSuite) SetUpTestVagrant(c *C) {
@@ -1438,20 +1442,11 @@ func (s *systemtestSuite) SetUpTestVagrant(c *C) {
 		}
 	}
 
+	s.setGlobalSettings(c, s.fwdMode)
+	time.Sleep(120 * time.Second)
+
 	if s.basicInfo.Scheduler == kubeScheduler {
 		c.Assert(s.SetupDefaultNetwork(), IsNil)
-	}
-
-	if s.fwdMode == "routing" {
-		c.Assert(s.cli.GlobalPost(&client.Global{FwdMode: "routing",
-			Name:             "global",
-			NetworkInfraType: "default",
-			Vlans:            "1-4094",
-			Vxlans:           "1-10000",
-			ArpMode:          "proxy",
-			PvtSubnet:        "172.19.0.0/16",
-		}), IsNil)
-		time.Sleep(120 * time.Second)
 	}
 }
 

--- a/utils/netutils/netutils.go
+++ b/utils/netutils/netutils.go
@@ -921,23 +921,16 @@ func HostIPToGateway(hostIP string) (string, error) {
 	return ip[0] + "." + ip[1] + ".255.254", nil
 }
 
-// CIDRToMask converts a mask to corresponding netmask
+// CIDRToMask converts a CIDR to corresponding network number
 func CIDRToMask(cidr string) (int, error) {
-
-	n := strings.Split(cidr, "/")
-	if len(n) != 2 {
-		return -1, core.Errorf("Error bad cidr %s", cidr)
+	_, net, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return -1, err
 	}
-
-	ip := net.ParseIP(n[0])
-	if ip == nil {
-		return -1, core.Errorf("Error bad cidr %s", cidr)
-	}
-
+	ip := net.IP
 	if len(ip) == 16 {
 		return int(binary.BigEndian.Uint32(ip[12:16])), nil
 	}
-
 	return int(binary.BigEndian.Uint32(ip)), nil
 }
 


### PR DESCRIPTION
Currently netplugin is trying to init from default settings if global
setting is not ready or wrong, and when the settings don't match it
will re-init netplugin. This is very easy to go wrong when there are
resources created before global settings are ready.
This commit makes netplugin wait until the global settings ready, and
initiate itself according to it. If the global settings are mis-match,
it will return error.

Signed-off-by: Wei Tie <wtie@cisco.com>
