### PR TITLE
Makefile: fix tarball creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ HOST_GOBIN := `if [ -n "$$(go env GOBIN)" ]; then go env GOBIN; else dirname $$(
 HOST_GOROOT := `go env GOROOT`
 NAME := netplugin
 VERSION := $(shell scripts/getGitVersion.sh)
-TAR := $(shell command -v gtar || echo command -v tar || echo "Could not find tar")
+TAR := $(shell command -v gtar || command -v tar || echo "Could not find tar")
 TAR_EXT := tar.bz2
 export NETPLUGIN_CONTAINER_TAG := $(shell ./scripts/getGitVersion.sh)
 TAR_FILENAME := $(NAME)-$(VERSION).$(TAR_EXT)
@@ -381,7 +381,7 @@ binaries-from-container:
 	c_id=$$(docker create --name netplugin-build \
 		 netplugin-build:$(NETPLUGIN_CONTAINER_TAG)) && \
 	for f in netplugin netmaster netctl contivk8s netcontiv; do \
-		docker cp -a $${c_id}:/go/bin/$$f bin/$$f; done && \
+		docker cp $${c_id}:/go/bin/$$f bin/$$f; done && \
 	docker rm $${c_id}
 
 ##########################


### PR DESCRIPTION
The Docker versions we use for the netplugin project don't have support for the `-a` flag for `docker cp`. Based on my testing and the changes made by this PR, everything seems to work fine without that flag.

This PR also makes one small change to fix the detection of the tar binary.