### PR TITLE
add OVS Docker image 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export V2PLUGIN_TAR_FILENAME := v2plugin-$(VERSION).tar.gz
 GO_MIN_VERSION := 1.7
 GO_MAX_VERSION := 1.8
 GO_VERSION := $(shell go version | cut -d' ' -f3 | sed 's/go//')
-CI_HOST_TARGETS ?= "host-unit-test host-integ-test host-build-docker-image tar host-pluginfs-create clean-tar"
+CI_HOST_TARGETS ?= "host-unit-test host-integ-test host-build-docker-image host-build-ovs-image tar host-pluginfs-create clean-tar"
 SYSTEM_TESTS_TO_RUN ?= "00SSH|Basic|Network|Policy|TestTrigger|ACIM|Netprofile"
 K8S_SYSTEM_TESTS_TO_RUN ?= "00SSH|Basic|Network|Policy"
 ACI_GW_IMAGE ?= "contiv/aci-gw:04-12-2017.2.2_1n"
@@ -255,6 +255,9 @@ start-aci-gw:
 
 host-build-docker-image: compile-with-docker binaries-from-container
 	@./scripts/netContain/build_image.sh
+
+host-build-ovs-image:
+	@./scripts/ovscontainer/build_image.sh
 
 host-cleanup:
 	@echo dev: cleaning up services...

--- a/scripts/netContain/scripts/ovsInit.sh
+++ b/scripts/netContain/scripts/ovsInit.sh
@@ -3,7 +3,9 @@
 
 set -euo pipefail
 
-modprobe openvswitch
+if [[ $(lsmod | cut -d" " -f1 | grep -q openvswitch) -eq 1 ]]; then
+	modprobe openvswitch
+fi
 
 mkdir -p /var/run/openvswitch
 mkdir -p /var/contiv/log/

--- a/scripts/ovscontainer/Dockerfile
+++ b/scripts/ovscontainer/Dockerfile
@@ -1,0 +1,15 @@
+# OVS Docker image
+
+FROM alpine:3.7
+LABEL maintainer "Cisco Contiv (https://contiv.github.io)"
+
+RUN mkdir -p /etc/openvswitch /var/run/contiv/log \
+ && echo 'http://dl-cdn.alpinelinux.org/alpine/v3.4/main' >> /etc/apk/repositories \
+ && apk --no-cache add \
+      openvswitch=2.5.0-r0 iptables ca-certificates openssl curl bash
+
+# copy scripts
+COPY ovsInit.sh /
+#COPY startcontiv.sh /
+
+ENTRYPOINT ["/ovsInit.sh"]

--- a/scripts/ovscontainer/build_image.sh
+++ b/scripts/ovscontainer/build_image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPOSITORY="contivovs"
+IMAGE=$REPOSITORY:${NETPLUGIN_CONTAINER_TAG:-latest}
+
+function get_image_id() {
+	docker inspect --format '{{.ID}}' $IMAGE || :
+}
+
+old_image=$(get_image_id)
+
+cd scripts/ovscontainer
+
+docker build -t $IMAGE .
+
+new_image=$(get_image_id)
+
+if [ "$old_image" != "" ] && [ "$old_image" != "$new_image" ]; then
+	echo Removing old image $old_image
+	docker rmi -f $old_image >/dev/null 2>&1 || true
+fi

--- a/scripts/ovscontainer/ovsInit.sh
+++ b/scripts/ovscontainer/ovsInit.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#Start OVS in the Contiv container
+
+set -euo pipefail
+
+if [[ $(lsmod | cut -d" " -f1 | grep -q openvswitch) -eq 1 ]]; then
+	modprobe openvswitch
+fi
+
+mkdir -p /var/run/openvswitch
+mkdir -p /var/contiv/log/
+
+sleep 2
+
+if [ -d "/etc/openvswitch" ]; then
+	if [ -f "/etc/openvswitch/conf.db" ]; then
+		echo "INFO: The Open vSwitch database exists"
+	else
+		echo "INFO: The Open VSwitch database doesn't exist"
+		echo "INFO: Creating the Open VSwitch database..."
+		ovsdb-tool create /etc/openvswitch/conf.db /usr/share/openvswitch/vswitch.ovsschema
+	fi
+else
+	echo "CRITICAL: Open vSwitch is not mounted from host"
+	exit 1
+fi
+
+echo "INFO: Starting ovsdb-server..."
+ovsdb-server --remote=punix:/var/run/openvswitch/db.sock \
+	--remote=db:Open_vSwitch,Open_vSwitch,manager_options \
+	--private-key=db:Open_vSwitch,SSL,private_key \
+	--certificate=db:Open_vSwitch,SSL,certificate \
+	--bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert \
+	--log-file=/var/contiv/log/ovs-db.log -vsyslog:info -vfile:info \
+	--pidfile /etc/openvswitch/conf.db &
+OVSDB_PID=$!
+
+echo "INFO: Starting ovs-vswitchd"
+ovs-vswitchd -v --pidfile --detach --log-file=/var/contiv/log/ovs-vswitchd.log \
+	-vconsole:err -vsyslog:info -vfile:info &
+VSWITCHD_PID=$!
+
+retry=0
+while [[ $(ovsdb-client list-dbs | grep -c Open_vSwitch) -eq 0 ]]; do
+	if [[ ${retry} -eq 5 ]]; then
+		echo "CRITICAL: Failed to start ovsdb in 5 seconds."
+		exit 1
+	else
+		echo "INFO: Waiting for ovsdb to start..."
+		sleep 1
+		((retry += 1))
+	fi
+done
+
+echo "INFO: Setting OVS manager (tcp)..."
+ovs-vsctl set-manager tcp:127.0.0.1:6640
+
+echo "INFO: Setting OVS manager (ptcp)..."
+ovs-vsctl set-manager ptcp:6640
+
+STATUS=0
+
+for pid in "$OVSDB_PID $VSWITCHD_PID"; do
+	wait $pid || let STATUS=1
+done
+
+if [ "$STATUS" == "1" ]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This PR adds support for building a standalone openvswitch image and it adds a new target to the list of CI targets.

The PR also modifies scripts/netContain/build_image.sh. That change makes it load the openvswitch kernel module only if it's not loaded.