### PR TITLE
contiv k8s container now tagged with git version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,8 +272,8 @@ start-aci-gw:
 	docker pull $(ACI_GW_IMAGE)
 	docker run --net=host -itd -e "APIC_URL=SANITY" -e "APIC_USERNAME=IGNORE" -e "APIC_PASSWORD=IGNORE" --name=contiv-aci-gw $(ACI_GW_IMAGE)
 
-host-build-docker-image:
-	./scripts/netContain/build_image.sh
+host-build-docker-image: compile-with-docker binaries-from-container
+	@./scripts/netContain/build_image.sh
 
 host-cleanup:
 	@echo dev: cleaning up services...

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,6 +70,6 @@ release isn't made from the HEAD of master.
 ## Build and upload container image (manual only)
 
 	1. cd scripts/netContain
-	2. ./ReleaseContainer.sh -v <version> -u contiv -i contiv/netplugin
+	2. ./release_image.sh -v <version> \[-i <image_name>] \[-t <image_tag>]
 
 Here <version> is a version that has been released using steps above and exists on github.

--- a/scripts/netContain/build_image.sh
+++ b/scripts/netContain/build_image.sh
@@ -1,74 +1,31 @@
 #!/bin/bash
 
-BUILD_ENV_IMAGE_NAME="contiv-netplugin-build"
-TEMPORARY_CONTAINER_NAME="contiv-netplugin-build-temporary"
-FINAL_IMAGE_NAME="contivbase"
+set -euo pipefail
 
+REPOSITORY="contivbase"
 NETPLUGIN_BINARIES="netplugin netmaster netctl contivk8s"
+IMAGE=$REPOSITORY:${NETPLUGIN_CONTAINER_TAG}
 
 function get_image_id() {
-	docker inspect --format '{{.ID}}' $1
-	return $?
+	docker inspect --format '{{.ID}}' $IMAGE || :
 }
-
-function build_image_from_path() {
-	set +e
-	old_image=$(get_image_id $2)
-	set -e
-	if [ "$?" -ne 0 ]; then
-		old_image=
-	fi
-
-	echo "Building image $2 from $1 ..."
-	docker build -t $2 --force-rm $1
-	if [ "$?" -ne 0 ]; then
-		echo "Image $2 was not built properly"
-		return 1
-	fi
-
-	new_image=$(get_image_id $2)
-	if [ "$old_image" != "" ] && [ "$old_image" != "$new_image" ]; then
-		docker rmi $old_image >/dev/null 2>&1 || true
-	fi
-
-	echo "Image $2 has been built"
-	return 0
-}
-
-set -x
-set -e
-
-# ensure this script wasn't called from the directory where this script
-# lives; it should be called from the repository's top level
-script_dir="$(dirname -- "$0")"
-if [ "$script_dir" == "." ]; then
-	echo "This script must be called from the top level of the repository"
-	exit 1
-fi
 
 rm -rf scripts/netContain/bin
 mkdir scripts/netContain/bin
 
-build_image_from_path . $BUILD_ENV_IMAGE_NAME
-if [ "$?" -ne 0 ]; then
-	echo "Failed to build the "
-	exit 1
+# it's expected that makefile targets compile-with-docker and
+# binaries-from-container have already been run
+tar c -C bin $NETPLUGIN_BINARIES | tar x -C scripts/netcontain/bin
+
+old_image=$(get_image_id)
+
+cd scripts/netContain
+
+docker build -t $IMAGE -t $REPOSITORY:latest .
+
+new_image=$(get_image_id)
+
+if [ "$old_image" != "" ] && [ "$old_image" != "$new_image" ]; then
+    echo Removing old image $old_image
+	docker rmi -f $old_image >/dev/null 2>&1 || true
 fi
-
-docker run --name=$TEMPORARY_CONTAINER_NAME $BUILD_ENV_IMAGE_NAME || true
-
-echo "Copying the Contiv binaries..."
-for f in $NETPLUGIN_BINARIES; do
-	docker cp $TEMPORARY_CONTAINER_NAME:/go/bin/$f scripts/netContain/bin/
-done
-
-docker rm -fv $TEMPORARY_CONTAINER_NAME
-
-echo "Building the final Docker image..."
-build_image_from_path scripts/netContain contivbase
-if [ "$?" -ne 0 ]; then
-	echo "Failed to build the final Docker image"
-	exit 1
-fi
-
-rm -rf scripts/netContain/bin

--- a/scripts/netContain/build_image.sh
+++ b/scripts/netContain/build_image.sh
@@ -15,7 +15,7 @@ mkdir scripts/netContain/bin
 
 # it's expected that makefile targets compile-with-docker and
 # binaries-from-container have already been run
-tar c -C bin $NETPLUGIN_BINARIES | tar x -C scripts/netcontain/bin
+tar c -C bin $NETPLUGIN_BINARIES | tar x -C scripts/netContain/bin
 
 old_image=$(get_image_id)
 


### PR DESCRIPTION
the container build can leverage other new tasks to simplify the build
script considerably

drive-by: found the release notes for the container release was wrong

Signed-off-by: Chris Plock <chrisplo@cisco.com>