### PR TITLE
Fix netns directory permissions

### DIFF
--- a/mgmtfn/mesosplugin/cnidriver.go
+++ b/mgmtfn/mesosplugin/cnidriver.go
@@ -153,7 +153,7 @@ func (cniReq *cniServer) configureNetNs(ovsEpDriver *drivers.OperEndpointState,
 	mResp *master.CreateEndpointResponse,
 	nwState *mastercfg.CfgNetworkState) error {
 
-	os.MkdirAll(netNsDir, 644)
+	os.MkdirAll(netNsDir, 0644)
 
 	// link new name space
 	if _, err := os.Stat(netNsDir + cniReq.pluginArgs.CniContainerid); err != nil {


### PR DESCRIPTION
Changed created netns directory permissions from 644 (-w----r--) to 0644 (rw-r--r--) when calling `MkdirAll(...)`.

PoC:
```
dc@jhtc:~/gogo/makedir$ cat main.go
package main

import "os"

func main() {
    os.MkdirAll("644", 644)
    os.MkdirAll("0644", 0644)
}
dc@jhtc:~/gogo/makedir$ go run main.go
ls dc@jhtc:~/gogo/makedir$ ls -la
total 20
drwxrwxr-x 4 dc dc 4096 Jun  9 17:10 .
drwxrwxr-x 5 dc dc 4096 Jun  9 17:10 ..
drw-r--r-- 2 dc dc 4096 Jun  9 17:10 0644
d-w----r-- 2 dc dc 4096 Jun  9 17:10 644
-rw-rw-r-- 1 dc dc  101 Jun  9 17:05 main.go
```

Note: I found this issue via static analysis. I am not involved in this project and I don't have time to add tests etc.

PS: Can you accept this commit being not signed off? ;)