### PR TITLE
fix build failure

### DIFF
--- a/scripts/netContain/Dockerfile
+++ b/scripts/netContain/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:16.04
 # ENV export https_proxy=https://proxy.localhost.com:8080
 
 RUN apt-get update \
- && apt-get install -y openvswitch-switch=2.5.2* \
+ && apt-get install -y openvswitch-switch=2.5.5* \
         net-tools \
         iptables \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description of the changes
#### Type of fix:  Bug Fix 
#### Fixes #<!-- Issue number -->
Please describe:
- openvswitch-switch 2.5.2 no longer exists in ubuntu repo, update to 2.5.5

