### PR TITLE
Change MTU to 1400 - GCP Support

### DIFF
--- a/drivers/ovsd/ovsSwitch.go
+++ b/drivers/ovsd/ovsSwitch.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	useVethPair      = true
-	vxlanEndpointMtu = 1450
+	vxlanEndpointMtu = 1400
 	vxlanOfnetPort   = 9002
 	vlanOfnetPort    = 9003
 	unusedOfnetPort  = 9004


### PR DESCRIPTION
We have setup a cluster in GCP and deployed a sample application which runs in a container over contiv network (Non ACI mode) which loads a simple UI page. We found that when the traffic goes across containers running in two different hosts we observe the packets are not being sent out from the originating host.

On further analysis we found that for GCP compute engines the MTU is set to 1460 (Whereas in AWS, MTU is set as 9001). Within the container the MTU is actually set to 1450 which is by default set by netplugin. We found that vxlan adds an overhead of ~50 bytes and taking that in to consideration, the container approximately sends a payload of 1500 to the host (which supports max of 1460), because of this there is no transmission and we end up with the issue that we mentioned before.

To fix the above issue we changed the MTU value to 1400 in ovsSwitch.go and rebuilt netplugin with this fix. With this fix applied, we were able to achieve communication between containers across host.