### PR TITLE
modified burst value

### DIFF
--- a/contivmodel/contivModel.go
+++ b/contivmodel/contivModel.go
@@ -3457,7 +3457,7 @@ func ValidateNetprofile(obj *Netprofile) error {
 		return errors.New("bandwidth string invalid format")
 	}
 
-	if obj.Burst > 10486 {
+	if obj.Burst > obj.Burst {
 		return errors.New("burst Value Out of bound")
 	}
 


### PR DESCRIPTION
Bugfix: modified that check burst value when run the function ValidateNetprofile.
1. the burst is hard code
2. the burst can't set 10% of rate
3. if want to achieve the desired performance, it's best to equal the value of rate

## Description of the changes
#### Type of fix: <!-- Bug Fix | New feature | Cosmetic change -->
#### Fixes #<!-- Issue number -->
Please describe:
1. No matter how much the value of rate is set, The value of burst cannot exceed 10486. 
2. If rate is 100mbps and the burst is 10485, Actually, the bandwidth  only 50mbps.
![image](https://user-images.githubusercontent.com/12890818/37633682-4b4ab534-2c2e-11e8-947f-f6fc064e70e2.png)
3. If set the rate is 1000mbps and the burst is 10485, the result is same to above.
![image](https://user-images.githubusercontent.com/12890818/37633700-58d1481c-2c2e-11e8-9236-b4ea47b4c00b.png)
## TODO
- [ ] Tests
- [ ] Documentation
