### PR TITLE
Modified that check burst value when run the function ValidateNetprofile

### DIFF
--- a/contivmodel/contivModel.go
+++ b/contivmodel/contivModel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/netplugin/objdb/modeldb"
-        "github.com/contiv/netplugin/utils/netutils"
+	"github.com/contiv/netplugin/utils/netutils"
 	"github.com/gorilla/mux"
 	"net/http"
 	"regexp"
@@ -3458,8 +3458,8 @@ func ValidateNetprofile(obj *Netprofile) error {
 		return errors.New("bandwidth string invalid format")
 	}
 
-        bwint64 := netutils.ConvertBandwidth(obj.Bandwidth)
-        if int64(obj.Burst) > bwint64 {
+	bwint64 := netutils.ConvertBandwidth(obj.Bandwidth)
+	if int64(obj.Burst) > bwint64 {
 		return errors.New("burst Value Out of bound")
 	}
 

--- a/contivmodel/contivModel.go
+++ b/contivmodel/contivModel.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/netplugin/objdb/modeldb"
+        "github.com/contiv/netplugin/utils/netutils"
 	"github.com/gorilla/mux"
 	"net/http"
 	"regexp"
@@ -3457,7 +3458,8 @@ func ValidateNetprofile(obj *Netprofile) error {
 		return errors.New("bandwidth string invalid format")
 	}
 
-	if obj.Burst > 10486 {
+        bwint64 := netutils.ConvertBandwidth(obj.Bandwidth)
+        if int64(obj.Burst) > bwint64 {
 		return errors.New("burst Value Out of bound")
 	}
 


### PR DESCRIPTION
## Modified that check burst value when run the function ValidateNetprofile
#### Type of fix: Bug Fix
Please describe:
- The burst is hard code, if want to achieve the desired performance, 
   it's best to equal the value of bandwidth.
- Add func ConvertBandwidth,that convert the bandwidth to bytes.
- Modified func ValidateNetprofile.
- Test pass on local env

## TODO
- [ ] Documentation
