### PR TITLE
fix v2plugin startcontiv.sh for netplugin updates

### DIFF
--- a/install/v2plugin/Dockerfile
+++ b/install/v2plugin/Dockerfile
@@ -5,7 +5,8 @@ LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
 
 RUN mkdir -p /run/docker/plugins /etc/openvswitch /var/run/contiv/log \
  && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
- && apk --no-cache add openvswitch=2.5.0-r0 iptables ca-certificates openssl curl \
+ && apk --no-cache add \
+      openvswitch=2.5.0-r0 iptables ca-certificates openssl curl bash \
  && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/andyshinn/alpine-pkg-glibc/master/sgerrand.rsa.pub \
  && wget https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk \
  && apk --no-cache add glibc-2.23-r1.apk


### PR DESCRIPTION
run startcontiv.sh with bash

start netplugin after netmaster

set network and forward modes for v2plugin
netplugin will not start without setting the network and forward modes

Signed-off-by: Chris Plock <chrisplo@cisco.com>