### PR TITLE
feature_support_multi-endpoints

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -83,7 +83,7 @@ type InstanceInfo struct {
 	RouterIP     string      `json:"router-ip"`
 	FwdMode      string      `json:"fwd-mode"`
 	ArpMode      string      `json:"arp-mode"`
-	DbURL        string      `json:"db-url"`
+	DbURL        []string     `json:"db-url"`
 	PluginMode   string      `json:"plugin-mode"`
 	HostPvtNW    int         `json:"host-pvt-nw"`
 	VxlanUDPPort int         `json:"vxlan-port"`

--- a/netmaster/daemon/daemon.go
+++ b/netmaster/daemon/daemon.go
@@ -50,7 +50,7 @@ type MasterDaemon struct {
 	ListenURL          string // URL where netmaster listens for ext requests
 	ControlURL         string // URL where netmaster listens for ctrl pkts
 	ClusterStoreDriver string // state store driver name
-	ClusterStoreURL    string // state store endpoint
+	ClusterStoreURL    []string // state store endpoint
 	ClusterMode        string // cluster scheduler used docker/kubernetes/mesos etc
 	NetworkMode        string // network mode (vlan or vxlan)
 	NetForwardMode     string // forwarding mode (bridge or routing)
@@ -81,7 +81,7 @@ func (d *MasterDaemon) Init() {
 	// initialize state driver
 	d.stateDriver, err = utils.NewStateDriver(d.ClusterStoreDriver, &core.InstanceInfo{DbURL: d.ClusterStoreURL})
 	if err != nil {
-		log.Fatalf("Failed to init state-store: driver %q, URLs %q. Error: %s", d.ClusterStoreDriver, d.ClusterStoreURL, err)
+		log.Fatalf("Failed to init state-store: driver %q, URLs %v. Error: %s", d.ClusterStoreDriver, d.ClusterStoreURL, err)
 	}
 
 	// Initialize resource manager
@@ -91,9 +91,9 @@ func (d *MasterDaemon) Init() {
 	}
 
 	// Create an objdb client
-	d.objdbClient, err = objdb.InitClient(d.ClusterStoreDriver, []string{d.ClusterStoreURL})
+	d.objdbClient, err = objdb.InitClient(d.ClusterStoreDriver, d.ClusterStoreURL)
 	if err != nil {
-		log.Fatalf("Error connecting to state store: driver %q, URLs %q. Err: %v", d.ClusterStoreDriver, d.ClusterStoreURL, err)
+		log.Fatalf("Error connecting to state store: driver %q, URLs %v. Err: %v", d.ClusterStoreDriver, d.ClusterStoreURL, err)
 	}
 }
 

--- a/netmaster/docknet/docknet_test.go
+++ b/netmaster/docknet/docknet_test.go
@@ -31,9 +31,9 @@ import (
 
 // initStateDriver initialize etcd state driver
 func initStateDriver() (core.StateDriver, error) {
-	instInfo := core.InstanceInfo{DbURL: "etcd://127.0.0.1:2379"}
+	instInfo := core.InstanceInfo{DbURL: []string{"etcd://127.0.0.1:2379"}}
 
-	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo)
+	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo),nil
 }
 
 // getDocknetState gets docknet oper state

--- a/netmaster/k8snetwork/networkpolicy_test.go
+++ b/netmaster/k8snetwork/networkpolicy_test.go
@@ -112,9 +112,9 @@ const (
 
 // initStateDriver initialize etcd state driver
 func initStateDriver() (core.StateDriver, error) {
-	instInfo := core.InstanceInfo{DbURL: "etcd://127.0.0.1:2379"}
+	instInfo := core.InstanceInfo{DbURL: []string{"etcd://127.0.0.1:2379"}}
 
-	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo)
+	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo),nil
 }
 
 // cleanupState cleans up default tenant and other global state

--- a/netmaster/main.go
+++ b/netmaster/main.go
@@ -107,7 +107,7 @@ func initNetMaster(ctx *cli.Context) (*daemon.MasterDaemon, error) {
 		ListenURL:          externalAddress,
 		ControlURL:         internalAddress,
 		ClusterStoreDriver: dbConfigs.StoreDriver,
-		ClusterStoreURL:    dbConfigs.StoreURL, //TODO: support more than one url
+		ClusterStoreURL:    dbConfigs.StoreURL,
 		ClusterMode:        netConfigs.Mode,
 		NetworkMode:        netConfigs.NetworkMode,
 		NetForwardMode:     netConfigs.ForwardMode,

--- a/netmaster/objApi/objapi_test.go
+++ b/netmaster/objApi/objapi_test.go
@@ -53,9 +53,9 @@ var stateStore core.StateDriver
 
 // initStateDriver initialize etcd state driver
 func initStateDriver() (core.StateDriver, error) {
-	instInfo := core.InstanceInfo{DbURL: "etcd://127.0.0.1:2379"}
+	instInfo := core.InstanceInfo{DbURL: []string{"etcd://127.0.0.1:2379"}}
 
-	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo)
+	return utils.NewStateDriver(utils.EtcdNameStr, &instInfo),nil
 }
 
 type restAPIFunc func(r *http.Request) (interface{}, error)

