### PR TITLE
Return pkttag with network list objects

### DIFF
--- a/vendor/github.com/contiv/contivmodel/contivModel.go
+++ b/vendor/github.com/contiv/contivmodel/contivModel.go
@@ -3513,12 +3513,19 @@ func GetOperNetwork(obj *NetworkInspect) error {
 
 // LIST REST call
 func httpListNetworks(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	var netobj NetworkInspect
 	log.Debugf("Received httpListNetworks: %+v", vars)
 
 	list := make([]*Network, 0)
 	collections.networkMutex.Lock()
 	defer collections.networkMutex.Unlock()
 	for _, obj := range collections.networks {
+		netobj.Config = *obj
+		if err := GetOperNetwork(&netobj); err != nil {
+			log.Errorf("GetNetwork error for: %+v. Err: %v", netobj, err)
+			return nil, err
+		}
+		obj.PktTag = netobj.Oper.PktTag
 		list = append(list, obj)
 	}
 


### PR DESCRIPTION
Bug Fix: Return pkttag with network list objects

Manual testing: add network with VLAN id, list networks, verify VLAN id

Fixes-Jira: CNTV-175
