### PR TITLE
netplugin/netd.go: call Fatalf to use formatting

### DIFF
--- a/netplugin/netd.go
+++ b/netplugin/netd.go
@@ -81,7 +81,7 @@ func initNetPluginConfig(ctx *cli.Context) (*plugin.Config, error) {
 	if controlIP == "" {
 		controlIP, configErr = netutils.GetDefaultAddr()
 		if configErr != nil {
-			logrus.Fatal("Failed to get host address: %s", configErr.Error())
+			logrus.Fatalf("Failed to get host address: %s", configErr.Error())
 		}
 	}
 	logrus.Infof("Using netplugin control IP: %v", controlIP)
@@ -90,7 +90,7 @@ func initNetPluginConfig(ctx *cli.Context) (*plugin.Config, error) {
 	if vtepIP == "" {
 		vtepIP, configErr = netutils.GetDefaultAddr()
 		if configErr != nil {
-			logrus.Fatal("Failed to get host address: %s", configErr.Error())
+			logrus.Fatalf("Failed to get host address: %s", configErr.Error())
 		}
 	}
 	logrus.Infof("Using netplugin VTEP IP: %v", vtepIP)


### PR DESCRIPTION
This PR addresses a govet failure I've observed:
```
netplugin/netd.go:84: possible formatting directive in Fatal call
netplugin/netd.go:93: possible formatting directive in Fatal call
```

This halts the build for me.