### PR TITLE
Ensure global config is valid before creating network

### DIFF
--- a/netmaster/objApi/objapi_test.go
+++ b/netmaster/objApi/objapi_test.go
@@ -869,6 +869,8 @@ func checkDeleteTenant(t *testing.T, expError bool, tenant string) {
 
 // TestTenantDelete tests deletion of tenant
 func TestTenantDelete(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 	// Create one tenant, two networks and 3 epgs
 	checkCreateTenant(t, false, "tenant1")
 	checkCreateNetwork(t, false, "tenant1", "net1", "data", "vlan", "10.1.1.1/16", "10.1.1.254", 1, "", "", "")
@@ -971,7 +973,8 @@ func TestTenantAddDelete(t *testing.T) {
 
 // TestOverlappingSubnets tests overlapping network create/delete REST api
 func TestOverlappingSubnets(t *testing.T) {
-
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 	// Non-overlapping subnet for same tenant - vlan & gateway
 	checkCreateNetwork(t, false, "default", "contiv1", "", "vlan", "10.1.1.0/24", "10.1.1.220", 1, "", "", "")
 	checkCreateNetwork(t, false, "default", "contiv2", "", "vlan", "10.1.2.0/24", "10.1.2.254", 2, "", "", "")
@@ -1094,6 +1097,9 @@ func TestNetworkAddDeleteACIMode(t *testing.T) {
 
 // TestNetworkAddDelete tests network create/delete REST api
 func TestNetworkAddDelete(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	// Basic vlan network
 	checkCreateNetwork(t, false, "default", "contiv", "", "vlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
 	checkInspectNetwork(t, false, "default", "contiv", "10.1.1.254", 1, 0)
@@ -1201,9 +1207,10 @@ func TestNetworkAddDelete(t *testing.T) {
 }
 
 func TestDynamicGlobalVlanRange(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 
 	// Basic vlan network creation
-
 	checkCreateNetwork(t, false, "default", "contiv1", "", "vlan", "10.1.1.1/24", "10.1.1.254", 10, "", "", "")
 	checkInspectNetwork(t, false, "default", "contiv1", "10.1.1.254", 10, 0)
 	//checkInspectGlobal(t, false, "1", "")
@@ -1265,7 +1272,8 @@ func TestDynamicGlobalVlanRange(t *testing.T) {
 }
 
 func TestDynamicGlobalVxlanRange(t *testing.T) {
-
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 	insp, _ := contivClient.GlobalInspect("global") // Basic vxlan network creation
 
 	log.Printf("THE GLOBAL DUMP: %#v \n", insp)
@@ -1380,6 +1388,9 @@ func TestAciGwSetting(t *testing.T) {
 
 // TestNetworkPktRanges tests pkt-tag ranges in network REST api
 func TestNetworkPktRanges(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	// verify auto allocation of vlans
 	checkCreateNetwork(t, false, "default", "contiv", "data", "vlan", "10.1.1.1/24", "10.1.1.254", 0, "", "", "")
 	verifyNetworkState(t, "default", "contiv", "data", "vlan", "10.1.1.1", "10.1.1.254", 24, 1, 0, "", "", 0)
@@ -1418,6 +1429,9 @@ func TestNetworkPktRanges(t *testing.T) {
 
 // TestPolicyRules tests policy and rule REST objects
 func TestPolicyRules(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	containerID1 := "723e55bf5b244f47c1b184cb786a1c2ad8870cc3a3db723c49ac09f68a9d1e69"
 	ep1 := "657355bf5b244f47c1b184cb786a14535d8870cc3a3db723c49ac09f68a9d6a5"
 	checkCreateNetwork(t, false, "default", "contiv", "data", "vxlan", "10.1.1.1/16", "10.1.1.254", 1, "", "", "")
@@ -1516,6 +1530,9 @@ func TestPolicyRules(t *testing.T) {
 
 // TestEpgPolicies tests attaching policy to EPG
 func TestEpgPolicies(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	// create network
 	checkCreateNetwork(t, false, "default", "contiv", "data", "vxlan", "10.1.1.1/16", "10.1.1.254", 1, "", "", "")
 
@@ -1582,6 +1599,8 @@ func TestEpgPolicies(t *testing.T) {
 
 // TestExtContractsGroups tests management of external contracts groups
 func TestExtContractsGroups(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 	// create network for the test
 	checkCreateNetwork(t, false, "default", "test-net", "data", "vlan", "23.1.1.1/16", "23.1.1.254", 1, "", "", "")
 	// create contract groups used for the test
@@ -1620,6 +1639,8 @@ func TestExtContractsGroups(t *testing.T) {
 
 // TestAppProfile tests app-profile REST objects
 func TestAppProfile(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 	// Create two networks and 3 epgs
 	checkCreateNetwork(t, false, "default", "net1", "data", "vlan", "10.1.1.1/16", "10.1.1.254", 1, "", "", "")
 	checkCreateNetwork(t, false, "default", "net2", "data", "vlan", "20.1.1.1/16", "20.1.1.254", 2, "", "", "")
@@ -1650,6 +1671,8 @@ func TestAppProfile(t *testing.T) {
 
 //TestEpgNetprofile tests the netprofile netprofile REST objects.
 func TestEpgnpTenant(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 
 	//create a network,
 	checkCreateNetwork(t, false, "default", "np-net", "data", "vxlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
@@ -1708,6 +1731,9 @@ func TestEpgnpTenant(t *testing.T) {
 }
 
 func TestEpgnp(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	//create a network and  netprofile
 	checkCreateNetwork(t, false, "default", "np-net", "data", "vxlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
 	checkCreateNetProfile(t, false, 5, 1500, "2gbps", "netprofile", "default")
@@ -1723,6 +1749,9 @@ func TestEpgnp(t *testing.T) {
 }
 
 func TestEpgUpdate(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	//create a network, netprofile and group.
 	checkCreateNetwork(t, false, "default", "np-net", "data", "vxlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
 	checkCreateNetProfile(t, false, 5, 1500, "2gbps", "netprofile", "default")
@@ -1774,6 +1803,9 @@ func TestEpgUpdate(t *testing.T) {
 }
 
 func TestDeleteEpgNp(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	//create a network, netprofile and group.
 	checkCreateNetwork(t, false, "default", "np-net", "data", "vxlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
 	checkCreateNetProfile(t, false, 5, 1500, "2gbps", "netprofile", "default")
@@ -1794,6 +1826,8 @@ func TestDeleteEpgNp(t *testing.T) {
 }
 
 func TestNetProfileupdate(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 
 	//create a network, netprofile.
 	checkCreateNetwork(t, false, "default", "np-net", "data", "vxlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
@@ -1830,6 +1864,9 @@ func TestNetProfileupdate(t *testing.T) {
 }
 
 func TestNetprofile(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	//create a network & netprofile
 	checkCreateNetwork(t, false, "default", "net", "data", "vxlan", "10.1.1.1/24", "10.1.1.254", 1, "", "", "")
 	checkCreateNetProfile(t, false, 5, 1500, "2gbps", "profile1", "default")
@@ -1889,6 +1926,8 @@ func TestNetprofile(t *testing.T) {
 }
 
 func TestServiceProviderUpdate(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 
 	labels := []string{"key1=value1", "key2=value2"}
 	port := []string{"80:8080:TCP"}
@@ -1954,6 +1993,8 @@ func TestServiceProviderUpdate(t *testing.T) {
 }
 
 func TestServiceProviderUpdateServiceAdd(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 
 	labels := []string{"key1=value1", "key2=value2"}
 	port := []string{"80:8080:TCP"}
@@ -2018,6 +2059,8 @@ func TestServiceProviderUpdateServiceAdd(t *testing.T) {
 }
 
 func TestServicePreferredIP(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
 
 	labels := []string{"key1=value1", "key2=value2"}
 	port := []string{"80:8080:TCP"}
@@ -2334,6 +2377,9 @@ func AddEP(tenant, nw, epg, id string) error {
 }
 
 func TestEPCreate(t *testing.T) {
+	// ensure global configs set
+	checkGlobalSet(t, false, "default", "1-4094", "1-10000", "bridge", "proxy", "172.19.0.0/16")
+
 	checkCreateTenant(t, false, "teatwo")
 	checkCreateNetwork(t, false, "teatwo", "t2-net", "data", "vlan",
 		"60.1.1.1/24", "60.1.1.254", 1, "", "", "")


### PR DESCRIPTION
When global config (espeically fwd mode) is not set, we shouldn't
allow creating network. The network created at that moment is may
not having enough data to proceed.

Signed-off-by: Wei Tie <wtie@cisco.com>