### PR TITLE
map k8s namespace to EPG

### DIFF
--- a/mgmtfn/k8splugin/driver.go
+++ b/mgmtfn/k8splugin/driver.go
@@ -354,6 +354,12 @@ func getEPSpec(pInfo *cniapi.CNIPodAttr) (*epSpec, error) {
 	resp.Tenant = tenant
 	resp.Network = netw
 	resp.Group = epg
+
+	// non-system pod with no EPG ? configure it in namespace
+	if pInfo.K8sNameSpace != "kube-system" && len(resp.Group) <= 0 {
+		resp.Group = pInfo.K8sNameSpace
+	}
+
 	resp.EndpointID = pInfo.InfraContainerID
 	resp.Name = pInfo.Name
 

--- a/test/systemtests/basic_test.go
+++ b/test/systemtests/basic_test.go
@@ -34,6 +34,12 @@ func (s *systemtestSuite) testBasicStartRemoveContainer(c *C, encap string) {
 		TenantName:  "default",
 	}), IsNil)
 
+	c.Assert(s.cli.EndpointGroupPost(&client.EndpointGroup{
+		GroupName:   "default",
+		NetworkName: "private",
+		TenantName:  "default",
+	}), IsNil)
+
 	for i := 0; i < s.basicInfo.Iterations; i++ {
 		containers, err := s.runContainers(s.basicInfo.Containers, false, "private", "", nil, nil)
 		c.Assert(err, IsNil)
@@ -68,6 +74,8 @@ func (s *systemtestSuite) testBasicStartRemoveContainer(c *C, encap string) {
 		c.Assert(s.pingTest(containers), IsNil)
 		c.Assert(s.removeContainers(containers), IsNil)
 	}
+
+	c.Assert(s.cli.EndpointGroupDelete("default", "default"), IsNil)
 	c.Assert(s.cli.EndpointGroupDelete("default", "epg1"), IsNil)
 	c.Assert(s.cli.NetworkDelete("default", "private"), IsNil)
 }


### PR DESCRIPTION
configure pods with no epg labels in namespace.
This also maps k8s namespace to EPG