### PR TITLE
Disallow invalid VLAN/VNI value

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -751,13 +751,15 @@ func deleteNetworkHelper(networkID string) error {
 		// delete the dnet oper state
 		err = docknet.DeleteDockNetState(dnet.TenantName, dnet.NetworkName, dnet.ServiceName)
 		if err != nil {
-			log.Errorf("Couldn't delete docknet for nwID %s: %s", networkID, err.Error())
-			return errors.New("Failed to delete docket network state")
+			msg := fmt.Sprintf("Could not delete docknet for nwID %s: %s", networkID, err.Error())
+			log.Errorf(msg)
+			return errors.New(msg)
 		}
 		log.Infof("Deleted docker network mapping for %v", networkID)
 	} else {
-		log.Errorf("Couldn't find Docker network %s: %s", networkID, err.Error())
-		return errors.New("Unable to find Docker network")
+		msg := fmt.Sprintf("Could not find Docker network %s: %s", networkID, err.Error())
+		log.Errorf(msg)
+		return errors.New(msg)
 	}
 
 	netID := networkID + ".default"
@@ -771,8 +773,9 @@ func deleteNetworkHelper(networkID string) error {
 
 		err = cluster.MasterDelReq(url)
 		if err != nil {
-			log.Errorf("Failed to delete network: %s", err.Error())
-			return errors.New("Failed to delete network")
+			msg := fmt.Sprintf("Failed to delete network: %s", err.Error())
+			log.Errorf(msg)
+			return errors.New(msg)
 		}
 		log.Infof("Deleted contiv network %v", networkID)
 	} else {

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -742,10 +742,22 @@ func createNetworkHelper(networkID string, tag string, IPv4Data, IPv6Data []driv
 	return nil
 }
 
-// deleteNetworkHelper removes the association between docker network and contiv network
+// deleteNetworkHelper removes the association between docker network
+// and contiv network. We have to remove docker network state before
+// remove network in contiv.
 func deleteNetworkHelper(networkID string) error {
+	dnet, err := docknet.FindDocknetByUUID(networkID)
+	if err == nil {
+		// delete the dnet oper state
+		err = docknet.DeleteDockNetState(dnet.TenantName, dnet.NetworkName, dnet.ServiceName)
+		if err != nil {
+			log.Errorf("Couldn't delete docknet for nwID %s", networkID)
+		}
+		log.Infof("Deleted docker network mapping for %v", networkID)
+	}
+
 	netID := networkID + ".default"
-	_, err := utils.GetNetwork(netID)
+	_, err = utils.GetNetwork(netID)
 	if err == nil {
 		// if we find a contiv network with the ID hash, then it must be
 		// a docker created network (from the libnetwork create api).
@@ -762,14 +774,6 @@ func deleteNetworkHelper(networkID string) error {
 	} else {
 		log.Infof("Could not find contiv network %v", networkID)
 	}
-	dnet, err := docknet.FindDocknetByUUID(networkID)
-	if err == nil {
-		// delete the dnet oper state
-		err = docknet.DeleteDockNetState(dnet.TenantName, dnet.NetworkName, dnet.ServiceName)
-		if err != nil {
-			log.Errorf("Couldn't delete docknet for nwID %s", networkID)
-		}
-		log.Infof("Deleted docker network mapping for %v", networkID)
-	}
+
 	return nil
 }

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -751,7 +751,7 @@ func deleteNetworkHelper(networkID string) error {
 		// delete the dnet oper state
 		err = docknet.DeleteDockNetState(dnet.TenantName, dnet.NetworkName, dnet.ServiceName)
 		if err != nil {
-			log.Errorf("Couldn't delete docknet for nwID %s", networkID)
+			log.Errorf("Couldn't delete docknet for nwID %s: %s", networkID, err.Error())
 		}
 		log.Infof("Deleted docker network mapping for %v", networkID)
 	}

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -752,8 +752,12 @@ func deleteNetworkHelper(networkID string) error {
 		err = docknet.DeleteDockNetState(dnet.TenantName, dnet.NetworkName, dnet.ServiceName)
 		if err != nil {
 			log.Errorf("Couldn't delete docknet for nwID %s: %s", networkID, err.Error())
+			return errors.New("Failed to delete docket network state")
 		}
 		log.Infof("Deleted docker network mapping for %v", networkID)
+	} else {
+		log.Errorf("Couldn't find Docker network %s: %s", networkID, err.Error())
+		return errors.New("Unable to find Docker network")
 	}
 
 	netID := networkID + ".default"

--- a/mgmtfn/dockplugin/netDriver.go
+++ b/mgmtfn/dockplugin/netDriver.go
@@ -759,7 +759,6 @@ func deleteNetworkHelper(networkID string) error {
 	} else {
 		msg := fmt.Sprintf("Could not find Docker network %s: %s", networkID, err.Error())
 		log.Errorf(msg)
-		return errors.New(msg)
 	}
 
 	netID := networkID + ".default"

--- a/mgmtfn/dockplugin/netDriver_test.go
+++ b/mgmtfn/dockplugin/netDriver_test.go
@@ -76,19 +76,11 @@ func TestCreateAndDeleteNetwork(t *testing.T) {
 		t.Fatalf("Unable to delete docker network. Error: %v", err)
 		t.Fail()
 	}
-}
 
-func TestDeleteNonExistingNetwork(t *testing.T) {
-	// Update plugin driver for unit test
-	docknet.UpdateDockerV2PluginName("bridge", "default")
-
-	initFakeStateDriver(t)
-
-	// Delete Docker network by using helper
-	delErr := deleteNetworkHelper("non_existing_network_id")
-
-	if delErr == nil {
-		t.Fatalf("Expect deleteNetworkHelper returns error when network is not presented")
+	// ensure network is not in the oper state
+	err = dnetOper.Read(fmt.Sprintf("%s.%s.%s", tenantName, networkName, serviceName))
+	if err == nil {
+		t.Fatalf("Fail to delete docket network")
 		t.Fail()
 	}
 }

--- a/mgmtfn/dockplugin/netDriver_test.go
+++ b/mgmtfn/dockplugin/netDriver_test.go
@@ -1,0 +1,64 @@
+package dockplugin
+
+import (
+	"fmt"
+    "testing"
+	"github.com/contiv/netplugin/core"
+	"github.com/contiv/netplugin/netmaster/docknet"
+	"github.com/contiv/netplugin/netmaster/mastercfg"
+	"github.com/contiv/netplugin/utils"
+)
+
+// initStateDriver initialize etcd state driver
+func initStateDriver() (core.StateDriver, error) {
+	instInfo := core.InstanceInfo{DbURL: "etcd://127.0.0.1:2379"}
+
+	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo)
+}
+
+// Ensure deleteNetworkHelper can delete docker network without issue
+func TestCreateAndDeleteNetwork(t *testing.T) {
+	// Update plugin driver for unit test
+	docknet.UpdatePluginName("bridge", "default")
+    initStateDriver()
+
+	tenantName := "t1"
+	networkName := "net1"
+	serviceName := ""
+    nwcfg := mastercfg.CfgNetworkState{
+		Tenant:      tenantName,
+		NetworkName: networkName,
+		PktTagType:  "vlan",
+		PktTag:      1,
+		ExtPktTag:   1,
+		SubnetIP:    "10.0.0.0",
+		SubnetLen:   24,
+		Gateway:     "10.0.0.1",
+	}
+
+    err := docknet.CreateDockNet(tenantName, networkName, "", &nwcfg)
+	if err != nil {
+		t.Fatalf("Error creating docker network. Error: %v", err)
+		t.Fail()
+	}
+
+	// Get Docker network UUID
+	stateDriver, err := utils.GetStateDriver()
+	dnetOper := docknet.DnetOperState{}
+	dnetOper.StateDriver = stateDriver
+
+	dnetOperErr := dnetOper.Read(
+		fmt.Sprintf("%s.%s.%s", tenantName, networkName, serviceName))
+	if dnetOperErr != nil {
+		t.Fatalf("Unable to read network state. Error: %v", dnetOperErr)
+		t.Fail()
+	}
+
+	// Delete Docker network by using helper
+	delErr := deleteNetworkHelper(dnetOper.DocknetUUID)
+
+	if delErr != nil {
+		t.Fatalf("Unable to delete docker network. Error: %v", delErr)
+		t.Fail()
+	}
+}

--- a/mgmtfn/dockplugin/netDriver_test.go
+++ b/mgmtfn/dockplugin/netDriver_test.go
@@ -2,11 +2,11 @@ package dockplugin
 
 import (
 	"fmt"
-    "testing"
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/netmaster/docknet"
 	"github.com/contiv/netplugin/netmaster/mastercfg"
 	"github.com/contiv/netplugin/utils"
+	"testing"
 )
 
 // initStateDriver initialize etcd state driver
@@ -20,12 +20,13 @@ func initStateDriver() (core.StateDriver, error) {
 func TestCreateAndDeleteNetwork(t *testing.T) {
 	// Update plugin driver for unit test
 	docknet.UpdatePluginName("bridge", "default")
-    initStateDriver()
+
+	initStateDriver()
 
 	tenantName := "t1"
 	networkName := "net1"
 	serviceName := ""
-    nwcfg := mastercfg.CfgNetworkState{
+	nwcfg := mastercfg.CfgNetworkState{
 		Tenant:      tenantName,
 		NetworkName: networkName,
 		PktTagType:  "vlan",
@@ -36,7 +37,7 @@ func TestCreateAndDeleteNetwork(t *testing.T) {
 		Gateway:     "10.0.0.1",
 	}
 
-    err := docknet.CreateDockNet(tenantName, networkName, "", &nwcfg)
+	err := docknet.CreateDockNet(tenantName, networkName, "", &nwcfg)
 	if err != nil {
 		t.Fatalf("Error creating docker network. Error: %v", err)
 		t.Fail()

--- a/mgmtfn/dockplugin/netDriver_test.go
+++ b/mgmtfn/dockplugin/netDriver_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/contiv/netplugin/core"
 	"github.com/contiv/netplugin/netmaster/docknet"
 	"github.com/contiv/netplugin/netmaster/mastercfg"
-	"github.com/contiv/netplugin/utils"
 	"github.com/contiv/netplugin/state"
+	"github.com/contiv/netplugin/utils"
 	"testing"
 )
 
@@ -16,10 +16,8 @@ var stateDriver *state.FakeStateDriver
 func initFakeStateDriver() {
 	instInfo := core.InstanceInfo{}
 	d, _ := utils.NewStateDriver("fakedriver", &instInfo)
-
 	stateDriver = d.(*state.FakeStateDriver)
 }
-
 
 func deinitStateDriver() {
 	utils.ReleaseStateDriver()
@@ -62,9 +60,10 @@ func TestCreateAndDeleteNetwork(t *testing.T) {
 		t.Fatalf("Unable to read network state. Error: %v", dnetOperErr)
 		t.Fail()
 	}
+
 	testData := make([]byte, 3)
-	networkID := dnetOper.DocknetUUID + ".default"
-	stateDriver.Write(networkID, testData)
+	networkID := mastercfg.StateConfigPath + "nets/" + dnetOper.DocknetUUID + ".default"
+	dnetOper.StateDriver.Write(networkID, testData)
 
 	// Delete Docker network by using helper
 	delErr := deleteNetworkHelper(dnetOper.DocknetUUID)

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -519,6 +520,8 @@ func createNetwork(ctx *cli.Context) {
 	subnetv6 := ctx.String("subnetv6")
 	gatewayv6 := ctx.String("gatewayv6")
 
+	pktTagInString := ctx.String("pkt-tag")
+
 	if subnet == "" {
 		errExit(ctx, exitHelp, "Subnet is required", true)
 	}
@@ -529,14 +532,22 @@ func createNetwork(ctx *cli.Context) {
 	}
 	if gatewayv6 != "" {
 		if ok := net.ParseIP(gatewayv6); ok == nil {
-			errExit(ctx, exitHelp, "Invalid IPv6 gateway ", true)
+			errExit(ctx, exitHelp, "Invalid IPv6 gateway", true)
+		}
+	}
+
+	var pktTag int
+	var err error
+	if len(pktTagInString) > 0 {
+		pktTag, err = strconv.Atoi(pktTagInString)
+		if err != nil {
+			errExit(ctx, exitHelp, "Invalid VLAN ID or VNI, expected an integer", true)
 		}
 	}
 
 	tenant := ctx.String("tenant")
 	network := ctx.Args()[0]
 	encap := ctx.String("encap")
-	pktTag := ctx.Int("pkt-tag")
 	nwType := ctx.String("nw-type")
 	nwTag := ctx.String("nw-tag")
 

--- a/netmaster/docknet/docknet.go
+++ b/netmaster/docknet/docknet.go
@@ -101,11 +101,11 @@ func GetDocknetName(tenantName, networkName, epgName string) string {
 	return netName
 }
 
-// UpdatePluginName update the docker v2 plugin name
-func UpdatePluginName(netdriver string, ipamDriver string) {
+// UpdateDockerV2PluginName update the docker v2 plugin name
+func UpdateDockerV2PluginName(netDriver string, ipamDriver string) {
 	log.Infof("docker v2plugin (%s) updated to %s and ipam (%s) updated to %s",
-		netDriverName, netdriver, ipamDriverName, ipamDriver)
-	netDriverName = netdriver
+		netDriverName, netDriver, ipamDriverName, ipamDriver)
+	netDriverName = netDriver
 	ipamDriverName = ipamDriver
 }
 

--- a/netmaster/docknet/docknet.go
+++ b/netmaster/docknet/docknet.go
@@ -102,10 +102,11 @@ func GetDocknetName(tenantName, networkName, epgName string) string {
 }
 
 // UpdatePluginName update the docker v2 plugin name
-func UpdatePluginName(pluginName string) {
-	log.Infof("docker v2plugin name (%s) updated to %s", netDriverName, pluginName)
-	netDriverName = pluginName
-	ipamDriverName = pluginName
+func UpdatePluginName(netdriver string, ipamDriver string) {
+	log.Infof("docker v2plugin (%s) updated to %s and ipam (%s) updated to %s",
+		netDriverName, netdriver, ipamDriverName, ipamDriver)
+	netDriverName = netdriver
+	ipamDriverName = ipamDriver
 }
 
 // CreateDockNet Creates a network in docker daemon

--- a/netmaster/docknet/docknet_test.go
+++ b/netmaster/docknet/docknet_test.go
@@ -204,7 +204,7 @@ func checkDocknetDelete(t *testing.T, tenantName, networkName, serviceName strin
 
 func TestMain(m *testing.M) {
 	// change driver names for unit-testing
-	UpdatePluginName("bridge", "default")
+	UpdateDockerV2PluginName("bridge", "default")
 
 	initStateDriver()
 
@@ -225,10 +225,10 @@ func TestDocknetCreateDelete(t *testing.T) {
 	checkDocknetDelete(t, "unit-test", "net1", "srv1")
 }
 
-func TestUpdatePluginName(t *testing.T) {
+func TestUpdateDockerV2PluginName(t *testing.T) {
 	expectNetDriver := "bridge"
 	expectIPAMDriver := "default"
-	UpdatePluginName("bridge", "default")
+	UpdateDockerV2PluginName("bridge", "default")
 
 	if expectNetDriver != netDriverName {
 		t.Fatalf("Unexpected netdriver name. Expected: %s. Actual: %s",

--- a/netmaster/docknet/docknet_test.go
+++ b/netmaster/docknet/docknet_test.go
@@ -224,3 +224,21 @@ func TestDocknetCreateDelete(t *testing.T) {
 	checkDocknetCreate(t, "unit-test", "net1", "srv1", "10.1.1.1/24", "10.1.1.254")
 	checkDocknetDelete(t, "unit-test", "net1", "srv1")
 }
+
+func TestUpdatePluginName(t *testing.T) {
+	expectNetDriver := "bridge"
+	expectIPAMDriver := "default"
+	UpdatePluginName("bridge", "default")
+
+	if expectNetDriver != netDriverName {
+		t.Fatalf("Unexpected netdriver name. Expected: %s. Actual: %s",
+			expectNetDriver, netDriverName)
+		t.Fail()
+	}
+
+	if expectIPAMDriver != ipamDriverName {
+		t.Fatalf("Unexpected ipamdriver name. Expected: %s. Actual: %s",
+			expectIPAMDriver, ipamDriverName)
+		t.Fail()
+	}
+}

--- a/netmaster/docknet/docknet_test.go
+++ b/netmaster/docknet/docknet_test.go
@@ -76,7 +76,7 @@ func checkDocknetCreate(t *testing.T, tenantName, networkName, serviceName, subn
 	// create a docker network
 	err := CreateDockNet(tenantName, networkName, serviceName, &nwcfg)
 	if err != nil {
-		t.Fatalf("Error creating docker ntework. Err: %v", err)
+		t.Fatalf("Error creating docker network. Err: %v", err)
 	}
 
 	// verify docknet state is created
@@ -204,8 +204,7 @@ func checkDocknetDelete(t *testing.T, tenantName, networkName, serviceName strin
 
 func TestMain(m *testing.M) {
 	// change driver names for unit-testing
-	netDriverName = "bridge"
-	ipamDriverName = "default"
+	UpdatePluginName("bridge", "default")
 
 	initStateDriver()
 

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -155,7 +155,7 @@ func execOpts(opts *cliOpts) {
 	log.Infof("Control IP:Port %s:%s", controlIP, controlURL[1])
 
 	if opts.clusterMode == master.Docker || opts.clusterMode == master.SwarmMode {
-		docknet.UpdatePluginName(opts.pluginName, opt.pluginName)
+		docknet.UpdatePluginName(opts.pluginName, opts.pluginName)
 	}
 }
 

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -155,7 +155,7 @@ func execOpts(opts *cliOpts) {
 	log.Infof("Control IP:Port %s:%s", controlIP, controlURL[1])
 
 	if opts.clusterMode == master.Docker || opts.clusterMode == master.SwarmMode {
-		docknet.UpdatePluginName(opts.pluginName)
+		docknet.UpdatePluginName(opts.pluginName, opt.pluginName)
 	}
 }
 

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -155,7 +155,7 @@ func execOpts(opts *cliOpts) {
 	log.Infof("Control IP:Port %s:%s", controlIP, controlURL[1])
 
 	if opts.clusterMode == master.Docker || opts.clusterMode == master.SwarmMode {
-		docknet.UpdatePluginName(opts.pluginName, opts.pluginName)
+		docknet.UpdateDockerV2PluginName(opts.pluginName, opts.pluginName)
 	}
 }
 


### PR DESCRIPTION
Currently, netctl parse the pkgTag input as an integer directly.
    Therefore when user put a garbage in pkgTag, the conversion will
    default it to 0 instead.

    This patchset is to cast the input to string and perform further
    validation logic before we create network

    Signed-off-by: Kahou Lei <kalei@cisco.com>