### PR TITLE
Add extra validation check for v2plugin

### DIFF
--- a/scripts/python/startSwarm.py
+++ b/scripts/python/startSwarm.py
@@ -2,10 +2,10 @@
 
 # Start netplugin and netmaster
 import api.tnode
-import time
-import sys
-import os
 import argparse
+import os
+import re
+import time
 
 # Parse command line args
 # Create the parser and sub parser
@@ -45,6 +45,21 @@ if args.swarm == "swarm_mode":
         node.runCmdThread(command)
 
     time.sleep(15)
+
+    print "Check netplugin is installed and enabled"
+    out, x, y = nodes[0].runCmd("docker plugin ls")
+
+    installed = re.search('contiv/v2plugin', out[1])
+
+    if installed == None:
+        print "Make target failed: Contiv plugin is not installed"
+        os._exit(1)
+        
+    enabled = re.search('false', out[1])
+    if enabled != None:
+        print "Make target failed: Contiv plugin is installed but disabled"
+        os._exit(1)
+
     print "################### Swarm Mode is up  #####################"
 else:
     swarmScript= scriptPath + "/start-swarm.sh"

--- a/scripts/python/startSwarm.py
+++ b/scripts/python/startSwarm.py
@@ -38,7 +38,7 @@ if args.swarm == "swarm_mode":
     nodes[0].runCmd("docker swarm init --advertise-addr " + nodes[0].addr + ":2377")
     # Get the token for joining swarm
     out, x, y = nodes[0].runCmd("docker swarm join-token worker -q")
-    token = out[0][:-1] #remove newlineØ
+    token = out[0][:-1] #remove newline
     # Make all workers join the swarm
     for node in nodes[1:]:
         command = "docker swarm join --token "+ token + " " + nodes[0].addr + ":2377"

--- a/scripts/python/startSwarm.py
+++ b/scripts/python/startSwarm.py
@@ -38,7 +38,7 @@ if args.swarm == "swarm_mode":
     nodes[0].runCmd("docker swarm init --advertise-addr " + nodes[0].addr + ":2377")
     # Get the token for joining swarm
     out, x, y = nodes[0].runCmd("docker swarm join-token worker -q")
-    token = out[0][:-1] #remove newline
+    token = out[0][:-1] #remove newlineØ
     # Make all workers join the swarm
     for node in nodes[1:]:
         command = "docker swarm join --token "+ token + " " + nodes[0].addr + ":2377"
@@ -47,7 +47,7 @@ if args.swarm == "swarm_mode":
     time.sleep(15)
 
     print "Check netplugin is installed and enabled"
-    out, x, y = nodes[0].runCmd("docker plugin ls")
+    out, _, _ = nodes[0].runCmd("docker plugin ls")
 
     installed = re.search('contiv/v2plugin', out[1])
 


### PR DESCRIPTION
Currently, demo-v2plugin doesn't check if contiv is installed and
enabled.

This patchset is to check if v2plugin is installed and enabled at the
end of the installation

Signed-off-by: <kalei@cisco.com>

