### PR TITLE
Create a single Dockerfile that builds K8S image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-# we want to get the git commit SHA but not all the binary repo data
-.git/objects/pack
 bin/
 **/*.pyc
 .vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,38 @@
-##
-#Copyright 2014 Cisco Systems Inc. All rights reserved.
-#
-#Licensed under the Apache License, Version 2.0 (the "License");
-#you may not use this file except in compliance with the License.
-#You may obtain a copy of the License at
-#http://www.apache.org/licenses/LICENSE-2.0
-#
-#Unless required by applicable law or agreed to in writing, software
-#distributed under the License is distributed on an "AS IS" BASIS,
-#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#See the License for the specific language governing permissions and
-#limitations under the License.
-##
+# builder is where netplugin got complied
+FROM golang:1.7.6 as builder
 
-##
-# Container image for compiled netplugin binaries
-#
-# Run netplugin:
-# docker run --net=host <image> -host-label=<label>
-##
+ENV GOPATH /go
 
-FROM golang:1.7.6
+COPY . $GOPATH/src/github.com/contiv/netplugin/
 
-# Insert your proxy server settings if this build is running behind
-# a proxy.
-#ENV http_proxy ""
-#ENV https_proxy ""
-ARG http_proxy
-ARG https_proxy
+WORKDIR $GOPATH/src/github.com/contiv/netplugin/
 
-WORKDIR /go/src/github.com/contiv/netplugin/
+RUN VERSION_SUFFIX="$(if git diff-index --quiet HEAD --; then echo '-unsupported'; fi)" && \
+    GIT_COMMIT=$(git rev-parse --short HEAD)$VERSION_SUFFIX && \
+    BUILD_VERSION=$(git describe --tags --always)$VERSION_SUFFIX  && \
+    PKG_NAME=github.com/contiv/netplugin/version && \
+    BUILD_TIME=$(date -u +%m-%d-%Y.%H-%M-%S.UTC) && \
+    GOGC=1500 CGO_ENABLED=0 go install -v \
+    -a -installsuffix cgo \
+    -ldflags "-X $PKG_NAME.version=$BUILD_VERSION \
+    -X $PKG_NAME.buildTime=$BUILD_TIME \
+    -X $PKG_NAME.gitCommit=$GIT_COMMIT \
+    -s -w -d" -pkgdir /tmp/foo-cgo \
+    ./netplugin/ ./netmaster/ ./netctl/netctl/ ./mgmtfn/k8splugin/contivk8s/ && \
+    mkdir -p /contiv/bin && \
+    for bin in netplugin netmaster netctl contivk8s; do cp /go/bin/$bin /contiv/bin/ ; done && \
+    /contiv/bin/netplugin --version && /contiv/bin/netmaster --version
 
-ENTRYPOINT ["netplugin"]
-CMD ["--help"]
+# The container where netplugin will be run
+FROM ubuntu:16.04
 
-# by far, most of the compilation time is building vendor packages
-# build the vendor dependencies as a separate docker caching layer
-COPY ./vendor/ /go/src/github.com/contiv/netplugin/vendor/
-COPY ./objdb/ /go/src/github.com/contiv/netplugin/objdb/
+RUN apt-get update \
+ && apt-get install -y openvswitch-switch=2.5.2* \
+        net-tools \
+        iptables \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN GOGC=1500 go install -ldflags "-s -w" $(go list ./vendor/...)
+COPY --from=builder /contiv/bin/ /contiv/bin/
+COPY --from=builder /go/src/github.com/contiv/netplugin/scripts/netContain/scripts/ /contiv/scripts/
 
-# build the netplugin binaries
-COPY ./ /go/src/github.com/contiv/netplugin/
-
-ARG BUILD_VERSION=""
-ARG NIGHTLY_RELEASE=""
-
-RUN GOPATH=/go/ \
-    BUILD_VERSION="${BUILD_VERSION}" \
-    NIGHTLY_RELEASE="${NIGHTLY_RELEASE}" \
-    make compile \
-      && cp scripts/contrib/completion/bash/netctl /etc/bash_completion.d/netctl \
-      && netplugin -version
+ENTRYPOINT ["/contiv/scripts/contivNet.sh"]

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -1,0 +1,51 @@
+##
+#Copyright 2014 Cisco Systems Inc. All rights reserved.
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+##
+
+##
+# Container image for compiled netplugin binaries
+#
+# Run netplugin:
+# docker run --net=host <image> -host-label=<label>
+##
+
+FROM golang:1.7.6
+
+ARG http_proxy
+ARG https_proxy
+
+WORKDIR /go/src/github.com/contiv/netplugin/
+
+ENTRYPOINT ["netplugin"]
+CMD ["--help"]
+
+# by far, most of the compilation time is building vendor packages
+# build the vendor dependencies as a separate docker caching layer
+COPY ./vendor/ /go/src/github.com/contiv/netplugin/vendor/
+COPY ./objdb/ /go/src/github.com/contiv/netplugin/objdb/
+
+RUN GOGC=1500 go install -ldflags "-s -w" $(go list ./vendor/...)
+
+# build the netplugin binaries
+COPY ./ /go/src/github.com/contiv/netplugin/
+
+ARG BUILD_VERSION=""
+ARG NIGHTLY_RELEASE=""
+
+RUN GOPATH=/go/ \
+    BUILD_VERSION="${BUILD_VERSION}" \
+    NIGHTLY_RELEASE="${NIGHTLY_RELEASE}" \
+    make compile \
+      && cp scripts/contrib/completion/bash/netctl /etc/bash_completion.d/netctl \
+      && netplugin -version

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ run-build: deps checks clean compile archive
 
 compile-with-docker:
 	docker build \
+		-f Dockerfile-compile \
 		--build-arg NIGHTLY_RELEASE=$(NIGHTLY_RELEASE) \
 		--build-arg BUILD_VERSION=$(VERSION) \
 		-t netplugin-build:$(NETPLUGIN_CONTAINER_TAG) .


### PR DESCRIPTION
We need a single Dockerfile in order to create docker image by
dockerhub autobuild, and also make it easy for nightly build and
dev build.

Signed-off-by: Wei Tie <wtie@cisco.com>