### PR TITLE
If we're deleting kube-dns, let's do it properly and remove dangling kube-dns k8s resources

### DIFF
--- a/install/k8s/README.md
+++ b/install/k8s/README.md
@@ -48,9 +48,13 @@ netctl net create -t default --subnet=20.1.1.0/24 default-net
 netctl group create -t default default-net default-epg
 ```
 
-* When in vxlan mode, delete the kube-dns deployment as follows:
+* When in vxlan mode, delete the kube-dns as follows:
 ```sh
 kubectl delete deployment/kube-dns -n kube-system
+kubectl delete service kube-dns -n=kube-system
+kubectl delete serviceaccounts kube-dns -n=kube-system
+kubectl delete clusterrolebindings system:kube-dns -n=kube-system
+kubectl delete endpoint kube-dns -n=kube-system
 ```
 
 Note: netctl uses "netmaster" as the default netmaster host. So add a reference for "netmaster" in /etc/hosts or explicitly specify it as a parameter to all netctl calls.

--- a/install/k8s/cluster/k8smaster_centos.sh
+++ b/install/k8s/cluster/k8smaster_centos.sh
@@ -11,6 +11,10 @@ if [ -n "$CONTIV_TEST" ]; then
         # remove kube-dns
         # TODO: enable kube-dns
         kubectl delete deployment -n kube-system kube-dns
+        kubectl delete service kube-dns -n=kube-system
+        kubectl delete serviceaccounts kube-dns -n=kube-system
+        kubectl delete clusterrolebindings system:kube-dns -n=kube-system
+        kubectl delete endpoint kube-dns -n=kube-system
     elif [ "$CONTIV_TEST" = "dev" ]; then
         ./contiv-compose add-systest --start --k8s-api https://$2:$3 ./contiv-base.yaml > /shared/contiv.yaml
     fi


### PR DESCRIPTION
`kube-dns` is pod-less, endpoint-less, backend-less, useless and dangling in `contiv/netplugin`'s vagrant dev setup. This is a bit confusing and makes the user think that contiv uses `kube-dns` when it does not.

```
[vagrant@k8master ~]$ kubectl describe service kube-dns -n=kube-system  | grep -i end
Endpoints:         <none>
Endpoints:         <none>

[vagrant@k8master ~]$ kubectl get services -n=kube-system | grep -i dns
kube-dns      ClusterIP   10.96.0.10      <none>        53/UDP,53/TCP   10h

[vagrant@k8master ~]$ kubectl get serviceaccounts -n=kube-system | grep -i dns
kube-dns                             1         10h

[vagrant@k8master ~]$ kubectl get clusterrolebindings -n=kube-system | grep -i dns
system:kube-dns                                        10h

[vagrant@k8master ~]$ kubectl get endpoints -n=kube-system | grep -i dns
kube-dns                  <none>              10h

[vagrant@k8master ~]$ kubectl get secrets -n=kube-system | grep -i dns
kube-dns-token-8nqvc                             kubernetes.io/service-account-token   3         10h
```

Contiv uses its own custom DNS in k8s:

https://github.com/contiv/netplugin/blob/master/docs/dns.md

The k8s dev confirmed that if we're using external/custom DNS in k8s and deleting the `kube-dns` deployment, we need to delete all the remaining dangling, pod-less `kube-dns` k8s resources (`service, serviceaccount, clusterrolebinding` and `endpoint`) too, so that they do not conflict with the contiv's external/custom DNS in any way.

Signed-off-by: Vikram Hosakote <vhosakot@cisco.com>