### PR TITLE
fix_contivk8s_support_timeout

### DIFF
--- a/mgmtfn/k8splugin/contivk8s/clients/network.go
+++ b/mgmtfn/k8splugin/contivk8s/clients/network.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/netplugin/mgmtfn/k8splugin/cniapi"
@@ -48,7 +49,7 @@ func NewNWClient() *NWClient {
 	c.baseURL = nwURL
 
 	transport := &http.Transport{Dial: unixDial}
-	c.client = &http.Client{Transport: transport}
+	c.client = &http.Client{Transport: transport,Timeout: 20 * time.Second}
 
 	return &c
 }


### PR DESCRIPTION
## Description of the changes
#### Type of fix: New feature

Please describe:
- changes made in the Pull request

Add a Timeout in the contivK8s client.
When the kubelet use the cni plugin (contiv),it will execute the contivk8s client.Then the contivk8s will
post a request to the netplugin.
If sometimes  the netplugin can not get the p.lock.The netplugin will be locked.And the contivk8s would
not get any response.Then the kubelet will also locked by this.

- type of testing done (both manual and automated)
Manual  test have been done.

## TODO
- [ ] Tests
1. use k8s to add  a pod by contiv.
2. lock the plugin.
3.The contivk8s can timeout by set the timeout time.

- [ ] Documentation