--- a/netplugin/agent/agent.go
+++ b/netplugin/agent/agent.go
@@ -50,7 +50,7 @@ func NewAgent(pluginConfig *plugin.Config) *Agent {
 	netPlugin := &plugin.NetPlugin{}
 
 	// init cluster state
-	err := cluster.Init(pluginConfig.Drivers.State, []string{opts.DbURL})
+	err := cluster.Init(pluginConfig.Drivers.State, opts.DbURL)
 	if err != nil {
 		log.Fatalf("Error initializing cluster. Err: %v", err)
 	}

--- a/netplugin/agent/state_event.go
+++ b/netplugin/agent/state_event.go
@@ -350,11 +350,11 @@ func processEpgEvent(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, ID str
 func processReinit(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, newCfg *mastercfg.GlobConfig) {
 
 	// parse store URL
-	parts := strings.Split(opts.DbURL, "://")
-	if len(parts) < 2 {
-		log.Fatalf("Invalid cluster-store-url %s", opts.DbURL)
+	//parts := strings.Split(opts.DbURL, "://")
+	if len(opts.DbURL) == 0 {
+		log.Fatalf("Invalid cluster-store-url %v", opts.DbURL)
 	}
-	stateStore := parts[0]
+	stateStore := strings.Split(opts.DbURL[0], "://")[0]
 	// initialize the config
 	pluginConfig := plugin.Config{
 		Drivers: plugin.Drivers{
@@ -412,11 +412,11 @@ func processGlobalConfigUpdEvent(netPlugin *plugin.NetPlugin, opts core.Instance
 func processARPModeChange(netPlugin *plugin.NetPlugin, opts core.InstanceInfo, arpMode string) {
 
 	// parse store URL
-	parts := strings.Split(opts.DbURL, "://")
-	if len(parts) < 2 {
-		log.Fatalf("Invalid cluster-store-url %s", opts.DbURL)
+	//parts := strings.Split(opts.DbURL, "://")
+	if len(opts.DbURL) == 0 {
+		log.Fatalf("Invalid cluster-store-url %v", opts.DbURL)
 	}
-	stateStore := parts[0]
+	stateStore := strings.Split(opts.DbURL[0], "://")[0]
 	// initialize the config
 	pluginConfig := plugin.Config{
 		Drivers: plugin.Drivers{

--- a/state/consulstatedriver.go
+++ b/state/consulstatedriver.go
@@ -48,10 +48,10 @@ func (d *ConsulStateDriver) Init(instInfo *core.InstanceInfo) error {
 	var err error
 	var endpoint *url.URL
 
-	if instInfo == nil || instInfo.DbURL == "" {
+	if instInfo == nil || len(instInfo.DbURL) == 0 {
 		return errors.New("no consul config found")
 	}
-	endpoint, err = url.Parse(instInfo.DbURL)
+	endpoint, err = url.Parse(instInfo.DbURL[0])
 	if err != nil {
 		return err
 	}

--- a/utils/configs.go
+++ b/utils/configs.go
@@ -73,7 +73,7 @@ func BuildDBFlags(binary string) []cli.Flag {
 // DBConfigs validated db configs
 type DBConfigs struct {
 	StoreDriver string
-	StoreURL    string
+	StoreURL    []string
 }
 
 // BuildLogFlags CLI logging flags for given binary
@@ -177,8 +177,9 @@ func InitLogging(binary string, ctx *cli.Context) error {
 // ValidateDBOptions returns error if db options are not valid
 func ValidateDBOptions(binary string, ctx *cli.Context) (*DBConfigs, error) {
 	var storeDriver string
-	var storeURL string
 	var storeURLs string
+
+	storeURL := []string{}
 	etcdURLs := ctx.String("etcd")
 	consulURLs := ctx.String("consul")
 
@@ -201,12 +202,12 @@ func ValidateDBOptions(binary string, ctx *cli.Context) (*DBConfigs, error) {
 			return nil, fmt.Errorf("invalid %s %v endpoint: %v", binary, storeDriver, endpoint)
 		}
 		// TODO: support multi-endpoints
-		storeURL = endpoint
+		storeURL = append(storeURL,endpoint)
 		logrus.Infof("Using %s state db endpoints: %v: %v", binary, storeDriver, storeURL)
-		break
+
 	}
 
-	if storeURL == "" {
+	if len(storeURL) == 0 {
 		return nil, fmt.Errorf("invalid %s %s endpoints: empty", binary, storeDriver)
 	}
 


### PR DESCRIPTION
## Description of the changes
####  New feature

Please describe:
- changes made in the Pull request

support etcd multi-endpoints

- type of testing done (both manual and automated)

both manual and automated

## TODO
- [ ] Tests
1、change the .contiv.yaml to set the etcd cluster as "http://127.0.0.1:2381,http://127.0.0.2:2381,http://127.0.0.3:2381"

2、kubectl apply -f contiv.yaml

3、then the netplugin can use the multi-endpoint to init it's etcd client

- [ ] Documentation
None