### PR TITLE
build static binaries & remove glibc from v2plugin

### DIFF
--- a/install/v2plugin/Dockerfile
+++ b/install/v2plugin/Dockerfile
@@ -1,14 +1,11 @@
 # Docker v2plugin container with OVS / netplugin / netmaster
 
-FROM alpine:3.5
+FROM alpine:3.6
 LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
 
 RUN mkdir -p /run/docker/plugins /etc/openvswitch /var/run/contiv/log \
  && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
- && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl \
- && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/sgerrand.rsa.pub \
- && wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk \
- && apk --no-cache add glibc-2.23-r1.apk
+ && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl
 
 # copy in binaries and scripts
 ARG TAR_FILE

--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -75,8 +75,7 @@ func startNetPlugin(pluginConfig *plugin.Config) {
 	}
 }
 
-func initNetPluginConifg(ctx *cli.Context) (plugin.Config, error) {
-
+func initNetPluginConfig(ctx *cli.Context) (plugin.Config, error) {
 	// 1. validate and set up log
 	if ctx.Bool("use-syslog") {
 		syslogURL := ctx.String("syslog-url")
@@ -301,7 +300,7 @@ func main() {
 	}
 	sort.Sort(cli.FlagsByName(app.Flags))
 	app.Action = func(ctx *cli.Context) error {
-		configs, err := initNetPluginConifg(ctx)
+		configs, err := initNetPluginConfig(ctx)
 		if err != nil {
 			errmsg := err.Error()
 			logrus.Error(errmsg)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,9 +5,10 @@ set -euxo pipefail
 GIT_COMMIT=$(./scripts/getGitCommit.sh)
 
 PKG_NAME=github.com/contiv/netplugin/version
-GOGC=1500 go install -v \
+GOGC=1500 CGO_ENABLED=0 go install -v \
+	-a -installsuffix cgo \
 	-ldflags "-X $PKG_NAME.version=$BUILD_VERSION \
 	-X $PKG_NAME.buildTime=$(date -u +%m-%d-%Y.%H-%M-%S.UTC) \
 	-X $PKG_NAME.gitCommit=$GIT_COMMIT \
-	-s -w" \
+	-s -w -d" -pkgdir /tmp/foo-cgo \
 	$TO_BUILD


### PR DESCRIPTION
This PR makes the following changes:
- makes the compiled binaries static
- removes glibc from the v2plugin Dockerfile
- bumps the alpine image version used in v2plugin to alpine 3.6