### PR TITLE
Disallow invalid VLAN/VNI value during network creation

### DIFF
--- a/netctl/commands.go
+++ b/netctl/commands.go
@@ -216,9 +216,9 @@ var Commands = []cli.Command{
 						Usage: "Encap type (vlan or vxlan)",
 						Value: "vxlan",
 					},
-					cli.StringFlag{
+					cli.IntFlag{
 						Name:  "pkt-tag, p",
-						Usage: "Packet tag (Vlan/Vxlan ids)",
+						Usage: "Packet tag (Vlan ID/VNI)",
 					},
 					cli.StringFlag{
 						Name:  "subnet, s",

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -518,8 +517,6 @@ func createNetwork(ctx *cli.Context) {
 	subnetv6 := ctx.String("subnetv6")
 	gatewayv6 := ctx.String("gatewayv6")
 
-	pktTagInString := ctx.String("pkt-tag")
-
 	if subnet == "" {
 		errExit(ctx, exitHelp, "Subnet is required", true)
 	}
@@ -530,22 +527,14 @@ func createNetwork(ctx *cli.Context) {
 	}
 	if gatewayv6 != "" {
 		if ok := net.ParseIP(gatewayv6); ok == nil {
-			errExit(ctx, exitHelp, "Invalid IPv6 gateway", true)
-		}
-	}
-
-	var pktTag int
-	var err error
-	if len(pktTagInString) > 0 {
-		pktTag, err = strconv.Atoi(pktTagInString)
-		if err != nil {
-			errExit(ctx, exitHelp, "Invalid VLAN ID or VNI, expected an integer", true)
+			errExit(ctx, exitHelp, "Invalid IPv6 gateway ", true)
 		}
 	}
 
 	tenant := ctx.String("tenant")
 	network := ctx.Args()[0]
 	encap := ctx.String("encap")
+	pktTag := ctx.Int("pkt-tag")
 	nwType := ctx.String("nw-type")
 	nwTag := ctx.String("nw-tag")
 

--- a/netctl/netctl.go
+++ b/netctl/netctl.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -517,6 +518,8 @@ func createNetwork(ctx *cli.Context) {
 	subnetv6 := ctx.String("subnetv6")
 	gatewayv6 := ctx.String("gatewayv6")
 
+	pktTagInString := ctx.String("pkt-tag")
+
 	if subnet == "" {
 		errExit(ctx, exitHelp, "Subnet is required", true)
 	}
@@ -527,14 +530,22 @@ func createNetwork(ctx *cli.Context) {
 	}
 	if gatewayv6 != "" {
 		if ok := net.ParseIP(gatewayv6); ok == nil {
-			errExit(ctx, exitHelp, "Invalid IPv6 gateway ", true)
+			errExit(ctx, exitHelp, "Invalid IPv6 gateway", true)
+		}
+	}
+
+	var pktTag int
+	var err error
+	if len(pktTagInString) > 0 {
+		pktTag, err = strconv.Atoi(pktTagInString)
+		if err != nil {
+			errExit(ctx, exitHelp, "Invalid VLAN ID or VNI, expected an integer", true)
 		}
 	}
 
 	tenant := ctx.String("tenant")
 	network := ctx.Args()[0]
 	encap := ctx.String("encap")
-	pktTag := ctx.Int("pkt-tag")
 	nwType := ctx.String("nw-type")
 	nwTag := ctx.String("nw-tag")
 


### PR DESCRIPTION
Currently, netctl parse the pkgTag input as an integer directly.
Therefore when user put a garbage in pkgTag, the conversion will
default it to 0 instead.

This patchset is to cast the input to string and perform further
validation logic before we create network

Signed-off-by: Kahou Lei <kalei@cisco.com>
